### PR TITLE
Update ignore_uri_patterns configuration pattern

### DIFF
--- a/Resources/doc/reference/advanced_configuration.rst
+++ b/Resources/doc/reference/advanced_configuration.rst
@@ -36,7 +36,7 @@ Full configuration options (config.yml file):
             - sonata_cache_apc
 
         ignore_uri_patterns:
-            - ^/admin(.*)   # ignore admin route, ie route containing 'admin'
+            - ^/admin\/   # ignore admin route, ie route containing 'admin'
 
         cache_invalidation:
             service:  sonata.page.cache.invalidation.simple

--- a/Resources/doc/reference/advanced_usage.rst
+++ b/Resources/doc/reference/advanced_usage.rst
@@ -23,7 +23,7 @@ tweak this behavior by ignoring patterns :
             - sonata_page_js_cache
 
         ignore_uri_patterns:
-            - ^/admin(.*)     # ignore admin route, ie route containing 'admin'
+            - ^/admin\/     # ignore admin route, ie route containing 'admin'
 
 Page defaults options
 ---------------------

--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -130,7 +130,7 @@ configuration file.
             - sonata_cache_apc
 
         ignore_uri_patterns:
-            - ^/admin(.*)   # ignore admin route, ie route containing 'admin'
+            - ^/admin\/   # ignore admin route, ie route containing 'admin'
 
         page_defaults:
             homepage: {decorate: false} # disable decoration for homepage, key - is a page route


### PR DESCRIPTION
We have a french URI which contains the "administration" term.

A 404 error is returned by the DecoratorStrategy because the regular expression in the configuration file was `^/admin(.*)` and matching with our "administration" term.

This is a documentation update to match a new correct route : `^/admin\/`.
