### PR TITLE
SONATA-322 - Enable modal for page enabled, decorate & edited fields

### DIFF
--- a/Admin/PageAdmin.php
+++ b/Admin/PageAdmin.php
@@ -81,9 +81,18 @@ class PageAdmin extends Admin
             ->add('type')
             ->add('pageAlias')
             ->add('site')
-            ->add('decorate', null, array('editable' => true))
-            ->add('enabled', null, array('editable' => true))
-            ->add('edited', null, array('editable' => true))
+            ->add('decorate', null, array(
+                'editable'     => true,
+                'confirmation' => true,
+            ))
+            ->add('enabled', null, array(
+                'editable'     => true,
+                'confirmation' => true,
+            ))
+            ->add('edited', null, array(
+                'editable'     => true,
+                'confirmation' => true,
+            ))
         ;
     }
 


### PR DESCRIPTION
Added confirmation modal for page `enabled`, `edited` and `decorate` fields in administration list template.

Merge or the following PR is needed before: sonata-project/SonataAdminBundle#1873
