### PR TITLE
Bugfix: Remove unneeded abstract method implementation

### DIFF
--- a/Page/Service/BasePageService.php
+++ b/Page/Service/BasePageService.php
@@ -49,9 +49,4 @@ abstract class BasePageService implements PageServiceInterface
     {
         return $this->name;
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    abstract public function execute(PageInterface $page, Request $request, array $parameters = array(), Response $response = null);
 }


### PR DESCRIPTION
An abstract method was implementing an interface method. This should never have been done, unfortunately recent PHP versions don't bother to warn you, while versions 5.3.3 or less cause a Fatal Error.
