### PR TITLE
Update schema for oracle compatibility issue

### DIFF
--- a/Resources/config/doctrine/BaseBlock.orm.xml
+++ b/Resources/config/doctrine/BaseBlock.orm.xml
@@ -2,15 +2,12 @@
 <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xsi="http://www.w3.org/2001/XMLSchema-instance" schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
     <mapped-superclass name="Sonata\PageBundle\Entity\BaseBlock">
 
-        <field name="type"          type="string"     column="type" length="64" />
-
-        <field name="settings"      type="json"      column="settings" />
-
-        <field name="enabled"       type="boolean"    column="enabled" nullable="true" default="false"/>
-        <field name="position"      type="integer"    column="position" nullable="true"/>
-
-        <field name="createdAt"    type="datetime"   column="created_at" />
-        <field name="updatedAt"    type="datetime"   column="updated_at" />
+        <field name="type"         type="string"    column="type"       length="64" />
+        <field name="settings"     type="json"      column="settings" />
+        <field name="enabled"      type="boolean"   column="enabled"    nullable="true"     default="false"/>
+        <field name="position"     type="integer"   column="position"   nullable="true"/>
+        <field name="createdAt"    type="datetime"  column="created_at" />
+        <field name="updatedAt"    type="datetime"  column="updated_at" />
 
         <lifecycle-callbacks>
             <lifecycle-callback type="prePersist" method="prePersist" />

--- a/Resources/config/doctrine/BasePage.orm.xml
+++ b/Resources/config/doctrine/BasePage.orm.xml
@@ -1,32 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
 <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xsi="http://www.w3.org/2001/XMLSchema-instance" schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
     <mapped-superclass name="Sonata\PageBundle\Entity\BasePage">
-        <field name="routeName"         type="string"     column="route_name" length="255"/>
-        <field name="position"          type="integer"      column="position"  default="1"/>
 
-        <field name="enabled"           type="boolean"      column="enabled"         default="false" />
-        <field name="decorate"          type="boolean"      column="decorate"        default="false" />
-        <field name="edited"            type="boolean"      column="edited"          default="false" />
-
-        <field name="name"              type="string"       column="name"           length="255"/>
-
-        <field name="slug"              type="text"         column="slug"           nullable="true"/>
-        <field name="url"               type="text"         column="url"            nullable="true"/>
-        <field name="customUrl"         type="text"         column="custom_url"     nullable="true"/>
-
-        <field name="requestMethod"     type="string"       column="request_method"     length="255" nullable="true" />
-
-        <field name="title"             type="string"       column="title"              nullable="true" length="255"/>
-        <field name="metaKeyword"       type="string"       column="meta_keyword"       nullable="true" length="255"/>
-        <field name="metaDescription"   type="string"       column="meta_description"   nullable="true" length="255"/>
-
+        <field name="routeName"         type="string"       column="route_name"         length="255"/>
+        <field name="position"          type="integer"      column="position"           default="1"/>
+        <field name="enabled"           type="boolean"      column="enabled"            default="false" />
+        <field name="decorate"          type="boolean"      column="decorate"           default="false" />
+        <field name="edited"            type="boolean"      column="edited"             default="false" />
+        <field name="name"              type="string"       column="name"               length="255"/>
+        <field name="slug"              type="string"       column="slug"               nullable="true"  length="4000"/>
+        <field name="url"               type="string"       column="url"                nullable="true"  length="4000"/>
+        <field name="customUrl"         type="string"       column="custom_url"         nullable="true"  length="4000"/>
+        <field name="requestMethod"     type="string"       column="request_method"     nullable="true"  length="255"/>
+        <field name="title"             type="string"       column="title"              nullable="true"  length="255"/>
+        <field name="metaKeyword"       type="string"       column="meta_keyword"       nullable="true"  length="255"/>
+        <field name="metaDescription"   type="string"       column="meta_description"   nullable="true"  length="255"/>
         <field name="javascript"        type="text"         column="javascript"         nullable="true"/>
         <field name="stylesheet"        type="text"         column="stylesheet"         nullable="true"/>
         <field name="rawHeaders"        type="text"         column="raw_headers"        nullable="true"/>
-
-        <field name="templateCode"          type="string"       column="template"           nullable="false" />
-        <field name="createdAt"    type="datetime"   column="created_at" />
-        <field name="updatedAt"    type="datetime"   column="updated_at" />
+        <field name="templateCode"      type="string"       column="template"           nullable="false" />
+        <field name="createdAt"         type="datetime"     column="created_at" />
+        <field name="updatedAt"         type="datetime"     column="updated_at" />
 
         <lifecycle-callbacks>
             <lifecycle-callback type="prePersist" method="prePersist" />

--- a/Resources/config/doctrine/BaseSite.orm.xml
+++ b/Resources/config/doctrine/BaseSite.orm.xml
@@ -2,20 +2,19 @@
 <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xsi="http://www.w3.org/2001/XMLSchema-instance" schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
     <mapped-superclass name="Sonata\PageBundle\Entity\BaseSite">
 
