### PR TITLE
Fix support for host_with_path sites

### DIFF
--- a/Entity/PageManager.php
+++ b/Entity/PageManager.php
@@ -118,7 +118,11 @@ class PageManager implements PageManagerInterface
             } else {
                 // a parent page does not have any slug - can have a custom url ...
                 $page->setSlug(null);
-                $page->setUrl('/'.$page->getSlug());
+                $urlPrefix = '/';
+                if($page->getSite()->getRelativePath()){
+                    $urlPrefix = $page->getSite()->getRelativePath() . '/';
+                }
+                $page->setUrl($urlPrefix.$page->getSlug());
             }
         }
 


### PR DESCRIPTION
Creating pages for host with path sites was creating the route at the domain root rather than domain-root/relativePath

See issue discussion here:

https://groups.google.com/forum/#!topic/sonata-devs/E9k0F45LePs%5B1-25-false%5D