### PR TITLE
sonata.page.admin.page service depends on sonata.cache.manager

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "sonata-project/seo-bundle": "dev-master",
         "sonata-project/notification-bundle": "dev-master",
         "sonata-project/doctrine-extensions" : "dev-master",
+        "sonata-project/cache-bundle": "dev-master",
         "symfony-cmf/routing-extra-bundle": "1.0.*"
     },
     "suggest": {


### PR DESCRIPTION
added sonata-project/cache-bundle because sonata.page.admin.page service has a dependency to sonata.cache.manager
