### PR TITLE
Using twig formatter for blog posts fails

### DIFF
--- a/Site/BaseSiteSelector.php
+++ b/Site/BaseSiteSelector.php
@@ -124,13 +124,13 @@ abstract class BaseSiteSelector implements SiteSelectorInterface
      */
     final public function onKernelRequest(GetResponseEvent $event)
     {
-        if (!$this->decoratorStrategy->isRouteUriDecorable($event->getRequest()->getPathInfo())) {
-            return;
-        }
-
         $this->setRequest($event->getRequest());
 
         $this->handleKernelRequest($event);
+        
+        if (!$this->decoratorStrategy->isRouteUriDecorable($event->getRequest()->getPathInfo())) {
+            return;
+        }
 
         if ($this->site) {
             if ($this->site->getTitle()) {


### PR DESCRIPTION
Using twig formatter and trying to use {{ path('some_path_name_here') }} fails, because the current site cannot be determined. Null is returned which triggers an error, because implementation is expected.

The error is invoked at Sonata\PageBundle\Route\CmsPageRouter:getPageByPageAlias() on line 287.
