### PR TITLE
[Security] Update permissions for the compose actions

### DIFF
--- a/Controller/PageAdminController.php
+++ b/Controller/PageAdminController.php
@@ -144,7 +144,10 @@ class PageAdminController extends Controller
      */
     public function composeAction()
     {
-        if (false === $this->admin->isGranted('LIST')) {
+        if (
+            false === $this->admin->isGranted('EDIT')
+            || false === $this->get('sonata.page.admin.block')->isGranted('LIST')
+        ) {
             throw new AccessDeniedException();
         }
 


### PR DESCRIPTION
About `$this->admin->isGranted('EDIT')` I think the edit permission is open to question because it depends if we consider that the compose actions are part of the page edition (in my opinion I think so).

But one thing is sure about the former permission, I think @plouc wanted to check the list permission for the block admin and not for the page admin like `composeContainerShowAction()` otherwise it does not make sense.
