### PR TITLE
Enhance page front editor UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ A [BC BREAK] means the update will break the project for many reasons:
 * new dependencies
 * class refactoring
 
+### 2012-10-23
+
+* [BC BREAK] The front page editor has been completely redesigned.
+
+  Assets ``page.js`` and ``page.css`` have been rewritten to provide new functionality to the front page editor.
+
+  Templates for base blocks and container blocks have been updated to provide additional information on blocks when
+  in the front editor mode.
+
+  ``BlockInteractor`` has its ``saveBlocksPosition()`` method updated. It now performs unit updates and does not
+  require a tree structure anymore.
+
+  The BlockManager interface and class have been updated to implement a ``updatePosition()`` method.
+
+* [BC BREAK] The container layout setting is now used to decorate inside the block div instead of decorating
+  outside.
+
 ### 2012-09-14
 
 * [BC BREAK] Integrate the SymfonyCmfRoutingExtraBundle from the CMF project

--- a/Entity/BlockManager.php
+++ b/Entity/BlockManager.php
@@ -98,4 +98,29 @@ class BlockManager implements BlockManagerInterface
     {
         return $this->getRepository()->findOneBy($criteria);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function updatePosition($id, $position, $parentId, $pageId)
+    {
+        $em = $this->entityManager;
+        $meta = $em->getClassMetadata($this->getClass());
+
+        // retrieve object references
+        $block = $em->getReference($this->getClass(), $id);
+        $pageRelation = $meta->getAssociationMapping('page');
+        $page = $em->getPartialReference($pageRelation['targetEntity'], $pageId);
+
+        $parentRelation = $meta->getAssociationMapping('parent');
+        $parent = $em->getPartialReference($parentRelation['targetEntity'], $parentId);
+
+        // set new values
+        $block->setPosition($position);
+        $block->setPage($page);
+        $block->setParent($parent);
+        $em->persist($block);
+
+        return $block;
+    }
 }