-        <field name="enabled"           type="boolean"      column="enabled"        default="false" />
-        <field name="name"              type="string"       column="name"           length="255"/>
-        <field name="relativePath"      type="string"       column="relative_path"  length="255" nullable='true'/>
-        <field name="host"              type="string"       column="host"           length="255"/>
+        <field name="enabled"           type="boolean"      column="enabled"          default="false" />
+        <field name="name"              type="string"       column="name"             length="255"/>
+        <field name="relativePath"      type="string"       column="relative_path"    nullable="true"   length="255"/>
+        <field name="host"              type="string"       column="host"             length="255"/>
         <field name="enabledFrom"       type="datetime"     column="enabled_from" />
         <field name="enabledTo"         type="datetime"     column="enabled_to"   />
-        <field name="isDefault"         type="boolean"      column="is_default"     length="255"/>
+        <field name="isDefault"         type="boolean"      column="is_default"       length="255"/>
         <field name="createdAt"         type="datetime"     column="created_at" />
         <field name="updatedAt"         type="datetime"     column="updated_at" />
-        <field name="locale"            type="string"       column="locale"         length="6" nullable="true"/>
-
-        <field name="title"             type="string"       column="title"              nullable="true" length="64" />
-        <field name="metaKeywords"      type="string"       column="meta_keywords"      nullable="true" length="255"/>
-        <field name="metaDescription"   type="string"       column="meta_description"   nullable="true" length="255"/>
+        <field name="locale"            type="string"       column="locale"           nullable="true"   length="6" />
+        <field name="title"             type="string"       column="title"            nullable="true"   length="64" />
+        <field name="metaKeywords"      type="string"       column="meta_keywords"    nullable="true"   length="255"/>
+        <field name="metaDescription"   type="string"       column="meta_description" nullable="true"   length="255"/>
 
         <lifecycle-callbacks>
             <lifecycle-callback type="prePersist" method="prePersist" />

--- a/Resources/config/doctrine/BaseSnapshot.orm.xml
+++ b/Resources/config/doctrine/BaseSnapshot.orm.xml
@@ -2,25 +2,19 @@
 <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xsi="http://www.w3.org/2001/XMLSchema-instance" schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
     <mapped-superclass name="Sonata\PageBundle\Entity\BaseSnapshot">
 
-        <field name="routeName"         type="string"     column="route_name" length="255"/>
-        <field name="position"          type="integer"      column="position"  default="1"/>
-
-        <field name="enabled"           type="boolean"      column="enabled"        default="false" />
-        <field name="decorate"          type="boolean"      column="decorate"       default="false" />
-
-        <field name="name"              type="string"       column="name"           length="255"/>
-
-        <field name="url"               type="text"         column="url"            nullable="true"/>
-
-        <field name="parentId"          type="integer"      column="parent_id"      nullable="true" />
-        <field name="targetId"          type="integer"      column="target_id"      nullable="true" />
-        <field name="content"           type="json"         column="content"        nullable="true"/>
-
-        <field name="publicationDateStart"   type="datetime"   column="publication_date_start"    nullable="true"/>
-        <field name="publicationDateEnd"     type="datetime"   column="publication_date_end"      nullable="true"/>
-
-        <field name="createdAt"    type="datetime"   column="created_at" />
-        <field name="updatedAt"    type="datetime"   column="updated_at" />
+        <field name="routeName"            type="string"     column="route_name"             length="255"/>
+        <field name="position"             type="integer"    column="position"               default="1"/>
+        <field name="enabled"              type="boolean"    column="enabled"                default="false"/>
+        <field name="decorate"             type="boolean"    column="decorate"               default="false"/>
+        <field name="name"                 type="string"     column="name"                   length="255"/>
+        <field name="url"                  type="string"     column="url"                    nullable="true"    length="4000" />
+        <field name="parentId"             type="integer"    column="parent_id"              nullable="true"/>
+        <field name="targetId"             type="integer"    column="target_id"              nullable="true"/>
+        <field name="content"              type="json"       column="content"                nullable="true"/>
+        <field name="publicationDateStart" type="datetime"   column="publication_date_start" nullable="true"/>
+        <field name="publicationDateEnd"   type="datetime"   column="publication_date_end"   nullable="true"/>
+        <field name="createdAt"            type="datetime"   column="created_at" />
+        <field name="updatedAt"            type="datetime"   column="updated_at" />
 
         <lifecycle-callbacks>
             <lifecycle-callback type="prePersist" method="prePersist" />


### PR DESCRIPTION
This PR changes some "page" and "site" fields from "text" to "string(4000)"  because oracle doesn't support where conditions on CLOB (text equivalent). It requires the use of a Oracle function to convert the clob into a string of 4000 characters which then works the same way as a varchar2(4000).

This fix also works on MySQL 5.0.3+ since it supports varchar fields up to 65535 characters.

PS: I made some style updates on the xml files too
