### PR TITLE
Adds missing information about block configuration. Issue #30

### DIFF
--- a/Resources/doc/reference/your_first_block.rst
+++ b/Resources/doc/reference/your_first_block.rst
@@ -161,7 +161,7 @@ defined, a error message is displayed.
 Service
 -------
 
-We are almost done! Now just declare the block as a service.
+We are almost done! Now just declare the block as a service
 
 .. code-block:: xml
 
@@ -171,3 +171,14 @@ We are almost done! Now just declare the block as a service.
         <argument type="service" id="templating" />
     </service>
 
+and add it to sonata configuration
+
+.. code-block:: yaml
+
+    #config.yml
+    sonata_page:
+        services:
+            sonata.page.block.rss:
+    #           cache: sonata.page.cache.memcached 
+
+    


### PR DESCRIPTION
After some thoughts I agree that config.yml is a good place for block caching configuration. Also I think there is no need to add "noop" cache to any service automatically because this "extra" row will remind developers to think about caching for their blocks. So the only change is needed is to add this missing information to manuals.
