### PR TITLE
Removed the hardcoded 'og:type' to make it customizable

### DIFF
--- a/Page/Service/DefaultPageService.php
+++ b/Page/Service/DefaultPageService.php
@@ -88,7 +88,6 @@ class DefaultPageService extends BasePageService
             $this->seoPage->addMeta('name', 'keywords', $page->getMetaKeyword());
         }
 
-        $this->seoPage->addMeta('property', 'og:type', 'article');
         $this->seoPage->addHtmlAttributes('prefix', 'og: http://ogp.me/ns#');
     }
 }

--- a/Tests/Page/Service/DefaultPageServiceTest.php
+++ b/Tests/Page/Service/DefaultPageServiceTest.php
@@ -71,10 +71,9 @@ class DefaultPageServiceTest extends \PHPUnit_Framework_TestCase
         $metaMapping = array(
             array('name',       'description',  'page meta description', true),
             array('name',       'keywords',     'page meta keywords',    true),
-            array('property',   'og:type',      'article',               true)
         );
 
-        $this->seoPage->expects($this->exactly(3))->method('addMeta')->will($this->returnValueMap($metaMapping));
+        $this->seoPage->expects($this->exactly(2))->method('addMeta')->will($this->returnValueMap($metaMapping));
 
         $this->seoPage->expects($this->once())
             ->method('addHtmlAttributes')->with($this->equalTo('prefix'), $this->equalTo('og: http://ogp.me/ns#'));


### PR DESCRIPTION
This PR removes the hardcoded 'og:type' to make it customizable through the sonata_seo config