### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,14 +22,14 @@
         "sonata-project/doctrine-extensions" : "1.*",
         "sonata-project/cache-bundle": "2.1.*",
         "symfony-cmf/routing-extra-bundle": "1.0.*@dev",
-        "symfony-cmf/routing": "1.0.*@dev"
+        "symfony-cmf/routing": "1.0.*@dev",
+        "sonata-project/notification-bundle": "2.1.*"
     },
     "require-dev": {
         "sonata-project/doctrine-orm-admin-bundle": "2.2.*@dev"
     },
     "suggest": {
-        "sonata-project/doctrine-orm-admin-bundle": "2.2.*@dev",
-        "sonata-project/notification-bundle": "2.1.*"
+        "sonata-project/doctrine-orm-admin-bundle": "2.2.*@dev"
     },
     "autoload": {
         "psr-0": { "Sonata\\PageBundle": "" }


### PR DESCRIPTION
sonata-project/notification-bundle is a requirement because the service "sonata.page.notification.create_snapshots" has a dependency on a service "sonata.notification.backend"
