### PR TITLE
Hamonize commands argument names base-console to base-command

### DIFF
--- a/Command/CleanupSnapshotsCommand.php
+++ b/Command/CleanupSnapshotsCommand.php
@@ -30,7 +30,8 @@ class CleanupSnapshotsCommand extends BaseCommand
         $this->setDescription('Cleanups the deprecated snapshots by a given site');
 
         $this->addOption('site', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Site id', null);
-        $this->addOption('base-console', null, InputOption::VALUE_OPTIONAL, 'Base Symfony console command', 'app/console');
+        $this->addOption('base-console', null, InputOption::VALUE_OPTIONAL, 'Base Symfony console command (deprecated, use base-command instead)', 'app/console');
+        $this->addOption('base-command', null, InputOption::VALUE_OPTIONAL, 'Base Symfony console command', 'app/console');
         $this->addOption('mode', null, InputOption::VALUE_OPTIONAL, 'Run the command asynchronously', 'sync');
         $this->addOption('keep-snapshots', null, InputOption::VALUE_OPTIONAL, 'Keep a given count of snapshots per page', 5);
     }
@@ -83,8 +84,10 @@ class CleanupSnapshotsCommand extends BaseCommand
 
                 $output->writeln(" done!");
             } else {
+                $baseCommand = 'app/console' != $input->getOption('base-console') ? $input->getOption('base-console') : $input->getOption('base-command');
+
                 $p = new Process(sprintf('%s sonata:page:cleanup-snapshots --env=%s --site=%s --mode=%s --keep-snapshots=%s %s',
-                    $input->getOption('base-console'),
+                    $baseCommand,
                     $input->getOption('env'),
                     $site->getId(),
                     $input->getOption('mode'),

--- a/Command/CreateSnapshotsCommand.php
+++ b/Command/CreateSnapshotsCommand.php
@@ -33,7 +33,8 @@ class CreateSnapshotsCommand extends BaseCommand
         $this->setName('sonata:page:create-snapshots');
         $this->setDescription('Create a snapshots of all pages available');
         $this->addOption('site', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Site id', null);
-        $this->addOption('base-console', null, InputOption::VALUE_OPTIONAL, 'Base symfony console command', 'php app/console');
+        $this->addOption('base-console', null, InputOption::VALUE_OPTIONAL, 'Base symfony console command (deprecated, use base-command instead)', 'php app/console');
+        $this->addOption('base-command', null, InputOption::VALUE_OPTIONAL, 'Base symfony console command', 'php app/console');
 
         $this->addOption('mode', null, InputOption::VALUE_OPTIONAL, 'Run the command asynchronously', 'sync');
     }
@@ -72,7 +73,9 @@ class CreateSnapshotsCommand extends BaseCommand
 
                 $output->writeln(" done!");
             } else {
-                $p = new Process(sprintf('%s sonata:page:create-snapshots --env=%s --site=%s --mode=%s %s ', $input->getOption('base-console'), $input->getOption('env'), $site->getId(), $input->getOption('mode'), $input->getOption('no-debug') ? '--no-debug' : ''));
+                $baseCommand = 'php app/console' != $input->getOption('base-console') ? $input->getOption('base-console') : $input->getOption('base-command');
+
+                $p = new Process(sprintf('%s sonata:page:create-snapshots --env=%s --site=%s --mode=%s %s ', $baseCommand, $input->getOption('env'), $site->getId(), $input->getOption('mode'), $input->getOption('no-debug') ? '--no-debug' : ''));
                 $p->setTimeout(0);
                 $p->run(function($type, $data) use ($output) {
                     $output->write($data, OutputInterface::OUTPUT_RAW);


### PR DESCRIPTION
I've harmonized commands using both `base-console` and `base-command` option to `base-command`.

This is related to issue https://github.com/sonata-project/SonataPageBundle/issues/271