### PR TITLE
Fix a typo error on the installation chapter

### DIFF
--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -174,15 +174,11 @@ Don't forget to also add it in your autoload :
 
 .. code-block:: php
 
-    
-
-    .. code-block:: php
-
-        <?php
-        $loader->registerNamespaces(array(
-            // ...
-            'Application'       => __DIR__ . '/../src/',
-            // ... other declarations
-        ));
+    <?php
+    $loader->registerNamespaces(array(
+        // ...
+        'Application'       => __DIR__ . '/../src/',
+        // ... other declarations
+    ));
 
 And now, you're good to go !


### PR DESCRIPTION
A `.. code-block::php` and indententation level that are too much in the end of the installation chapter....
