### PR TITLE
Added configuration for entity manager (recreated pull request #68)

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -107,6 +107,8 @@ class Configuration implements ConfigurationInterface
                 ->useAttributeAsKey('id')
                 ->prototype('variable')->isRequired()->end()
             ->end()
+                
+            ->scalarNode('entity_manager')->defaultValue('doctrine.orm.default_entity_manager')->end()
 
             ->arrayNode('class')
                 ->addDefaultsIfNotSet()

--- a/DependencyInjection/SonataPageExtension.php
+++ b/DependencyInjection/SonataPageExtension.php
@@ -66,6 +66,9 @@ class SonataPageExtension extends Extension
             ->replaceArgument(1, $config['ignore_route_patterns'])
             ->replaceArgument(2, $config['ignore_uri_patterns'])
         ;
+        
+        //Set the entity manager that should be used to store pages:
+        $container->setAlias('sonata.page.entity_manager', $config['entity_manager']);
 
         $this->registerDoctrineMapping($config);
         $this->registerParameters($container, $config);

--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -14,7 +14,10 @@
     </parameters>
 
     <services>
-        <service id="sonata.page.entity_manager" alias="doctrine.orm.default_entity_manager" />
+        <!--
+          This alias is now set in the extension. Allows us to change the entity manager we use.
+          <service id="sonata.page.entity_manager" alias="doctrine.orm.default_entity_manager" />
+        -->
 
         <service id="sonata.page.manager.page" class="%sonata.page.manager.page.class%">
             <argument type="service" id="sonata.page.entity_manager" />


### PR DESCRIPTION
When multiple entity managers are used, this new configuration allows the developer to set which entity manager should be used in the configuration file. 
