### PR TITLE
 SonataPageBundle dependency on SonataDoctrineORMAdminBundle ?

### DIFF
--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -13,7 +13,7 @@ To begin, add the dependent bundles to the vendor/bundles directory. Add the fol
 
 .. note::
 
-    The SonataAdminBundle must be installed, please refer to `the dedicated documentation for more information <http://sonata-project.org/bundles/admin>`_.
+    The SonataAdminBundle and SonataDoctrineORMAdminBundle must be installed, please refer to `the dedicated documentation for more information <http://sonata-project.org/bundles/admin>`_.
 
 Next, be sure to enable the ``EasyExtends`` bundle in your application kernel:
 


### PR DESCRIPTION
I had to install SonataAdminBundle and SonataDoctrineORMAdminBundle in order to make the task "php app/console sonata:easy-extends:generate SonataPageBundle" work. Maybe is not intended but for now this change in the doc would help new adopters.
