### PR TITLE
Add dynamic page routing in cms page router

### DIFF
--- a/Resources/config/page.xml
+++ b/Resources/config/page.xml
@@ -110,6 +110,7 @@
         <service id="sonata.page.router" class="%sonata.page.router.class%">
             <argument type="service" id="sonata.page.cms_manager_selector" />
             <argument type="service" id="sonata.page.site.selector"/>
+            <argument type='service' id="router.default"/>
         </service>
     </services>
 </container>


### PR DESCRIPTION
cmsPageRouter handles dynamic pages so we can use the twig helper path(page, params) instead of path(page.routeName, params) when involving dynamic pages
