### PR TITLE
Fixed invalid entities in PageBundle ("inversedBy" parameter set to null)

### DIFF
--- a/DependencyInjection/SonataPageExtension.php
+++ b/DependencyInjection/SonataPageExtension.php
@@ -186,7 +186,7 @@ class SonataPageExtension extends Extension
                  'persist',
             ),
             'mappedBy'      => null,
-            'inversedBy'    => null,
+            'inversedBy'    => 'children',
             'joinColumns'   => array(
                 array(
                     'name'  => 'parent_id',
@@ -212,7 +212,7 @@ class SonataPageExtension extends Extension
                 'persist',
             ),
             'mappedBy' => null,
-            'inversedBy' => null,
+            'inversedBy' => 'sources',
             'joinColumns' => array(
                 array(
                     'name' => 'target_id',
@@ -243,7 +243,7 @@ class SonataPageExtension extends Extension
             'cascade' => array(
             ),
             'mappedBy' => null,
-            'inversedBy' => null,
+            'inversedBy' => 'children',
             'joinColumns' => array(
                 array(
                     'name' => 'parent_id',
@@ -261,7 +261,7 @@ class SonataPageExtension extends Extension
                 'persist',
             ),
             'mappedBy' => null,
-            'inversedBy' => null,
+            'inversedBy' => 'blocks',
             'joinColumns' => array(
                 array(
                     'name' => 'page_id',


### PR DESCRIPTION
Fix for alerts (on the Symfony profiler toolbar) about invalid entities in SonataPageBundle. The given messages are :

Application\Sonata\PageBundle\Entity\Page :
The field Application\Sonata\PageBundle\Entity\Page#children is on the inverse side of a bi-directional relationship, but the specified mappedBy association on the target-entity Application\Sonata\PageBundle\Entity\Page#parent does not contain the required 'inversedBy=children' attribute.
The field Application\Sonata\PageBundle\Entity\Page#blocks is on the inverse side of a bi-directional relationship, but the specified mappedBy association on the target-entity Application\Sonata\PageBundle\Entity\Block#page does not contain the required 'inversedBy=blocks' attribute.
The field Application\Sonata\PageBundle\Entity\Page#sources is on the inverse side of a bi-directional relationship, but the specified mappedBy association on the target-entity Application\Sonata\PageBundle\Entity\Page#target does not contain the required 'inversedBy=sources' attribute.
Application\Sonata\PageBundle\Entity\Block : 
The field Application\Sonata\PageBundle\Entity\Block#children is on the inverse side of a bi-directional relationship, but the specified mappedBy association on the target-entity Application\Sonata\PageBundle\Entity\Block#parent does not contain the required 'inversedBy=children' attribute.
