### PR TITLE
Rendering a custom form fails with the default layout

### DIFF
--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -35,10 +35,13 @@ file that was distributed with this source code.
             <div class="row">
                 {% if content is defined %}
                     {{ content|raw }}
-                {% elseif block('content')%}
-                    {{ block('content')|raw }}
-                {% else %}
-                    {{ sonata_page_render_container('content', page) }}
+                {% else %}                    
+                    {% set content = block('content') %}
+                    {% if content|length > 0 %}
+                        {{ content|raw }}
+                    {% else %}
+                        {{ sonata_page_render_container('content', page) }}
+                    {% endif %}
                 {% endif %}
             </div>
 


### PR DESCRIPTION
I'm not 100% sure why this is happening, but when you render a custom form in a template of a hybrid page using the default sonata page layout, the form fields are not rendered at all.

This PR solves this by simply setting a content varialbe once to the output of `block('content')` and checking against that variable instead of calling `block('content')` twice.
