### PR TITLE
load all blocks, not just the leaves

### DIFF
--- a/CmsManager/CmsSnapshotManager.php
+++ b/CmsManager/CmsSnapshotManager.php
@@ -155,7 +155,10 @@ class CmsSnapshotManager extends BaseCmsPageManager
      */
     private function loadBlocks(PageInterface $page)
     {
-        $i = new \RecursiveIteratorIterator(new RecursiveBlockIterator($page->getBlocks()));
+        $i = new \RecursiveIteratorIterator(
+            new RecursiveBlockIterator($page->getBlocks()),
+            \RecursiveIteratorIterator::SELF_FIRST
+        );
 
         foreach ($i as $block) {
             $this->blocks[$block->getId()] = $block;


### PR DESCRIPTION
The default value for the mode argument of
\RecursiveIteratorIterator::__construct() is LEAVES_ONLY, which is
pretty self-explanatory. I think loadBlocks needs to load all the blocks
of the page, not just the leaves, doesn't it ?

How did I see that ? Well, I have enabled esi on my application, and after reading the documentation, I decided to enable esi for the container block, like this:

``` yaml
sonata_block:
    default_contexts: [sonata_page_bundle]
    context_manager: sonata.page.block.context_manager
    blocks:
        sonata.page.block.container:
            cache: sonata.page.cache.esi
```

I modified the homepage to add a text block in the "Top content" container block, and went to the homepage as a normal user, and I saw an esi block appear. 

Then, I enabled Symfony's reverse proxy, and I got a 500 indicating that the sub-query for the "Top content" block was giving a 500.

I went to the block url and saw that it couldn't find the "Top content" block, because it is not a leaf of the block tree.
