### PR TITLE
Add new RoutePageGenerator service

### DIFF
--- a/Admin/SiteAdmin.php
+++ b/Admin/SiteAdmin.php
@@ -18,6 +18,8 @@ use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 
+use Sonata\PageBundle\Route\RoutePageGenerator;
+
 /**
  * Admin definition for the Site class
  *
@@ -25,7 +27,25 @@ use Sonata\AdminBundle\Datagrid\DatagridMapper;
  */
 class SiteAdmin extends Admin
 {
-    protected $cmsManager;
+    /**
+     * @var RoutePageGenerator
+     */
+    protected $routePageGenerator;
+
+    /**
+     * Constructor
+     *
+     * @param string             $code               A Sonata admin code
+     * @param string             $class              A Sonata admin class name
+     * @param string             $baseControllerName A Sonata admin base controller name
+     * @param RoutePageGenerator $routePageGenerator Sonata route page generator service
+     */
+    public function __construct($code, $class, $baseControllerName, RoutePageGenerator $routePageGenerator)
+    {
+        $this->routePageGenerator = $routePageGenerator;
+
+        parent::__construct($code, $class, $baseControllerName);
+    }
 
     /**
      * {@inheritdoc}
@@ -107,5 +127,13 @@ class SiteAdmin extends Admin
     protected function configureRoutes(RouteCollection $collection)
     {
         $collection->add('snapshots', $this->getRouterIdParameter().'/snapshots');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function postPersist($object)
+    {
+        $this->routePageGenerator->update($object);
     }
 }

--- a/Resources/config/admin.xml
+++ b/Resources/config/admin.xml
@@ -96,6 +96,7 @@
             <argument />
             <argument>%sonata.page.admin.site.entity%</argument>
             <argument>%sonata.page.admin.site.controller%</argument>
+            <argument type="service" id="sonata.page.route.page.generator" />
 
             <call method="setTranslationDomain">
                 <argument>%sonata.page.admin.site.translation_domain%</argument>

--- a/Resources/config/page.xml
+++ b/Resources/config/page.xml
@@ -13,6 +13,7 @@
         <parameter key="sonata.page.site.selector.host.class"           >Sonata\PageBundle\Site\HostSiteSelector</parameter>
         <parameter key="sonata.page.site.selector.host_with_path.class" >Sonata\PageBundle\Site\HostPathSiteSelector</parameter>
         <parameter key="sonata.page.router.class"                       >Sonata\PageBundle\Route\CmsPageRouter</parameter>
+        <parameter key="sonata.page.route.page.generator.class"         >Sonata\PageBundle\Route\RoutePageGenerator</parameter>
         <parameter key="sonata.page.service.manager.class"              >Sonata\PageBundle\Page\PageServiceManager</parameter>
         <parameter key="sonata.page.template.manager.class"             >Sonata\PageBundle\Page\TemplateManager</parameter>
         <parameter key="sonata.page.service.default.class"              >Sonata\PageBundle\Page\Service\DefaultPageService</parameter>
@@ -87,6 +88,13 @@
             <argument type="service" id="sonata.page.cms_manager_selector" />
             <argument type="service" id="sonata.page.site.selector"/>
             <argument type='service' id="router.default"/>
+        </service>
+
+        <service id="sonata.page.route.page.generator" class="%sonata.page.route.page.generator.class%">
+            <argument type='service' id="router.default" />
+            <argument type="service" id="sonata.page.manager.page" />
+            <argument type="service" id="sonata.page.decorator_strategy" />
+            <argument type="service" id="sonata.page.kernel.exception_listener" />
         </service>
 
         <service id="sonata.page.template_manager" class="%sonata.page.template.manager.class%">

--- a/Route/RoutePageGenerator.php
+++ b/Route/RoutePageGenerator.php
@@ -1,0 +1,201 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\PageBundle\Route;
+
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Routing\RouterInterface;
+use Sonata\PageBundle\CmsManager\CmsPageManager;
+use Sonata\PageBundle\CmsManager\DecoratorStrategyInterface;
+use Sonata\PageBundle\Listener\ExceptionListener;
+use Sonata\PageBundle\Model\PageManagerInterface;
+use Sonata\PageBundle\Model\SiteInterface;
+
+/**
+ * This is the page generator service from existing routes
+ *
+ * @author Vincent Composieux <vincent.composieux@gmail.com>
+ */
+class RoutePageGenerator
+{
+    /**
+     * @var RouterInterface
+     */
+    protected $router;
+
+    /**
+     * @var PageManagerInterface
+     */
+    protected $pageManager;
+
+    /**
+     * @var DecoratorStrategyInterface
+     */
+    protected $decoratorStrategy;
+
+    /**
+     * @var ExceptionListener
+     */
+    protected $exceptionListener;
+
+    /**
+     * Constructor
+     *
+     * @param RouterInterface            $router            A Symfony router service
+     * @param PageManagerInterface       $pageManager       A Sonata Page manager
+     * @param DecoratorStrategyInterface $decoratorStrategy A Sonata page decorator strategy service
+     * @param ExceptionListener          $exceptionListener A Sonata page bundle exception listener
+     */
+    public function __construct(RouterInterface $router, PageManagerInterface $pageManager, DecoratorStrategyInterface $decoratorStrategy, ExceptionListener $exceptionListener)
+    {
+        $this->router            = $router;
+        $this->pageManager       = $pageManager;
+        $this->decoratorStrategy = $decoratorStrategy;
+        $this->exceptionListener = $exceptionListener;
+    }
+
+    /**
+     * Updates site page routes with all routes available in Symfony router service
+     *
+     * @param SiteInterface   $site   A page bundle site instance
+     * @param OutputInterface $output A Symfony console output
+     *
+     * @return void
+     */
+    public function update(SiteInterface $site, OutputInterface $output = null)
+    {
+        $message = sprintf(" > <info>Updating core routes for site</info> : <comment>%s - %s</comment>", $site->getName(), $site->getUrl());
+
+        $this->writeln($output, array(
+            str_repeat('=', strlen($message)),
+            "",
+            $message,
+            "",
+            str_repeat('=', strlen($message)),
+        ));
+
+        $knowRoutes = array();
+
+        // Iterate over declared routes from the routing mechanism
+        foreach ($this->router->getRouteCollection()->all() as $name => $route) {
+            $name = trim($name);
+
+            $knowRoutes[] = $name;
+
+            $page = $this->pageManager->findOneBy(array(
+                'routeName' => $name,
+                'site'      => $site->getId()
+            ));
+
+            if (!$this->decoratorStrategy->isRouteNameDecorable($name) || !$this->decoratorStrategy->isRouteUriDecorable($route->getPattern())) {
+                if ($page) {
+                    $page->setEnabled(false);
+
+                    $this->writeln($output, sprintf('  <error>DISABLE</error> <error>% -50s</error> %s', $name, $route->getPattern()));
+                } else {
+                    continue;
+                }
+            }
+
+            $update = true;
+
+            if (!$page) {
+                $update = false;
+
+                $requirements = $route->getRequirements();
+
+                $page = $this->pageManager->create(array(
+                    'routeName'     => $name,
+                    'name'          => $name,
+                    'url'           => $route->getPattern(),
+                    'site'          => $site,
+                    'requestMethod' => isset($requirements['_method']) ? $requirements['_method'] : 'GET|POST|HEAD|DELETE|PUT',
+                ));
+            }
+
+            $page->setSlug($route->getPattern());
+            $page->setUrl($route->getPattern());
+            $page->setRequestMethod(isset($requirements['_method']) ? $requirements['_method'] : 'GET|POST|HEAD|DELETE|PUT');
+
+            $this->pageManager->save($page);
+
+            $this->writeln($output, sprintf('  <info>%s</info> % -50s %s', $update ? 'UPDATE ' : 'CREATE ', $name, $route->getPattern()));
+        }
+
+        // Iterate over error pages
+        foreach ($this->exceptionListener->getHttpErrorCodes() as $name) {
+            $name = trim($name);
+
+            $knowRoutes[] = $name;
+
+            $page = $this->pageManager->findOneBy(array(
+                'routeName' => $name,
+                'site'      => $site->getId()
+            ));
+
+            if (!$page) {
+                $params = array(
+                    'routeName' => $name,
+                    'name'      => $name,
+                    'decorate'  => false,
+                    'site'      => $site,
+                );
+
+                $page = $this->pageManager->create($params);
+
+                $this->pageManager->save($page);
+
+                $this->writeln($output, sprintf('  <info>%s</info> % -50s %s', 'CREATE ', $name, ''));
+            }
+        }
+
+        $has = false;
+
+        foreach ($this->pageManager->getHybridPages($site) as $page) {
+            if (!$page->isHybrid() || $page->isInternal()) {
+                continue;
+            }
+
+            if (!in_array($page->getRouteName(), $knowRoutes)) {
+                if (!$has) {
+                    $has = true;
+
+                    $this->writeln($output, array('', 'Some hybrid pages does not exist anymore', str_repeat('-', 80)));
+                }
+
+                $this->writeln($output, sprintf('  <error>ERROR</error>   %s', $page->getRouteName()));
+            }
+        }
+
+        if ($has) {
+            $this->writeln($output, <<<MSG
+<error>
+  *WARNING* : Pages has been updated however some pages do not exist anymore.
+              You must remove them manually.
+</error>
+MSG
+            );
+        }
+    }
+
+    /**
+     * Output a Symfony console message with writeln() function
+     *
+     * @param OutputInterface $output  A Symfony console output instance
+     * @param string          $message A string message to output
+     */
+    protected function writeln(OutputInterface $output = null, $message)
+    {
+        if ($output instanceof OutputInterface) {
+            $output->writeln($message);
+        }
+    }
+}

--- a/Tests/Route/RoutePageGeneratorTest.php
+++ b/Tests/Route/RoutePageGeneratorTest.php
@@ -1,0 +1,120 @@
+<?php
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\PageBundle\Tests\Route;
+
+use Sonata\PageBundle\CmsManager\DecoratorStrategy;
+use Sonata\PageBundle\Tests\Model\Page;
+use Sonata\PageBundle\Route\RoutePageGenerator;
+
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Output\StreamOutput;
+use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Test RoutePageGenerator service
+ *
+ * @author Vincent Composieux <vincent.composieux@gmail.com>
+ */
+class RoutePageGeneratorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var RoutePageGenerator
+     */
+    protected $routePageGenerator;
+
+    /**
+     * Set up dependencies
+     */
+    public function setUp()
+    {
+        $this->routePageGenerator = $this->getRoutePageGenerator();
+    }
+
+    /**
+     * Tests site update route method with
+     */
+    public function testUpdateRoutes()
+    {
+        $site = $this->getMock('Sonata\PageBundle\Model\SiteInterface');
+
+        $tmpFile = tmpfile();
+
+        $this->routePageGenerator->update($site, new StreamOutput($tmpFile));
+
+        fseek($tmpFile, 0);
+
+        $output = '';
+
+        while (!feof($tmpFile)) {
+            $output = fread($tmpFile, 4096);
+        }
+
+        $this->assertRegExp('/CREATE(.*)route1(.*)\/first_custom_route/', $output);
+        $this->assertRegExp('/CREATE(.*)route1(.*)\/first_custom_route/', $output);
+        $this->assertRegExp('/CREATE(.*)404/', $output);
+        $this->assertRegExp('/CREATE(.*)500/', $output);
+
+        $this->assertRegExp('/ERROR(.*)test_hybrid_page_not_exists/', $output);
+    }
+
+    /**
+     * Returns a mock of Symfony router
+     *
+     * @return \Symfony\Component\Routing\Router
+     */
+    protected function getRouterMock()
+    {
+        $collection = new RouteCollection();
+        $collection->add('route1', new Route('first_custom_route'));
+        $collection->add('route2', new Route('second_custom_route'));
+
+        $router = $this->getMockBuilder('Symfony\Component\Routing\Router')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $router->expects($this->any())->method('getRouteCollection')->will($this->returnValue($collection));
+
+        return $router;
+    }
+
+    /**
+     * Returns Sonata route page generator service
+     *
+     * @return RoutePageGenerator
+     */
+    protected function getRoutePageGenerator()
+    {
+        $router = $this->getRouterMock();
+
+        $pageManager = $this->getMockBuilder('Sonata\PageBundle\Entity\PageManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $pageManager->expects($this->any())->method('create')->will($this->returnValue(new Page()));
+
+        $hybridPage= new Page();
+        $hybridPage->setRouteName('test_hybrid_page_not_exists');
+
+        $pageManager->expects($this->any())->method('getHybridPages')->will($this->returnValue(array($hybridPage)));
+
+        $decoratorStrategy = new DecoratorStrategy(array(), array(), array());
+
+        $exceptionListener = $this->getMockBuilder('Sonata\PageBundle\Listener\ExceptionListener')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $exceptionListener->expects($this->any())->method('getHttpErrorCodes')->will($this->returnValue(array(404, 500)));
+
+        return new RoutePageGenerator($router, $pageManager, $decoratorStrategy, $exceptionListener);
+    }
+}


### PR DESCRIPTION
I've moved `sonata:page:update-core-routes` logic into a dedicated service: `RoutePageGenerator`.

I've also added a `postPersist()` method in the `SiteAdmin` class in order to generate routes on new site creation.

This is related to issue https://github.com/sonata-project/SonataPageBundle/issues/265
