### PR TITLE
Allow sonata_page_render_block() to create blocks on-the-fly

### DIFF
--- a/Block/BlockContextManager.php
+++ b/Block/BlockContextManager.php
@@ -26,8 +26,11 @@ class BlockContextManager extends BaseBlockContextManager
         parent::setDefaultSettings($optionsResolver, $block);
 
         $optionsResolver->setDefaults(array(
-            'manager' => false,
-            'page_id' => false,
+            'container' => null,
+            'type'      => null,
+            'settings'  => array(),
+            'manager'   => false,
+            'page_id'   => false,
         ));
 
         $optionsResolver->addAllowedTypes(array(

--- a/Entity/BlockInteractor.php
+++ b/Entity/BlockInteractor.php
@@ -12,6 +12,7 @@ namespace Sonata\PageBundle\Entity;
 
 use Symfony\Bridge\Doctrine\RegistryInterface;
 
+use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\BlockBundle\Model\BlockManagerInterface;
 use Sonata\PageBundle\Model\BlockInteractorInterface;
 use Sonata\PageBundle\Model\PageInterface;
@@ -131,6 +132,36 @@ class BlockInteractor implements BlockInteractorInterface
         $this->blockManager->save($container);
 
         return $container;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createNewBlock($name, BlockInterface $container, array $options = array(), \Closure $alter = null)
+    {
+        if (!isset($options['type']) || !isset($options['page'])) {
+            throw new \RuntimeException('Block "type" and "page" options must be defined');
+        }
+
+        $block = $this->blockManager->create();
+        $block->setParent($container);
+        $block->setType($options['type']);
+        $block->setPage($options['page']);
+        $block->setCreatedAt(new \DateTime());
+        $block->setUpdatedAt(new \DateTime());
+        $block->setEnabled(isset($options['enabled']) ? $options['enabled'] : true);
+
+        $block->setName($name);
+        $block->setSettings(isset($options['settings']) ? $options['settings'] : array());
+        $block->setPosition(isset($options['position']) ? $options['position'] : 1);
+
+        if ($alter) {
+            $alter($block);
+        }
+
+        $this->blockManager->save($block);
+
+        return $block;
     }
 
     /**

--- a/Model/BlockInteractorInterface.php
+++ b/Model/BlockInteractorInterface.php
@@ -10,6 +10,8 @@
 
 namespace Sonata\PageBundle\Model;
 
+use Sonata\BlockBundle\Model\BlockInterface;
+
 /**
  * BlockInteractorInterface
  *
@@ -60,4 +62,16 @@ interface BlockInteractorInterface
      * @return \Sonata\BlockBundle\Model\BlockInterface
      */
     public function createNewContainer(array $values = array(), \Closure $alter = null);
+
+    /**
+     * Creates a new page block
+     *
+     * @param string         $name      A block name
+     * @param array          $options   An array of options for block creation
+     * @param BlockInterface $container A container block
+     * @param \Closure       $alter     A closure to alter container created
+     *
+     * @return \Sonata\BlockBundle\Model\BlockInterface
+     */
+    public function createNewBlock($name, BlockInterface $container, array $options = array(), \Closure $alter = null);
 }

--- a/Resources/config/twig.xml
+++ b/Resources/config/twig.xml
@@ -12,6 +12,8 @@
             <argument type="service" id="sonata.page.site.selector" />
             <argument type="service" id="router" />
             <argument type="service" id="sonata.block.templating.helper" />
+            <argument type="service" id="sonata.page.manager.block" />
+            <argument type="service" id="sonata.page.block_interactor" />
             <argument type="service" id="twig.extension.httpkernel" />
         </service>
 

--- a/Resources/doc/reference/twig_helpers.rst
+++ b/Resources/doc/reference/twig_helpers.rst
@@ -49,3 +49,25 @@ Optionally, you can pass as a third argument some settings that will override or
 .. code-block:: jinja
 
     {{ sonata_page_render_container('name', page, {key: value}) }}
+
+
+Block
+-----
+
+You can also render an existing block using this function by sending a block object instance:
+
+.. code-block:: jinja
+
+    {{ sonata_page_render_block(block, {key: value}) }}
+
+Or even create a on-the-fly block in a Twig template this way:
+
+.. code-block:: jinja
+
+    {{ sonata_page_render_block('my.template.text.block', {
+        type: 'sonata.block.service.text',
+        container: 'content_top',
+        settings: { content: 'Hi! this is my text content' }
+    }) }}
+
+This way, a ``sonata.block.service.text`` block will be added to your ``content_top`` container with the following settings given.

--- a/Tests/Model/Block.php
+++ b/Tests/Model/Block.php
@@ -1,0 +1,29 @@
+<?php
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\PageBundle\Tests\Model;
+
+/**
+ * This is a test Block instance for PageBundle model
+ */
+class Block extends \Sonata\PageBundle\Model\Block
+{
+    protected $id;
+
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+}

--- a/Tests/Model/BlockInteractorTest.php
+++ b/Tests/Model/BlockInteractorTest.php
@@ -12,9 +12,9 @@ namespace Sonata\PageBundle\Tests\Entity;
 
 use Symfony\Bundle\DoctrineBundle\Registry;
 
-use Sonata\BlockBundle\Model\Block;
 use Sonata\BlockBundle\Model\BlockManagerInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\PageBundle\Tests\Model\Block;
 use Sonata\PageBundle\Entity\BlockInteractor;
 
 /**
@@ -52,6 +52,45 @@ class BlockInteractorTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($container->getEnabled());
 
         $this->assertEquals('my-code', $settings['code']);
+        $this->assertEquals('<div class="custom-layout">{{ CONTENT }}</div>', $settings['layout']);
+    }
+
+    /**
+     * Test createNewBlock() method with some values
+     */
+    public function testCreateNewBlock()
+    {
+        $registry = $this->getMockBuilder('Symfony\Bridge\Doctrine\RegistryInterface')->disableOriginalConstructor()->getMock();
+
+        $blockManager = $this->getMock('Sonata\BlockBundle\Model\BlockManagerInterface');
+        $blockManager->expects($this->any())->method('create')->will($this->returnValue(new Block()));
+
+        $blockInteractor = new BlockInteractor($registry, $blockManager);
+
+        $container = new Block();
+        $container->setName('my.custom.container');
+        $container->setType('sonata.page.block.container');
+
+        $page = $this->getMock('Sonata\PageBundle\Model\PageInterface');
+
+        $block = $blockInteractor->createNewBlock('my.custom.text.block', $container, array(
+            'type' => 'sonata.block.service.text',
+            'page' => $page,
+        ), function ($container) {
+            $container->setSetting('layout', '<div class="custom-layout">{{ CONTENT }}</div>');
+        });
+
+        $this->assertInstanceOf('\Sonata\BlockBundle\Model\BlockInterface', $block);
+
+        $settings = $block->getSettings();
+
+        $this->assertTrue($block->getEnabled());
+
+        $this->assertEquals('my.custom.text.block', $block->getName());
+        $this->assertEquals('sonata.block.service.text', $block->getType());
+        $this->assertEquals($container, $block->getParent());
+        $this->assertEquals($page, $block->getPage());
+
         $this->assertEquals('<div class="custom-layout">{{ CONTENT }}</div>', $settings['layout']);
     }
 }

