### PR TITLE
cast page_id to integer because OptionsResolver raises exceptions on strings

### DIFF
--- a/Twig/Extension/PageExtension.php
+++ b/Twig/Extension/PageExtension.php
@@ -249,7 +249,7 @@ class PageExtension extends \Twig_Extension
         // defined extra default key for the cache
         $pageCacheKeys = array(
             'manager'   => $block->getPage() instanceof SnapshotPageProxy ? 'snapshot' : 'page',
-            'page_id'   => $block->getPage()->getId(),
+            'page_id'   => (int)$block->getPage()->getId(),
         );
 
         // build the parameters array


### PR DESCRIPTION
`The option "page_id" with value "30" is expected to be of type "int", "bool"` in Sonata/BlockBundle/Block/BlockContextManager.php at line 113.
