### PR TITLE
Add pages snapshots generation

### DIFF
--- a/Resources/config/api_controllers.xml
+++ b/Resources/config/api_controllers.xml
@@ -11,6 +11,7 @@
         </service>
 
         <service id="sonata.page.controller.api.page" class="Sonata\PageBundle\Controller\Api\PageController">
+            <argument type="service" id="sonata.page.manager.site" />
             <argument type="service" id="sonata.page.manager.page" />
             <argument type="service" id="sonata.page.manager.block" />
             <argument type="service" id="form.factory" />


### PR DESCRIPTION
I've added the last missing method to create a snapshot of all pages (of all sites):

![capture decran 2014-03-14 a 15 32 09](https://f.cloud.github.com/assets/103900/2421696/6efb4684-ab85-11e3-9f4c-78264e3bdee4.png)
