### PR TITLE
German translations

### DIFF
--- a/Resources/translations/SonataPageBundle.de.xliff
+++ b/Resources/translations/SonataPageBundle.de.xliff
@@ -172,7 +172,7 @@
       </trans-unit>
       <trans-unit id="42" resname="form.label_meta_keyword">
         <source>form.label_meta_keyword</source>
-        <target>Meta Keyword</target>
+        <target>Meta Keywords</target>
       </trans-unit>
       <trans-unit id="43" resname="form.label_name">
         <source>form.label_name</source>


### PR DESCRIPTION
## Changes German translations
- Fixed wrong translations (there were some very confusing mistakes)
- Unified translations (same things were translated differently)
- Added missing translations
- Changed "Site" to "Website" instead of "Seite", because "Pages" were already translated with "Seiten" and its hard to tell them apart.
