### PR TITLE
Update layout for new header

### DIFF
--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -14,15 +14,7 @@ file that was distributed with this source code.
     <div class="container">
         <div class="content">
             <div class="row page-header">
-                <div class="col-sm-4">
-                    {{ sonata_page_render_container('title', 'global') }}
-                </div>
-
-                <div class="col-sm-8 navigation pull-right">
-                    {{ sonata_page_render_container('header', 'global') }}
-                </div>
-
-                <div style="clear: both"></div>
+                {{ sonata_page_render_container('header', 'global') }}
             </div>
 
             {% block sonata_page_breadcrumb %}


### PR DESCRIPTION
I've updated layout to only have a single header block to manage header information.

This is related to the following sandbox PR: https://github.com/sonata-project/sandbox/pull/290
