### PR TITLE
Fix Response Service Priority

### DIFF
--- a/Resources/config/page.xml
+++ b/Resources/config/page.xml
@@ -40,7 +40,7 @@
         </service>
 
         <service id="sonata.page.response_listener" class="%sonata.page.response_listener.class%" scope="request">
-            <tag name="kernel.event_listener" event="kernel.response" method="onCoreResponse" priority="-1"/>
+            <tag name="kernel.event_listener" event="kernel.response" method="onCoreResponse" priority="1"/>
 
             <argument type="service" id="sonata.page.cms_manager_selector" />
             <argument type="service" id="sonata.page.page_service_manager" />


### PR DESCRIPTION
In Twig, {{ render(controler() }} wasn't work because the SonataPage response listener was executed after the FragmentHandler Response listener (it destroy his backup of the request).

With this priority Sonata Response is executed before FragmentHandler Response listener and the request is still available for the render function.

Signed-off-by: dsoriano infos@teknipc.com
