### PR TITLE
treeview update style and init script

### DIFF
--- a/Resources/public/tree.css
+++ b/Resources/public/tree.css
@@ -42,9 +42,66 @@
 .page-tree__item__is-hybrid {
     margin-right: 5px;
 }
+.page-tree__item.is-active {
+    border: 1px solid #3c8dbc;
+}
+.page-tree__item.is-active:after,
+.page-tree__item.is-active:before {
+    left: 100%;
+    top: 50%;
+    border: solid transparent;
+    content: " ";
+    height: 0;
+    width: 0;
+    position: absolute;
+    pointer-events: none;
+}
+.page-tree__item.is-active:after {
+    border-color: rgba(255, 255, 255, 0);
+    border-left-color: #fff;
+    border-width: 8px;
+    margin-top: -8px;
+}
+.page-tree__item.is-active:before {
+    border-color: rgba(255, 255, 255, 0);
+    border-left-color: #3c8dbc;
+    border-width: 9px;
+    margin-top: -9px;
+}
+.page-tree__item.is-active:hover:after {
+    border-left-color: #eee;
+}
+.page-tree__item.is-toggled .fa-caret-right {
+    -webkit-transform: rotate(90deg);
+    -moz-transform: rotate(90deg);
+    -o-transform: rotate(90deg);
+    -ms-transform: rotate(90deg);
+    transform: rotate(90deg);
+}
 .page-tree__item__edit {
     font-weight: bold;
 }
 .page-tree__item__edit:hover {
     text-decoration: underline;
+}
+
+/**
+ * Toggleable tree
+ */
+.page-tree--toggleable li > ul {
+    display: none;
+}
+.page-tree--toggleable .page-tree__item {
+    margin-left: 25px;
+}
+.page-tree--toggleable .page-tree__item .fa-caret-right {
+    cursor: pointer;
+}
+.page-tree--toggleable .page-tree__item .fa-caret-right:after {
+    content: '';
+    position: absolute;
+    top: -5px;
+    bottom: -5px;
+    left: -10px;
+    right: -10px;
 }

--- a/Resources/public/treeview.js
+++ b/Resources/public/treeview.js
@@ -1,0 +1,81 @@
+/**
+ *
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ */
+
+;(function ( $, window, document, undefined ) {
+
+    var pluginName = 'treeView',
+        defaultRegistry = '.js-treeview',
+        defaults = {
+            togglersAttribute: '[data-treeview-toggler]',
+            toggledState: 'is-toggled'
+        };
+
+    function TreeView( element, options ) {
+        this.element = element;
+        this.options = $.extend({}, defaults, options) ;
+        this._defaults = defaults;
+        this._name = pluginName;
+        this.init();
+    }
+
+    TreeView.prototype = {
+
+        /**
+         * Constructor
+         */
+        init: function() {
+            this.setElements();
+            this.setEvents();
+        },
+
+        /**
+         * Cache DOM elements to limit DOM parsing
+         */
+        setElements: function() {
+            this.$element = $(this.element);
+            this.$togglers = this.$element.find(this.options.togglersAttribute);
+        },
+
+        /**
+         * Set events and delegates
+         */
+        setEvents: function() {
+            this.$togglers.on('click', $.proxy(this.toggle, this));
+        },
+
+        /**
+         * Toggle an item
+         */
+        toggle: function(ev) {
+            var $target = $(ev.currentTarget),
+                $parent = $target.parent();
+            $parent.toggleClass(this.options.toggledState);
+            $parent.next('ul').slideToggle();
+        }
+
+    };
+
+    // A really lightweight plugin wrapper around the constructor,
+    // preventing against multiple instantiations
+    $.fn[pluginName] = function ( options ) {
+        return this.each(function () {
+            if (!$.data(this, 'plugin_' + pluginName)) {
+                $.data(this, 'plugin_' + pluginName, new TreeView(this, options));
+            }
+        });
+    };
+
+    // Default standard registry
+    $(function() {
+        $(defaultRegistry)[pluginName]();
+    });
+
+})( jQuery, window, document );


### PR DESCRIPTION
**Note**
- Most standard, reusable treeview javascript script (possible to replace the one used for the menu by this one).
- New styles for this dynamic treeview added to the current one.

**Toggleable tree markup (inspired by PageAdmin/tree.html.twig) :**

``` html
<ul class="page-tree page-tree--toggleable js-treeview">
    <li>
        <div class="page-tree__item">
            <i class="fa fa-caret-right" data-treeview-toggler></i>
            <a class="page-tree__item__edit" href="/">Rubrique A</a>
        </div>
        <ul>
            <li>
                <div class="page-tree__item is-active">
                    <i class="fa fa-caret-right" data-treeview-toggler></i>
                    <a class="page-tree__item__edit" href="/">Sous-rubrique AA</a>
                </div>
                <ul>
                    <li>
                        <div class="page-tree__item">
                            <a class="page-tree__item__edit" href="/">Sous-rubrique AAA</a>
                        </div>
                    </li>
                </ul>
            </li>
        </ul>
    </li>
    <li>
        <div class="page-tree__item">
            <i class="fa fa-caret-right" data-treeview-toggler></i>
            <a class="page-tree__item__edit" href="/">Rubrique B</a>
        </div>
        <ul>
            <li>
                <div class="page-tree__item">
                    <a class="page-tree__item__edit" href="/">Sous-rubrique BB</a>
                </div>
            </li>
        </ul>
    </li>
</ul>
```
