### PR TITLE
Fix error "Site in not defined in base_layout.html"

### DIFF
--- a/Resources/views/base_layout.html.twig
+++ b/Resources/views/base_layout.html.twig
@@ -76,7 +76,7 @@ file that was distributed with this source code.
                                     {% if sonata_page.isEditor %}
                                         {% set sites = sonata_page.siteavailables %}
 
-                                        {% if sites|length > 1 %}
+                                        {% if sites|length > 1 and site is defined %}
                                             <li class="dropdown">
                                                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">{{ site.name }} <span class="caret"></span></a>
                                                 <ul class="dropdown-menu">


### PR DESCRIPTION
I added an extra check for site variable in template. Sometimes "site" is not defined in the template when we are on one of the FOSUserBundle pages, for example.
