### PR TITLE
Refactor and add missing units tests for page & blocks APIs

### DIFF
--- a/Controller/Api/BlockController.php
+++ b/Controller/Api/BlockController.php
@@ -1,0 +1,179 @@
+<?php
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\PageBundle\Controller\Api;
+
+use FOS\RestBundle\Request\ParamFetcherInterface;
+use FOS\RestBundle\Controller\Annotations\QueryParam;
+use FOS\RestBundle\Controller\Annotations\View;
+use JMS\Serializer\SerializationContext;
+use Nelmio\ApiDocBundle\Annotation\ApiDoc;
+use Sonata\BlockBundle\Model\BlockManagerInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormFactoryInterface;
+use FOS\RestBundle\View\View as FOSRestView;
+use Sonata\BlockBundle\Model\BlockInterface;
+
+/**
+ * Class BlockController
+ *
+ * @author Vincent Composieux <vincent.composieux@gmail.com>
+ */
+class BlockController
+{
+    /**
+     * @var BlockManagerInterface
+     */
+    protected $blockManager;
+
+    /**
+     * @var FormFactoryInterface
+     */
+    protected $formFactory;
+
+    /**
+     * Constructor
+     *
+     * @param BlockManagerInterface $blockManager
+     * @param FormFactoryInterface  $formFactory
+     */
+    public function __construct(BlockManagerInterface $blockManager, FormFactoryInterface $formFactory)
+    {
+        $this->blockManager = $blockManager;
+        $this->formFactory  = $formFactory;
+    }
+
+    /**
+     * Retrieves a specific block
+     *
+     * @ApiDoc(
+     *  resource=true,
+     *  requirements={
+     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="block id"}
+     *  },
+     *  output={"class"="Sonata\PageBundle\Model\BlockInterface", "groups"="sonata_api_read"},
+     *  statusCodes={
+     *      200="Returned when successful",
+     *      404="Returned when page is not found"
+     *  }
+     * )
+     *
+     * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
+     *
+     * @param $id
+     *
+     * @return BlockInterface
+     */
+    public function getBlockAction($id)
+    {
+        return $this->getBlock($id);
+    }
+
+    /**
+     * Updates a block
+     *
+     * @ApiDoc(
+     *  requirements={
+     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="block identifier"},
+     *  },
+     *  input={"class"="sonata_page_api_form_block", "name"="", "groups"={"sonata_api_write"}},
+     *  output={"class"="Sonata\PageBundle\Model\Block", "groups"={"sonata_api_read"}},
+     *  statusCodes={
+     *      200="Returned when successful",
+     *      400="Returned when an error has occurred while block creation",
+     *      404="Returned when unable to find page"
+     *  }
+     * )
+     *
+     * @param int     $id      A Block identifier
+     * @param Request $request A Symfony request
+     *
+     * @return BlockInterface
+     *
+     * @throws NotFoundHttpException
+     */
+    public function putBlockAction($id, Request $request)
+    {
+        $block = $id ? $this->getBlock($id) : null;
+
+        $form = $this->formFactory->createNamed(null, 'sonata_page_api_form_block', $block, array(
+            'csrf_protection' => false
+        ));
+
+        $form->bind($request);
+
+        if ($form->isValid()) {
+            $block = $form->getData();
+
+            $this->blockManager->save($block);
+
+            $view = FOSRestView::create($block);
+            $serializationContext = SerializationContext::create();
+            $serializationContext->setGroups(array('sonata_api_read'));
+            $serializationContext->enableMaxDepthChecks();
+            $view->setSerializationContext($serializationContext);
+
+            return $view;
+        }
+
+        return $form;
+    }
+
+    /**
+     * Deletes a block
+     *
+     * @ApiDoc(
+     *  requirements={
+     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="block identifier"}
+     *  },
+     *  statusCodes={
+     *      200="Returned when block is successfully deleted",
+     *      400="Returned when an error has occured while block deletion",
+     *      404="Returned when unable to find block"
+     *  }
+     * )
+     *
+     * @param integer $id A Block identifier
+     *
+     * @return \FOS\RestBundle\View\View
+     *
+     * @throws NotFoundHttpException
+     */
+    public function deleteBlockAction($id)
+    {
+        $block = $this->getBlock($id);
+
+        $this->blockManager->delete($block);
+
+        return array('deleted' => true);
+    }
+
+    /**
+     * Retrieves Block with id $id or throws an exception if it doesn't exist
+     *
+     * @param $id
+     *
+     * @return BlockInterface
+     *
+     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     */
+    protected function getBlock($id)
+    {
+        $block = $this->blockManager->findOneBy(array('id' => $id));
+
+        if (null === $block) {
+            throw new NotFoundHttpException(sprintf('Block (%d) not found', $id));
+        }
+
+        return $block;
+    }
+}

