### PR TITLE
Add bootstrap library as needed for ecommerce frontend modals

### DIFF
--- a/Resources/views/base_layout.html.twig
+++ b/Resources/views/base_layout.html.twig
@@ -38,9 +38,7 @@ file that was distributed with this source code.
                 {% endblock %}
             {% endblock %}
 
-            {% if sonata_page.isEditor or (app.security and app.security.token and is_granted('ROLE_PREVIOUS_ADMIN')) %}
-                <script src="{{ asset('bundles/sonataadmin/bootstrap/js/bootstrap.min.js') }}" type="text/javascript"></script>
-            {% endif %}
+            <script src="{{ asset('bundles/sonataadmin/bootstrap/js/bootstrap.min.js') }}" type="text/javascript"></script>
         </head>
     {% endblock %}
 


### PR DESCRIPTION
On e-commerce, we will need to use this library for modals (on product page when clicking on "add to basket" for example and maybe on other templates)
