### PR TITLE
CmsPageRouter fix

### DIFF
--- a/Route/CmsPageRouter.php
+++ b/Route/CmsPageRouter.php
@@ -135,8 +135,8 @@ class CmsPageRouter implements ChainedRouterInterface
      */
     public function getRouteDebugMessage($name, array $parameters = array())
     {
-        if ($this->generator instanceof VersatileGeneratorInterface) {
-            return $this->generator->getRouteDebugMessage($name, $parameters);
+        if ($this->router instanceof VersatileGeneratorInterface) {
+            return $this->router->getRouteDebugMessage($name, $parameters);
         }
 
         return "Route '$name' not found";


### PR DESCRIPTION
fix to add getRouteDebugMessage a required method from VersatileGeneratorInterface