--- a/Controller/Api/PageController.php
+++ b/Controller/Api/PageController.php
@@ -163,32 +163,8 @@ class PageController
      * Adds a block
      *
      * @ApiDoc(
-     *  input={"class"="sonata_page_api_form_block", "name"="", "groups"={"sonata_api_write"}},
-     *  output={"class"="Sonata\PageBundle\Model\Block", "groups"={"sonata_api_read"}},
-     *  statusCodes={
-     *      200="Returned when successful",
-     *      400="Returned when an error has occurred while block creation",
-     *      404="Returned when unable to find page"
-     *  }
-     * )
-     *
-     * @param Request $request A Symfony request
-     *
-     * @return BlockInterface
-     *
-     * @throws NotFoundHttpException
-     */
-    public function postPageBlockAction(Request $request)
-    {
-        return $this->handleWriteBlock($request);
-    }
-
-    /**
-     * Updates a block
-     *
-     * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="block identifier"}
+     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="page identifier"}
      *  },
      *  input={"class"="sonata_page_api_form_block", "name"="", "groups"={"sonata_api_write"}},
      *  output={"class"="Sonata\PageBundle\Model\Block", "groups"={"sonata_api_read"}},
@@ -199,45 +175,39 @@ class PageController
      *  }
      * )
      *
-     * @param int     $id      Block id
+     * @param integer $id      A Page identifier
      * @param Request $request A Symfony request
      *
      * @return BlockInterface
      *
      * @throws NotFoundHttpException
      */
-    public function putPageBlockAction($id, Request $request)
+    public function postPageBlockAction($id, Request $request)
     {
-        return $this->handleWriteBlock($request, $id);
-    }
+        $page = $id ? $this->getPage($id) : null;
 
