### PR TITLE
Fixed path to bootstrap.css in base_error.html.twig

### DIFF
--- a/Resources/views/base_error.html.twig
+++ b/Resources/views/base_error.html.twig
@@ -15,7 +15,7 @@ file that was distributed with this source code.
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 
         {% block page_stylesheets %}
-            <link rel="stylesheet" href="{{ asset('bundles/sonataadmin/bootstrap/bootstrap.css') }}" type="text/css" media="all" >
+            <link rel="stylesheet" href="{{ asset('bundles/sonataadmin/bootstrap/css/bootstrap.css') }}" type="text/css" media="all" >
             <link rel="stylesheet" href="{{ asset('bundles/sonatapage/default.css') }}" type="text/css" media="all" >
         {% endblock %}
 


### PR DESCRIPTION
Fixed path to bootstrap.css
