### PR TITLE
Fix sonata page block children pages

### DIFF
--- a/Block/ChildrenPagesBlockService.php
+++ b/Block/ChildrenPagesBlockService.php
@@ -157,7 +157,7 @@ class ChildrenPagesBlockService extends BaseBlockService
     {
         if (is_numeric($block->getSetting('pageId'))) {
             $cmsManager = $this->cmsManagerSelector->retrieve();
-            $site       = $this->siteSelector->retrieve();
+            $site       = $block->getPage()->getSite();
 
             $block->setSetting('pageId', $cmsManager->getPage($site, $block->getSetting('pageId')));
         }


### PR DESCRIPTION
Hey,

Depending on the configuration of the bundle it is possible to trigger an exception when **\Sonata\PageBundle\CmsManager\CmsManagerSelectorInterface** instance tries to fetch the page  setting and there is not site available. This is the case with the sandbox application where all admin URLs are being ignored.
I believe it is save(er) to refer to the page attribute of current block  when retrieving the site.

Cheers,
Stan