-    /**
-     * Deletes a block
-     *
-     * @ApiDoc(
-     *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="block identifier"}
-     *  },
-     *  statusCodes={
-     *      200="Returned when block is successfully deleted",
-     *      400="Returned when an error has occured while block deletion",
-     *      404="Returned when unable to find block"
-     *  }
-     * )
-     *
-     * @param integer $id A Block identifier
-     *
-     * @return \FOS\RestBundle\View\View
-     *
-     * @throws NotFoundHttpException
-     */
-    public function deletePageBlockAction($id)
-    {
-        $block = $this->getBlock($id);
+        $form = $this->formFactory->createNamed(null, 'sonata_page_api_form_block', null, array(
+            'csrf_protection' => false
+        ));
 
-        $this->blockManager->delete($block);
+        $form->bind($request);
 
-        return array('deleted' => true);
+        if ($form->isValid()) {
+            $block = $form->getData();
+            $block->setPage($page);
+
+            $this->blockManager->save($block);
+
+            $view = FOSRestView::create($block);
+            $serializationContext = SerializationContext::create();
+            $serializationContext->setGroups(array('sonata_api_read'));
+            $serializationContext->enableMaxDepthChecks();
+            $view->setSerializationContext($serializationContext);
+
+            return $view;
+        }
+
+        return $form;
     }
 
     /**
@@ -414,40 +384,6 @@ class PageController
             $this->pageManager->save($page);
 
             $view = FOSRestView::create($page);
-            $serializationContext = SerializationContext::create();
-            $serializationContext->setGroups(array('sonata_api_read'));
-            $serializationContext->enableMaxDepthChecks();
-            $view->setSerializationContext($serializationContext);
-
-            return $view;
-        }
-
-        return $form;
-    }
-
-    /**
-     * Write a Block, this method is used by both POST and PUT action methods.
-     *
-     * @param Request      $request Symfony request
-     * @param integer|null $id      A Block identifier
-     *
-     * @return \FOS\RestBundle\View\View|FormInterface
-     */
-    protected function handleWriteBlock($request, $id = null)
-    {
-        $block = $id ? $this->getBlock($id) : null;
-
-        $form = $this->formFactory->createNamed(null, 'sonata_page_api_form_block', $block, array(
-            'csrf_protection' => false
-        ));
-
-        $form->bind($request);
-
-        if ($form->isValid()) {
-            $block = $form->getData();
-            $this->blockManager->save($block);
-
-            $view = FOSRestView::create($block);
             $serializationContext = SerializationContext::create();
             $serializationContext->setGroups(array('sonata_api_read'));
             $serializationContext->enableMaxDepthChecks();

--- a/Resources/config/api_controllers.xml
+++ b/Resources/config/api_controllers.xml
@@ -5,6 +5,11 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
+        <service id="sonata.page.controller.api.block" class="Sonata\PageBundle\Controller\Api\BlockController">
+            <argument type="service" id="sonata.page.manager.block" />
+            <argument type="service" id="form.factory" />
+        </service>
+
         <service id="sonata.page.controller.api.page" class="Sonata\PageBundle\Controller\Api\PageController">
             <argument type="service" id="sonata.page.manager.page" />
             <argument type="service" id="sonata.page.manager.block" />

--- a/Resources/config/routing/api.xml
+++ b/Resources/config/routing/api.xml
@@ -4,6 +4,7 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://friendsofsymfony.github.com/schema/rest https://raw.github.com/FriendsOfSymfony/FOSRestBundle/master/Resources/config/schema/routing/rest_routing-1.0.xsd">
 
+    <import type="rest" resource="sonata.page.controller.api.block" name-prefix="sonata_api_block_" />
     <import type="rest" resource="sonata.page.controller.api.page" name-prefix="sonata_api_page_" />
 
 </routes>

--- a/Tests/Controller/Api/BlockControllerTest.php
+++ b/Tests/Controller/Api/BlockControllerTest.php
@@ -1,0 +1,125 @@
+<?php
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+
+namespace Sonata\Test\PageBundle\Controller\Api;
+
+use Sonata\PageBundle\Controller\Api\BlockController;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Class BlockControllerTest
+ *
+ * @package Sonata\Test\PageBundle\Controller\Api
+ *
+ * @author Vincent Composieux <vincent.composieux@gmail.com>
+ */
+class BlockControllerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetBlockAction()
+    {
+        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+
+        $this->assertEquals($block, $this->createBlockController($block)->getBlockAction(1));
+    }
+
+    /**
+     * @expectedException        \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     * @expectedExceptionMessage Block (42) not found
+     */
+    public function testGetBlockActionNotFoundException()
+    {
+        $this->createBlockController()->getBlockAction(42);
+    }
+
+    public function testPutBlockAction()
+    {
+        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+
+        $blockManager = $this->getMock('Sonata\BlockBundle\Model\BlockManagerInterface');
+        $blockManager->expects($this->once())->method('save')->will($this->returnValue($block));
+
+        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form->expects($this->once())->method('bind');
+        $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
+        $form->expects($this->once())->method('getData')->will($this->returnValue($block));
+
+        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
+
+        $view = $this->createBlockController($block, $blockManager, $formFactory)->putBlockAction(1, new Request());
+
+        $this->assertInstanceOf('FOS\RestBundle\View\View', $view);
+    }
+
+    public function testPutBlockInvalidAction()
+    {
+        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+
+        $blockManager = $this->getMock('Sonata\BlockBundle\Model\BlockManagerInterface');
+        $blockManager->expects($this->never())->method('save')->will($this->returnValue($block));
+
+        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form->expects($this->once())->method('bind');
+        $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
+
+        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
+
+        $view = $this->createBlockController($block, $blockManager, $formFactory)->putBlockAction(1, new Request());
+
+        $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $view);
+    }
+
+    public function testDeleteBlockAction()
+    {
+        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+
+        $blockManager = $this->getMock('Sonata\BlockBundle\Model\BlockManagerInterface');
+        $blockManager->expects($this->once())->method('delete');
+
+        $view = $this->createBlockController($block, $blockManager)->deleteBlockAction(1);
+
+        $this->assertEquals(array('deleted' => true), $view);
+    }
+
+    public function testDeleteBlockInvalidAction()
+    {
+        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
+
+        $blockManager = $this->getMock('Sonata\BlockBundle\Model\BlockManagerInterface');
+        $blockManager->expects($this->never())->method('delete');
+
+        $this->createBlockController(null, $blockManager)->deleteBlockAction(1);
+    }
+
+    /**
+     * @param $block
+     * @param $blockManager
+     * @param $formFactory
+     *
+     * @return BlockController
+     */
+    public function createBlockController($block = null, $blockManager = null, $formFactory = null)
+    {
+        if (null === $blockManager) {
+            $blockManager = $this->getMock('Sonata\BlockBundle\Model\BlockManagerInterface');
+        }
+        if (null !== $block) {
+            $blockManager->expects($this->once())->method('findOneBy')->will($this->returnValue($block));
+        }
+        if (null === $formFactory) {
+            $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        }
+
+        return new BlockController($blockManager, $formFactory);
+    }
+}

