### PR TITLE
Fix navigation layout to be fully expanded

### DIFF
--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -18,7 +18,7 @@ file that was distributed with this source code.
                     {{ sonata_page_render_container('title', 'global') }}
                 </div>
 
-                <div class="span6 navigation pull-right">
+                <div class="span8 navigation pull-right">
                     {{ sonata_page_render_container('header', 'global') }}
                 </div>
 


### PR DESCRIPTION
Fluid grid can has 12 elements (see http://getbootstrap.com/2.3.2/scaffolding.html#fluidGridSystem).

I've replaced the span4 + span6 to span4 + span8.

This will also help us to have larger labels in sandbox menu.