--- a/Tests/Twig/Extension/PageExtensionTest.php
+++ b/Tests/Twig/Extension/PageExtensionTest.php
@@ -10,15 +10,21 @@
 
 namespace Sonata\PageBundle\Tests\Twig\Extension;
 
+use Sonata\PageBundle\Tests\Model\Page;
 use Sonata\PageBundle\Twig\Extension\PageExtension;
 
 /**
- *
+ * This is the PageExtension test class
  */
 class PageExtensionTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * Test ajaxUrl() PageExtension method
+     */
     public function testAjaxUrl()
     {
+        $blockManager = $this->getMock('Sonata\BlockBundle\Model\BlockManagerInterface');
+        $blockInteractor = $this->getMock('Sonata\PageBundle\Model\BlockInteractorInterface');
         $cmsManager = $this->getMock('Sonata\PageBundle\CmsManager\CmsManagerSelectorInterface');
         $siteSelector = $this->getMock('Sonata\PageBundle\Site\SiteSelectorInterface');
         $router = $this->getMock('Symfony\Component\Routing\RouterInterface');
@@ -37,7 +43,7 @@ class PageExtensionTest extends \PHPUnit_Framework_TestCase
         $block = $this->getMock('Sonata\PageBundle\Model\PageBlockInterface');
         $block->expects($this->exactly(2))->method('getPage')->will($this->returnValue($page));
 
-        $extension = new PageExtension($cmsManager, $siteSelector, $router, $blockHelper, $HttpKernelExtension);
+        $extension = new PageExtension($cmsManager, $siteSelector, $router, $blockHelper, $blockManager, $blockInteractor, $HttpKernelExtension);
         $this->assertEquals('/foo/bar', $extension->ajaxUrl($block));
     }
 }


### PR DESCRIPTION
I've worked on the `sonata_page_render_block()` Twig function to allow creating blocks on-the-fly.

This idea is related from issue https://github.com/sonata-project/SonataPageBundle/issues/264

For example, here is the Twig code for creating a `sonata.block.service.text.block` block on-the-fly in the `content_top` container:

```yml
{{ sonata_page_render_block('my.template.text.block', {
    type: 'sonata.block.service.text',
    container: 'content_top',
    settings: { content: 'Hi! this is my text content' }
}) }}
```

Block is created once and so not created again on the next parse if it already exists.