### PR TITLE
Dependency regression

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,14 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/symfony": "2.0.*",
-        "sonata-project/admin-bundle": "2.0.*",
-        "sonata-project/seo-bundle": "master-dev",
-        "sonata-project/notification-bundle": "2.1.*",
+        "symfony/symfony": "2.1.*",
+        "sonata-project/admin-bundle": "dev-master",
+        "sonata-project/seo-bundle": "dev-master",
+        "sonata-project/notification-bundle": "dev-master",
         "friendsofsymfony/user-bundle": "dev-master"
     },
     "suggest": {
-        "sonata-project/doctrine-orm-admin-bundle": "2.0.*"
+        "sonata-project/doctrine-orm-admin-bundle": "dev-master"
     },
     "autoload": {
         "psr-0": { "Sonata\\PageBundle": "" }


### PR DESCRIPTION
The composer dependencies were changed by the recent 2.0 -> master merge. This fixes them so the bundle works with 2.1 again.