--- a/Tests/Controller/Api/PageControllerTest.php
+++ b/Tests/Controller/Api/PageControllerTest.php
@@ -13,6 +13,8 @@ namespace Sonata\Test\PageBundle\Controller\Api;
 
 use Sonata\PageBundle\Controller\Api\PageController;
 
+use Symfony\Component\HttpFoundation\Request;
+
 /**
  * Class PageControllerTest
  *
@@ -38,6 +40,7 @@ class PageControllerTest extends \PHPUnit_Framework_TestCase
     public function testGetPageAction()
     {
         $page = $this->getMock('Sonata\PageBundle\Model\PageInterface');
+
         $this->assertEquals($page, $this->createPageController($page)->getPageAction(1));
     }
 
@@ -50,7 +53,7 @@ class PageControllerTest extends \PHPUnit_Framework_TestCase
         $this->createPageController()->getPageAction(42);
     }
 
-    public function testGetPagePageblocksAction()
+    public function testGetPageBlocksAction()
     {
         $page  = $this->getMock('Sonata\PageBundle\Model\PageInterface');
         $block = $this->getMock('Sonata\PageBundle\Model\PageBlockInterface');
@@ -58,6 +61,154 @@ class PageControllerTest extends \PHPUnit_Framework_TestCase
         $page->expects($this->once())->method('getBlocks')->will($this->returnValue(array($block)));
 
         $this->assertEquals(array($block), $this->createPageController($page)->getPageBlocksAction(1));
+    }
+
+    public function testPostPageAction()
+    {
+        $page = $this->getMock('Sonata\PageBundle\Model\PageInterface');
+
+        $pageManager = $this->getMock('Sonata\PageBundle\Model\PageManagerInterface');
+        $pageManager->expects($this->once())->method('save')->will($this->returnValue($page));
+
+        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form->expects($this->once())->method('bind');
+        $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
+        $form->expects($this->once())->method('getData')->will($this->returnValue($page));
+
+        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
+
+        $view = $this->createPageController(null, $pageManager, null, $formFactory)->postPageAction(new Request());
+
+        $this->assertInstanceOf('FOS\RestBundle\View\View', $view);
+    }
+
+    public function testPostPageInvalidAction()
+    {
+        $page = $this->getMock('Sonata\PageBundle\Model\PageInterface');
+
+        $pageManager = $this->getMock('Sonata\PageBundle\Model\PageManagerInterface');
+        $pageManager->expects($this->never())->method('save')->will($this->returnValue($page));
+
+        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form->expects($this->once())->method('bind');
+        $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
+
+        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
+
+        $view = $this->createPageController(null, $pageManager, null, $formFactory)->postPageAction(new Request());
+
+        $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $view);
+    }
+
+    public function testPutPageAction()
+    {
+        $page = $this->getMock('Sonata\UserBundle\Model\PageInterface');
+
+        $pageManager = $this->getMock('Sonata\PageBundle\Model\PageManagerInterface');
+        $pageManager->expects($this->once())->method('save')->will($this->returnValue($page));
+
+        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form->expects($this->once())->method('bind');
+        $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
+        $form->expects($this->once())->method('getData')->will($this->returnValue($page));
+
+        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
+
+        $view = $this->createPageController($page, $pageManager, null, $formFactory)->putPageAction(1, new Request());
+
+        $this->assertInstanceOf('FOS\RestBundle\View\View', $view);
+    }
+
+    public function testPutPageInvalidAction()
+    {
+        $page = $this->getMock('Sonata\PageBundle\Model\PageInterface');
+
+        $pageManager = $this->getMock('Sonata\PageBundle\Model\PageManagerInterface');
+        $pageManager->expects($this->never())->method('save')->will($this->returnValue($page));
+
+        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form->expects($this->once())->method('bind');
+        $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
+
+        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
+
+        $view = $this->createPageController($page, $pageManager, null, $formFactory)->putPageAction(1, new Request());
+
+        $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $view);
+    }
+
+    public function testDeletePageAction()
+    {
+        $page = $this->getMock('Sonata\PageBundle\Model\PageInterface');
+
+        $pageManager = $this->getMock('Sonata\PageBundle\Model\PageManagerInterface');
+        $pageManager->expects($this->once())->method('delete');
+
+        $view = $this->createPageController($page, $pageManager)->deletePageAction(1);
+
+        $this->assertEquals(array('deleted' => true), $view);
+    }
+
+    public function testDeletePageInvalidAction()
+    {
+        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
+
+        $pageManager = $this->getMock('Sonata\PageBundle\Model\PageManagerInterface');
+        $pageManager->expects($this->never())->method('delete');
+
+        $this->createPageController(null, $pageManager)->deletePageAction(1);
+    }
+
+    public function testPostPageBlockAction()
+    {
+        $block = $this->getMock('Sonata\PageBundle\Model\Block');
+        $block->expects($this->once())->method('setPage');
+
+        $page = $this->getMock('Sonata\PageBundle\Model\PageInterface');
+
+        $pageManager = $this->getMock('Sonata\PageBundle\Model\PageManagerInterface');
+
+        $blockManager = $this->getMock('Sonata\BlockBundle\Model\BlockManagerInterface');
+        $blockManager->expects($this->once())->method('save')->will($this->returnValue($block));
+
+        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form->expects($this->once())->method('bind');
+        $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
+        $form->expects($this->once())->method('getData')->will($this->returnValue($block));
+
+        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
+
+        $view = $this->createPageController($page, $pageManager, $blockManager, $formFactory)->postPageBlockAction(1, new Request());
+
+        $this->assertInstanceOf('FOS\RestBundle\View\View', $view);
+    }
+
+    public function testPostPageBlockInvalidAction()
+    {
+        $block = $this->getMock('Sonata\PageBundle\Model\Block');
+
+        $page = $this->getMock('Sonata\PageBundle\Model\PageInterface');
+
+        $pageManager = $this->getMock('Sonata\PageBundle\Model\PageManagerInterface');
+
+        $blockManager = $this->getMock('Sonata\BlockBundle\Model\BlockManagerInterface');
+        $blockManager->expects($this->never())->method('save')->will($this->returnValue($block));
+
+        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form->expects($this->once())->method('bind');
+        $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
+
+        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
+
+        $view = $this->createPageController($page, $pageManager, $blockManager, $formFactory)->postPageBlockAction(1, new Request());
+
+        $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $view);
     }
 
     /**


### PR DESCRIPTION
I've refactored `SonataPageBundle` APIs to have a `BlockController` in addition to `PageController` for methods that only interacts on blocks.

![capture decran 2014-03-14 a 14 36 27](https://f.cloud.github.com/assets/103900/2421128/d4c87016-ab7d-11e3-9c80-f99da93529aa.png)

I've also added missing units tests, Behat tests will be added to sandbox.
