### PR TITLE
Fix documentation for multisite with host and path

### DIFF
--- a/Resources/doc/reference/multisite.rst
+++ b/Resources/doc/reference/multisite.rst
@@ -67,7 +67,7 @@ The last action is to configure the ``sonata_page`` section as:
 .. code-block:: yaml
 
     sonata_page:
-        multisite: host_with_site
+        multisite: host_with_path
         [...]
 
 And that's it!


### PR DESCRIPTION
Checking the code it looks like the value of `multisite` has to be `host_with_path` and not `host_with_site`.

https://github.com/sonata-project/SonataPageBundle/blob/master/DependencyInjection/SonataPageExtension.php#L328
