### PR TITLE
Restrict core bundle version to dev-master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "sonata-project/seo-bundle": "~1.1",
         "sonata-project/doctrine-extensions" : "~1.0",
         "sonata-project/cache-bundle": "~2.1,>=2.1.7",
-        "sonata-project/core-bundle": "~2.2@dev",
+        "sonata-project/core-bundle": "~2.2@dev,>2.2.5",
         "symfony-cmf/routing-bundle": "~1.1",
         "sonata-project/notification-bundle": "~2.2",
         "sonata-project/datagrid-bundle": "~2.2@dev",


### PR DESCRIPTION
This bundle relies on PageableManagerInterface, which is only available
on the master branch of the core bundle. Specifying @dev is not enough
to ensure this. It allows me to install dev-master, but does not force
me to do it, and since I have prefer-stable set to true, Composer
installs 2.2.5, which does not have the interface.