### PR TITLE
Fix documentation and move contextual cache into SonataCacheBundle

### DIFF
--- a/Resources/doc/reference/advanced_usage.rst
+++ b/Resources/doc/reference/advanced_usage.rst
@@ -38,18 +38,3 @@ core routes):
     sonata_page:
         page_defaults:
             homepage: {decorate: false} # disable decoration for homepage route_name
-
-
-Contextual Cache
-----------------
-
-You can configure the ``Twig Recorder`` with the following configuration:
-
-.. code-block:: yaml
-
-    twig:
-        base_template_class: Sonata\PageBundle\Twig\TwigTemplate13
-        base_template_class: Sonata\PageBundle\Twig\TwigTemplate14
-
-
-// todo add more information

--- a/Resources/doc/reference/twig_helpers.rst
+++ b/Resources/doc/reference/twig_helpers.rst
@@ -43,3 +43,9 @@ Render a container using a page instance
 .. code-block:: jinja
 
     {{ sonata_page_render_container('name', page) }}
+
+Optionally, you can pass as a third argument some settings that will override original container settings:
+
+.. code-block:: jinja
+
+    {{ sonata_page_render_container('name', page, {key: value}) }}


### PR DESCRIPTION
I've added some doc and moved the `Contextual cache` part to `SonataCacheBundle` as it has been moved from `SonataPageBundle` to `SonataCacheBundle` in the very first commit of `SonataCacheBundle` (here: https://github.com/sonata-project/SonataCacheBundle/commit/fdf568fd07af0d1252a40e0079300dfdfbd905d9).