--- a/Resources/public/page.css
+++ b/Resources/public/page.css
@@ -1,103 +1,81 @@
-body.cms-edit-mode div.cms-container {
-    min-height: 50px;
-
-    background: #999; /* for non-css3 browsers */
-
-    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#dddddd', endColorstr='#eeeeee'); /* for IE */
-    background: -webkit-gradient(linear, left top, left bottom, from(#ddd), to(#eee)); /* for webkit browsers */
-    background: -moz-linear-gradient(top,  #ddd,  #eee); /* for firefox 3.6+ */
-
-    border-radius: 4px 4px 4px 4px;
-    box-shadow: 0 1px 3px #8493A6;
-    margin: 1px;
+/* sonata top bar style */
+.sonata-page-top-bar {
+    height: 45px;
 }
-
-body.cms-edit-mode div.cms-block-element {
-    min-height: 25px;
-    margin: 2px;
-    border-radius: 4px 4px 4px 4px;
-    box-shadow: 0 1px 3px #8493A6;
-}
-
-body.cms-edit-mode {
-    background-color: white !important;
-    background-image: none !important;
-    color: black !important;
-    padding-top: 40px;
-}
-
-body.cms-edit-mode div.cms-block-element {
-    min-height: 20px;
-    background-color: #BE9B4D;
-}
-
-body.cms-edit-mode div.cms-container-root {
-    padding-top: 15px;
-    background-color: #C53214;
-    padding-bottom: 15px
-}
-
-body.cms-edit-mode div.cms-block-hand-over {
-    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#BE9B4D', endColorstr='#eeeeee'); /* for IE */
-    background: -webkit-gradient(linear, left top, left bottom, from(#BE9B4D), to(#eee)); /* for webkit browsers */
-    background: -moz-linear-gradient(top,  #BE9B4D,  #eee); /* for firefox 3.6+ */
-    cursor: pointer;
-}
-
-body.cms-edit-mode div.cms-container-start {
-    background: #cccccc;
-}
-
-body.cms-edit-mode div.cms-container.cms-block-internal {
-    background: #FF4C00;
-}
-
-body.cms-edit-mode div.cms-container {
-    background: #A12000;
-}
-
-body.cms-edit-mode div.cms-container:hover {
-    background-color: #cccccc;
-}
-
-.sonata-bc body, body {
-    margin-top: 40px !important;
-}
-
-div.sonata-page-top-bar {
-
-}
-
-div.sonata-page-top-bar label {
+.sonata-page-top-bar label {
     color: #BFBFBF;
 }
 
-body.cms-edit-mode div.cms-block-start {
-    background: white;
+.cms-edit-mode-only {
+    visibility: hidden;
 }
 
-body.cms-edit-mode div.cms-block-placeholder {
-    background: yellow;
+.cms-edit-mode .cms-edit-mode-only {
+    visibility: visible;
 }
 
-body.cms-edit-mode div.cms-fake-block {
-    height: 1px;
-    min-height: 1px;
-    background: #cccccc;
+/* original block display */
+.cms-edit-mode .cms-block {
+    position: relative;
+    min-height: 40px;
 }
 
-body div.cms-fake-block {
-    display:none;
+/* block layer display */
+.cms-edit-mode .cms-layout-role-block {
+    background-color: rgba(255, 150, 0, 0.3);
 }
 
-textarea.title {
-    font-size: 1.5em;
-    font-family: "Lucida Grande";
-    height: 100px;
-    width: 500px
+/* container layer display */
+.cms-edit-mode .cms-layout-role-container {
 }
 
-body.cms-edit-mode div.cms-container {
-    min-height: 50px;
-    min-width: 150px;
+/* layer title display */
+.cms-edit-mode .cms-layout-title span {
+    display: inline-block;
+    padding: 2px;
+    font-size: 12pt;
+    color: #ffffff;
+}
+.cms-edit-mode .cms-layout-role-container > .cms-layout-title {
+    display: block;
+    width: 100%;
+    background-color: rgba(50, 50, 50, 1);
+}
+.cms-edit-mode .cms-layout-role-block > .cms-layout-title {
+    display: block;
+    background-color: rgba(75, 50, 0, 1);
+}
+/* layer title display (when dragging) */
+.cms-edit-mode .cms-container-drop-zone .cms-layout-role-block > .cms-layout-title {
+    display: block;
+}
+.cms-edit-mode .cms-container-drop-zone > .cms-layout-layer .cms-layout-title {
+    display: block;
+}
+
+/* container drag drop zone*/
+.cms-edit-mode .cms-container {
+    padding-top: 24px;
+    border: 2px dotted rgba(100, 100, 100, 1);
+}
+
+/*.cms-edit-mode .cms-container > .cms-layout-layer {*/
+    /*border: 2px dotted rgba(100, 100, 100, 1);*/
+/*}*/
+
+/* placeholder class used to simulate a dropped item while dragging */
+.cms-edit-mode .cms-block-placeholder {
+    background-color: rgba(100, 100, 100, 0.2);
+    min-height: 40px;
+}
+
+/* hover attributes */
+.cms-edit-mode div.cms-block-hand-over {
+    cursor: move;
+}
+
+/* block's layer when hover */
+.cms-edit-mode div.cms-block-hand-over > .cms-layout-role-block {
+    /*border: 1px solid #000000;*/
+    background-color: rgba(255, 150, 0, 0.5);
 }

--- a/Resources/public/page.js
+++ b/Resources/public/page.js
@@ -9,132 +9,487 @@
  *
  */
 
-jQuery(document).ready(function() {
-    Page.init();
-});
+/**
+ * Manages the Page Editor
+ *
+ * @author Olivier Paradis <paradis.olivier@gmail.com>
+ */
+var Sonata = Sonata || {};
 
-var Page = {
-    blocks: null,
-    log: function(message) {
-      try {
-          console.log(message);
-      } catch(e) {
+Sonata.Page = {
 
-      }
+    /**
+     * Enable/disable debug mode
+     *
+     * @var boolean
+     */
+    debug: false,
+
+    /**
+     * Collection of blocks found on the page
+     *
+     * @var array
+     */
+    blocks: [],
+
+    /**
+     * Collection of containers found on the page
+     *
+     * @var array
+     */
+    containers: [],
+
+    /**
+     * block data
+     *
+     * @var array
+     */
+    data: [],
+
+    /**
+     * Block DOM selector
+     *
+     * @var string
+     */
+    blockSelector: '.cms-block',
+
+    /**
+     * Container DOM selector
+     *
+     * @var string
+     */
+    containerSelector: '.cms-container',
+
+    /**
+     * Drop placeholder CSS class
+     *
+     * @var string
+     */
+    dropPlaceHolderClass: 'cms-block-placeholder',
+
+    /**
+     * Drop placeholder size
+     *
+     * @var integer
+     */
+    dropPlaceHolderSize: 100,
+
+    /**
+     * Drop zone container CSS class
+     *
+     * @var string
+     */
+    dropZoneClass: 'cms-container-drop-zone',
+
+    /**
+     * Block hover CSS class
+     *
+     * @var string
+     */
+    blockHoverClass: 'cms-block-hand-over',
+
+    /**
+     * URLs to use when performing ajax operations
+     *
+     * @var Object
+     */
+    url: {
+        block_save_position: null,
+        block_edit: null
     },
-    init: function() {
-        jQuery('#page-action-enabled-edit').change(Page.handleClickEnabledEdit);
-        jQuery('#page-action-save-position').click(Page.savePosition);
 
-        jQuery('#page-action-save-position').hide();
-
-        Page.blocks = jQuery('div.cms-block-element, div.cms-container-root');
-        Page.blocks.mouseover(Page.handleBlockHover);
-        Page.blocks.dblclick(Page.handleBlockClick);
-
-        Page.buildHandler();
-    },
-
-    handleBlockClick: function(event) {
-        event.stopPropagation();
-
-        var id = event.currentTarget.id.slice(10);
-        window.open(Page.url.block_edit.replace(/BLOCK_ID/, id), '_newtab');
-    },
-
-    handleBlockHover: function(event) {
-        event.stopPropagation();
-        Page.blocks.removeClass('cms-block-hand-over');
-        jQuery(this).addClass('cms-block-hand-over');
-    },
-
-    handleClickEnabledEdit: function(event) {
-        if (event.currentTarget.checked) {
-            jQuery('#page-action-save-position').show();
-            jQuery("div.cms-container").sortable('enable');
-
-            jQuery('body').addClass('cms-edit-mode');
-
-        } else {
-            jQuery('#page-action-save-position').hide();
-            jQuery("div.cms-container").sortable('disable');
-
-            jQuery('body').removeClass('cms-edit-mode');
+    /**
+     * Initialize Page editor mode
+     */
+    init: function(options) {
+        options = options || [];
+        for (property in options) {
+            this[property] = options[property];
         }
 
+        this.initInterface();
+        this.initBlocks();
+        this.initContainers();
+        this.initBlockData();
     },
-    buildHandler: function() {
-        jQuery("div.cms-container").sortable({
-            connectWith: "div.cms-container",
-            items: "div.cms-block-element",
-            placeholder: 'cms-block-placeholder',
-            helper: 'clone',
-            dropOnEmpty: true,
-            forcePlaceholderSize: 100,
-            cursor: 'move',
-            start: function(event, ui) {
-                jQuery('div.cms-container').addClass('cms-container-start');
-                jQuery('div.cms-block-element').addClass('cms-block-start');
-                jQuery('div.cms-fake-block').css('display', 'block');
-            },
-            stop: function(event, ui) {
-                jQuery('div.cms-container').removeClass('cms-container-start');
-                jQuery('div.cms-block-element').removeClass('cms-block-start');
-                jQuery('div.cms-fake-block').css('display', 'none');
-            }
+
+    /**
+     * Initialize Admin interface (buttons)
+     */
+    initInterface: function() {
+        jQuery('#page-action-enabled-edit').change(jQuery.proxy(this.toggleEditMode, this));
+        jQuery('#page-action-save-position').click(jQuery.proxy(this.saveBlockLayout, this));
+    },
+
+    /**
+     * Initialize block elements and behaviors
+     */
+    initBlocks: function() {
+        // cache blocks
+        this.blocks = jQuery(this.blockSelector);
+
+        this.blocks.mouseover(jQuery.proxy(this.handleBlockHover, this));
+        this.blocks.dblclick(jQuery.proxy(this.handleBlockClick, this));
+    },
+
+    /**
+     * Initialize container elements and behaviors
+     */
+    initContainers: function() {
+        // cache containers
+        this.containers = jQuery(this.containerSelector);
+
+        this.containers.sortable({
+            connectWith:          this.containerSelector,
+            items:                this.blockSelector,
+            placeholder:          this.dropPlaceHolderClass,
+            helper:               'clone',
+            dropOnEmpty:          true,
+            forcePlaceholderSize: this.dropPlaceHolderSize,
+            opacity:              1,
+            cursor:               'move',
+            start:                jQuery.proxy(this.startContainerSort, this),
+            stop:                 jQuery.proxy(this.stopContainerSort, this)
         }).sortable('disable');
     },
 
-    buildInformation: function() {
-
-        var blocks = jQuery("div.cms-container-root");
-        var information = {};
-
-        blocks.each(function(i, block) {
-            information[block.id] = {
-                type: block.getAttribute('type'),
-                child: Page.buildBlockInformation(block)
-            }
-        });
-
-        return information;
+    /**
+     * Initialize the block data (used to perform a diff when changing position/hierarchy)
+     */
+    initBlockData: function() {
+        this.data = this.buildBlockData();
     },
 
-    buildBlockInformation: function(block) {
-        if (!block.id) {
+    /**
+     * Starts the container sorting
+     *
+     * @param event
+     * @param ui
+     */
+    startContainerSort: function(event, ui) {
+        this.containers.addClass(this.dropZoneClass);
+        this.containers.append(jQuery('<div class="cms-fake-block">&nbsp;</div>'));
+    },
+
+    /**
+     * Stops the container sorting
+     *
+     * @param event
+     * @param ui
+     */
+    stopContainerSort: function(event, ui) {
+        this.containers.removeClass(this.dropZoneClass);
+        jQuery('div.cms-fake-block').remove();
+        this.refreshLayers();
+    },
+
+    /**
+     * Handle a click on the block
+     *
+     * @param event
+     */
+    handleBlockClick: function(event) {
+        var target = event.currentTarget,
+            id = jQuery(target).attr('data-id');
+
+        window.open(this.url.block_edit.replace(/BLOCK_ID/, id), '_newtab');
+
+        event.preventDefault();
+        event.stopPropagation();
+    },
+
+    /**
+     * Handle a hover on the block
+     *
+     * @param event
+     */
+    handleBlockHover: function(event) {
+        this.blocks.removeClass(this.blockHoverClass);
+        jQuery(this).addClass(this.blockHoverClass);
+        event.stopPropagation();
+    },
+
+    /**
+     * Toggle edit mode
+     *
+     * @param event
+     */
+    toggleEditMode: function(event) {
+        if (event && event.currentTarget.checked) {
+            jQuery('body').addClass('cms-edit-mode');
+            jQuery('.cms-container').sortable('enable');
+            this.buildLayers();
+        } else {
+            jQuery('body').removeClass('cms-edit-mode');
+            jQuery('div.cms-container').sortable('disable');
+            this.removeLayers();
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+    },
+
+    /**
+     * Build block layers
+     */
+    buildLayers:function() {
+        this.blocks.each(function(index) {
+            var block   = jQuery(this),
+                role    = block.attr('data-role') || 'block',
+                name    = block.attr('data-name') || 'missing data-name',
+                id      = block.attr('data-id') || 'missing data-id',
+                classes = [],
+                layer;
+
+            classes.push('cms-layout-layer');
+            classes.push('cms-layout-role-'+role);
+
+            // build layer
+            layer = jQuery('<div class="'+classes.join(' ')+'" ></div>');
+            layer.css({
+                position: "absolute",
+                left: 0,
+                top: 0,
+                width: '100%',
+                height: '100%',
+                zIndex: 2
+            });
+
+            // build layer title
+            title = jQuery('<div class="cms-layout-title"></div>');
+            title.css({
+                position: "absolute",
+                left: 0,
+                top: 0,
+                zIndex: 2
+            });
+            title.html('<span>'+name+'</span>');
+            layer.append(title);
+
+            block.prepend(layer);
+        });
+    },
+
+    /**
+     * Remove all block layers
+     */
+    removeLayers: function() {
+        jQuery('.cms-layout-layer').remove();
+    },
+
+    /**
+     * Refreshes the block layers
+     */
+    refreshLayers: function() {
+        jQuery('.cms-layout-layer').each(function(position) {
+            var layer = jQuery(this),
+                block = layer.parent();
+
+            layer.css('width', block.width());
+            layer.css('height', block.height());
+        });
+    },
+
+    /**
+     * Build block data used to perform a database update of block position and hierarchy
+     *
+     * @return {Array} An array of block information with id, position, and parent id
+     */
+    buildBlockData: function() {
+        var data = [];
+
+        this.blocks.each(jQuery.proxy(function(index, block) {
+            var item = this.buildSingleBlockData(block)
+            if (item) {
+                data.push(item);
+            }
+        }, this));
+
+        // sort items on page, parent and position
+        data.sort(function(a, b) {
+            if (a.page_id == b.page_id) {
+                if (a.parent_id == b.parent_id) {
+                    return a.position - b.position;
+                }
+                return a.parent_id - b.parent_id;
+            }
+            return a.page_id - b.page_id;
+        })
+
+        return data;
+    },
+
+    /**
+     * Builds a single block data
+     *
+     * @param original
+     */
+    buildSingleBlockData: function(original) {
+        var block, id, parent, parentId, pageId, previous, position;
+
+        block = jQuery(original);
+
+        // retrieve current block id
+        id = block.attr('data-id');
+        if (!id) {
+            this.log('Block has no data-id, ignored !');
             return;
         }
 
-        var blocks = jQuery('#' + block.id + ' > div.cms-block');
-        var information = {};
+        // retrieve parent block container
+        parent = this.findParentContainer(block);
+        if (!parent) {
+            this.log('Block '+id+' has no parent, it must be a root container, ignored');
+            return;
+        }
+        parentId = jQuery(parent).attr('data-id');
 
-        blocks.each(function(i, child) {
-            information[child.id] = {
-                type: child.getAttribute('type'),
-                child: Page.buildBlockInformation(child)
+        // retrieve root's page (because a root container cannot be moved)
+        root = this.findRootContainer(block);
+        if (!root) {
+            this.log('Block '+id+' has no root but has a parent, should never happen!');
+            return;
+        }
+        pageId = jQuery(root).attr('data-page-id');
+
+        // get previous siblings to count position
+        previous = block.prevAll(this.blockSelector+'[data-id]');
+        position = previous.length + 1;
+
+        if (!id || !parentId) {
+            return;
+        }
+
+        return {
+            id:        id,
+            position:  position,
+            parent_id: parentId,
+            page_id:   pageId
+        };
+    },
+
+    /**
+     * Returns an array with differences from 2 arrays
+     *
+     * @param previousData Previous data
+     * @param newData      New data
+     *
+     * @return Array
+     */
+    buildDiffBlockData: function(previousData, newData) {
+        var diff = [];
+
+        jQuery.map(previousData, function(previousItem, index) {
+            var found;
+
+            found = jQuery.grep(newData, function(newItem, index) {
+                if (previousItem.id != newItem.id) {
+                    return false;
+                }
+
+                if (previousItem.position != newItem.position || previousItem.parent_id != newItem.parent_id || previousItem.page_id != newItem.page_id) {
+                    return true;
+                }
+            });
+
+            if (found && found[0]) {
+                diff.push(found[0]);
             }
         });
 
-        return information;
+        return diff;
     },
 
-    savePosition: function() {
-        var params = {
-            disposition: Page.buildInformation()
-        };
+    /**
+     * Returns the parent container of a block
+     *
+     * @param block
+     *
+     * @return {*}
+     */
+    findParentContainer: function(block) {
+        var parents, parent;
+
+        parents = jQuery(block).parents(this.containerSelector+'[data-id]');
+        parent = parents.get(0);
+
+        return parent;
+    },
+
+    /**
+     * Returns the root container of a block
+     *
+     * @param block
+     *
+     * @return {*}
+     */
+    findRootContainer: function(block) {
+        var parents, root;
+
+        parents = jQuery(block).parents(this.containerSelector+'[data-id]');
+        root = parents.get(-1);
+
+        return root;
+    },
+
+    /**
+     * Save block layout to server
+     *
+     * @param event
+     */
+    saveBlockLayout: function(event) {
+        var diff;
+
+        event.preventDefault();
+        event.stopPropagation();
+
+        diff = this.buildDiffBlockData(this.data, this.buildBlockData());
+
+        if (diff.length == 0) {
+            alert('No changes found.');
+            return;
+        }
+
+        jQuery.each(diff, jQuery.proxy(function(item, block) {
+            this.log('Update block '+block.id+ ' (Page '+block.page_id+'), parent '+block.parent_id+', at position '+block.position+')');
+        }, this));
 
         jQuery.ajax({
             type: 'POST',
-            url: Page.url.block_save_position,
-            data: params,
+            url: this.url.block_save_position,
+            data: { disposition: diff },
             dataType: 'json',
-            success: function() {
-                alert('object saved !')
-            },
-            error: function() {
-                alert('Error');
-            }
+            success: jQuery.proxy(function(data, status, xhr) {
+                if (data.result == 'ok') {
+                    alert('Block ordering saved!');
+                    // re-initialize block data to consider as the new "previous" values
+                    this.initBlockData();
+                } else {
+                    this.log(data);
+                    alert('Server could not save block ordering!');
+                }
+            }, this),
+            error: jQuery.proxy(function(xhr, status, error) {
+                this.log('Unable to save block ordering: '+ error);
+                this.log(status);
+                this.log(xhr);
+            }, this)
         });
-    }
 
+    },
+
+    /**
+     * Log messages
+     */
+    log: function() {
+        if (!this.debug) {
+            return;
+        }
+
+        try {
+            console.log(arguments);
+        } catch(e) {
+
+        }
+    }
 }

--- a/Resources/views/Block/block_base.html.twig
+++ b/Resources/views/Block/block_base.html.twig
@@ -1,0 +1,22 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+<div id="cms-block-{{ block.id }}"
+     class="cms-block{% if block.hasParent() %} cms-block-element{% endif %}{% block block_class %}{% endblock %}"
+    {% if sonata_page.isEditor %}
+        data-id="{{ block.id }}"
+        data-name="{{ block.name }}"
+        data-role="{% block block_role %}block{% endblock %}"
+        data-page-id="{{ block.page.id }}"
+    {% endif %}
+    >
+    {% block block %}EMPTY CONTENT{% endblock %}
+</div>

--- a/Resources/views/Block/block_container.html.twig
+++ b/Resources/views/Block/block_container.html.twig
@@ -9,13 +9,20 @@ file that was distributed with this source code.
 
 #}
 
-<!-- block({{ container.id }}, {{ container.type }} : {% if not container.hasParent()%} {{ container.settings.code }} {% else %} inner-container{% endif%}) -->
-<div id="cms-block-{{ container.id }}" class="cms-block cms-container{% if not container.hasParent()%} cms-container-root{% else %} cms-block-element{%endif%}">
-    <div class="cms-block cms-block-element cms-fake-block">&nbsp;</div>
-    {% for block in container.children %}
-        <!-- block({{ block.id }}, {{ block.type }}) -->
-        {{ sonata_page_render_block(block) }}
-        <!-- end block({{ block.id }}, {{ block.type }}) -->
+{% extends "SonataPageBundle:Block:block_base.html.twig" %}
+
+{# block classes are prepended with a container class #}
+{% block block_class %} cms-container{% if not block.hasParent() %} cms-container-root{%endif%}{% if settings.class %} {{ settings.class }}{% endif %}{% endblock %}
+
+{# identify a block role used by the page editor #}
+{% block block_role %}container{% endblock %}
+
+{# render container block #}
+{% block block %}
+    {% if decorator %}{{ decorator.pre|raw }}{% endif %}
+    {% for child in block.children %}
+        {{ sonata_page_render_block(child) }}
     {% endfor %}
-</div>
-<!-- end block({{ container.id }}, {{ container.type }}) -->
+    {% if decorator %}{{ decorator.post|raw }}{% endif %}
+{% endblock %}
+

--- a/Resources/views/Block/block_core_children_pages.html.twig
+++ b/Resources/views/Block/block_core_children_pages.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataBlockBundle:Block:block_base.html.twig' %}
+{% extends 'SonataPageBundle:Block:block_base.html.twig' %}
 
 {% block block %}
     <div class="sonata-page-menu-container {{ settings.class }}">

--- a/Resources/views/base_layout.html.twig
+++ b/Resources/views/base_layout.html.twig
@@ -53,12 +53,14 @@ file that was distributed with this source code.
 
                     <!-- CMS specific variables -->
                     <script>
-                        Page.url = {};
-                        Page.url.block_save_position = '{{ path('admin_sonata_page_block_savePosition') }}';
-                        Page.url.block_edit          = '{{ path('admin_sonata_page_block_edit', {'id': 'BLOCK_ID'}) }}';
-                        {% if page is defined %}
-                            Page.url.page_edit           = '{{ path('admin_sonata_page_page_edit', {'id': page.id }) }}';
-                        {% endif %}
+                        jQuery(document).ready(function() {
+                            Sonata.Page.init({
+                                url: {
+                                    block_save_position: '{{ path('admin_sonata_page_block_savePosition') }}',
+                                    block_edit:          '{{ path('admin_sonata_page_block_edit', {'id': 'BLOCK_ID'}) }}'
+                                }
+                            });
+                        });
                     </script>
                 {% endif %}
 

--- a/Tests/Block/ContainerBlockServiceTest.php
+++ b/Tests/Block/ContainerBlockServiceTest.php
@@ -37,9 +37,34 @@ class ContainerBlockServiceTest extends \PHPUnit_Framework_TestCase
         $service->execute($block);
 
         $this->assertEquals('SonataPageBundle:Block:block_container.html.twig', $templating->view);
-        $this->assertEquals('block.code', $templating->parameters['container']->getSetting('code'));
-        $this->assertEquals('block.name', $templating->parameters['container']->getName());
-        $this->assertInstanceOf('Sonata\BlockBundle\Model\Block', $templating->parameters['container']);
+        $this->assertEquals('block.code', $templating->parameters['block']->getSetting('code'));
+        $this->assertEquals('block.name', $templating->parameters['block']->getName());
+        $this->assertInstanceOf('Sonata\BlockBundle\Model\Block', $templating->parameters['block']);
+    }
+
+    /**
+     * test the container layout
+     */
+    public function testLayout()
+    {
+        $templating = new FakeTemplating();
+        $service    = new ContainerBlockService('core.container', $templating);
+
+        $block = new Block;
+        $block->setName('block.name');
+        $block->setType('core.container');
+        $block->setSettings(array(
+            'layout' => 'before{{ CONTENT }}after',
+            'code'   => 'block.code'
+        ));
+
+        $service->execute($block);
+
+        $this->assertInternalType('array', $templating->parameters['decorator']);
+        $this->assertArrayHasKey('pre', $templating->parameters['decorator']);
+        $this->assertArrayHasKey('post', $templating->parameters['decorator']);
+        $this->assertEquals('before', $templating->parameters['decorator']['pre']);
+        $this->assertEquals('after', $templating->parameters['decorator']['post']);
     }
 
     /**


### PR DESCRIPTION
- [BC BREAK] The front page editor has been completely redesigned.
  
  Assets `page.js` and `page.css` have been rewritten to provide new functionality to the front page editor.
  
  Templates for base blocks and container blocks have been updated to provide additional information on blocks when in the front editor mode.
  
  `BlockInteractor` has its `saveBlocksPosition()` method updated. It now performs unit updates and does not require a tree structure anymore.
  
  The BlockManager interface and class have been updated to implement a `updatePosition()` method.
- [BC BREAK] The container layout setting is now used to decorate inside the block div instead of decorating outside.
