### PR TITLE
Fix deprecated method call - configureShowField should be configureShowFields

### DIFF
--- a/Admin/PageAdmin.php
+++ b/Admin/PageAdmin.php
@@ -41,7 +41,7 @@ class PageAdmin extends Admin
      * @param \Sonata\AdminBundle\Show\ShowMapper $showMapper
      * @return void
      */
-    protected function configureShowField(ShowMapper $showMapper)
+    protected function configureShowFields(ShowMapper $showMapper)
     {
         $showMapper
             ->add('site')


### PR DESCRIPTION
According to the contents of

Sonata\AdminBundle\Admin\Admin:

```
$this->configureShowField($mapper); // deprecated, use configureShowFields instead
$this->configureShowFields($mapper);
```
