### PR TITLE
Fixed saving parent page for new page. Get site id form post request.

### DIFF
--- a/Admin/PageAdmin.php
+++ b/Admin/PageAdmin.php
@@ -345,12 +345,13 @@ class PageAdmin extends Admin
             return false;
         }
 
+        $siteId = $this->getRequest()->get('siteId');
+
         if ($this->getRequest()->getMethod() == 'POST') {
             $values = $this->getRequest()->get($this->getUniqid());
-            $siteId = isset($values['site']) ? $values['site'] : null;
+            
+            $siteId = isset($values['site']) ? $values['site'] : $siteId;
         }
-        
-        $siteId = (null !== $siteId) ? $siteId : $this->getRequest()->get('siteId');
 
         if ($siteId) {
             $site = $this->siteManager->findOneBy(array('id' => $siteId));


### PR DESCRIPTION
On saving new page there isn't passed Site object to PageSelectorType, so parent page choices are always empty.
When selected parent page isn't null then form field throws error.
So only posibility is to create new page without parent.

In master branch saving new page doesn't work because of setting slug to null for page without parent in [PageManager](https://github.com/sonata-project/SonataPageBundle/blob/master/Entity/PageManager.php#L110) and form throws

> The URL /' is already associated with another page
