### PR TITLE
fix exception error when editing internal pages:

### DIFF
--- a/Admin/PageAdmin.php
+++ b/Admin/PageAdmin.php
@@ -241,7 +241,7 @@ class PageAdmin extends Admin
             array('uri' => $admin->generateUrl('sonata.page.admin.snapshot.list', array('id' => $id)))
         );
 
-        if (!$this->getSubject()->isHybrid()) {
+        if (!$this->getSubject()->isHybrid() && !$this->getSubject()->isInternal()) {
 
             try {
                 $menu->addChild(


### PR DESCRIPTION
An exception has been thrown during the rendering of a template ("Please provide a `path` parameters") in "SonataAdminBundle:CRUD:edit.html.twig".
