### PR TITLE
Fixing cleanup snapshots command on some MySQL versions

### DIFF
--- a/Entity/SnapshotManager.php
+++ b/Entity/SnapshotManager.php
@@ -271,8 +271,8 @@ class SnapshotManager implements SnapshotManagerInterface
                         FROM %s
                         WHERE page_id = %d
                         ORDER BY publication_date_end DESC
-                    )
-                    %s
+                        %s
+                    ) AS table_alias
             )',
             $tableName,
             $page->getId(),


### PR DESCRIPTION
Was failing on mysql  Ver 14.14 Distrib 5.5.32, for Linux (x86_64) using readline 5.1
