### PR TITLE
Use the snapshot roles to grant access to the snapshot actions

### DIFF
--- a/Controller/PageAdminController.php
+++ b/Controller/PageAdminController.php
@@ -32,7 +32,7 @@ class PageAdminController extends Controller
      */
     public function batchActionSnapshot($query)
     {
-        if (!$this->get('security.context')->isGranted('ROLE_SONATA_PAGE_ADMIN_PAGE_EDIT')) {
+        if (false === $this->get('sonata.page.admin.snapshot')->isGranted('CREATE')) {
             throw new AccessDeniedException();
         }
 

--- a/Controller/SiteAdminController.php
+++ b/Controller/SiteAdminController.php
@@ -31,7 +31,7 @@ class SiteAdminController extends Controller
      */
     public function snapshotsAction()
     {
-        if (false === $this->admin->isGranted('EDIT')) {
+        if (false === $this->get('sonata.page.admin.snapshot')->isGranted('CREATE')) {
             throw new AccessDeniedException();
         }
 

--- a/Controller/SnapshotAdminController.php
+++ b/Controller/SnapshotAdminController.php
@@ -91,7 +91,7 @@ class SnapshotAdminController extends Controller
      */
     public function batchActionToggleEnabled($query)
     {
-        if (!$this->get('security.context')->isGranted('ROLE_SONATA_PAGE_ADMIN_BLOCK_EDIT')) {
+        if (false === $this->admin->isGranted('EDIT')) {
             throw new AccessDeniedException();
         }
 


### PR DESCRIPTION
You can give a user snapshot roles but some of the admin controllers use different roles to grant access to the snapshot actions.
