### PR TITLE
Added a validation on the site's name parameter

### DIFF
--- a/Resources/config/validation.xml
+++ b/Resources/config/validation.xml
@@ -15,4 +15,10 @@
            </constraint>
         </property>
     </class>
+
+    <class name="Application\Sonata\PageBundle\Entity\Site">
+        <property name="name">
+           <constraint name="NotNull" />
+        </property>
+    </class>
 </constraint-mapping>


### PR DESCRIPTION
A validation on the name parameter of the site module was missing ; the creation of a site with errors intended throws a 500 error instead of a message "It failed" type.
