### PR TITLE
order found snapshots by publicationDateStart

### DIFF
--- a/Entity/SnapshotManager.php
+++ b/Entity/SnapshotManager.php
@@ -131,6 +131,7 @@ class SnapshotManager extends BaseEntityManager implements SnapshotManagerInterf
             throw new \RuntimeException('please provide a `pageId`, `url`, `routeName` or `name` as criteria key');
         }
 
+        $query->orderBy("s.publicationDateStart","desc");
         $query->setMaxResults(1);
         $query->setParameters($parameters);
 


### PR DESCRIPTION
It is counterintuitive that if more then one snapshot matches the date criteria, the one that was created first is selected, it should be the one with the newest startDate.