### PR TITLE
forms deprecated bindRequest() is removed, just use bind()

### DIFF
--- a/Controller/SnapshotAdminController.php
+++ b/Controller/SnapshotAdminController.php
@@ -53,7 +53,7 @@ class SnapshotAdminController extends Controller
 
         if ($this->getRequest()->getMethod() == 'POST') {
 
-            $form->bindRequest($this->getRequest());
+            $form->bind($this->getRequest());
 
             if ($form->isValid()) {
                 $snapshotManager = $this->get('sonata.page.manager.snapshot');


### PR DESCRIPTION
forms deprecated bindRequest() is removed, just use bind()

https://github.com/symfony/symfony/commit/b3081e85a062abb8fc8a22f20a2b3289db2ff501
