### PR TITLE
Updates the getting_started documentation

### DIFF
--- a/Resources/doc/reference/getting_started.rst
+++ b/Resources/doc/reference/getting_started.rst
@@ -151,7 +151,8 @@ To add a new container block, simply render the container with the desired name:
 ``sonata_page_render_container('footer_left', 'global')``
  
 When the SonataPageBundle renders this container, it will automatically insert a `sonata.page.block.container` with the name `footer_left` if it
-does not exist yet. You will then be able to add new child blocks to it in the frontend.
+does not exist yet. You will then be able to add new child blocks to it in the frontend. The second parameter is the name of the page.
+It can be either a string , or a `Page` instance. In case of a string, it will create a new  page with that name if it doesn't already exist.
 
 Publish a snapshot
 ------------------


### PR DESCRIPTION
The documentation was somehow missing some info on how to add a new container block to the page. As far as we can see that's the way to do it. Please disregard this PR if we're wrong about that ;)
