### PR TITLE
Allow multiple --site options in commands

### DIFF
--- a/Command/BaseCommand.php
+++ b/Command/BaseCommand.php
@@ -99,8 +99,10 @@ abstract class BaseCommand extends ContainerAwareCommand
     protected function getSites(InputInterface $input)
     {
         $parameters = array();
-        if ($input->getOption('site') != 'all') {
-            $parameters['id'] = $input->getOption('site');
+        $identifiers = $input->getOption('site');
+
+        if ('all' != current($identifiers)) {
+            $parameters['id'] = 1 === count($identifiers) ? current($identifiers) : $identifiers;
         }
 
         return $this->getSiteManager()->findBy($parameters);

--- a/Command/CleanupSnapshotsCommand.php
+++ b/Command/CleanupSnapshotsCommand.php
@@ -29,7 +29,7 @@ class CleanupSnapshotsCommand extends BaseCommand
         $this->setName('sonata:page:cleanup-snapshots');
         $this->setDescription('Cleanups the deprecated snapshots by a given site');
 
-        $this->addOption('site', null, InputOption::VALUE_REQUIRED, 'Site id', null);
+        $this->addOption('site', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Site id', null);
         $this->addOption('base-console', null, InputOption::VALUE_OPTIONAL, 'Base Symfony console command', 'app/console');
         $this->addOption('mode', null, InputOption::VALUE_OPTIONAL, 'Run the command asynchronously', 'sync');
         $this->addOption('keep-snapshots', null, InputOption::VALUE_OPTIONAL, 'Keep a given count of snapshots per page', 5);

--- a/Command/CreateSnapshotsCommand.php
+++ b/Command/CreateSnapshotsCommand.php
@@ -32,7 +32,7 @@ class CreateSnapshotsCommand extends BaseCommand
     {
         $this->setName('sonata:page:create-snapshots');
         $this->setDescription('Create a snapshots of all pages available');
-        $this->addOption('site', null, InputOption::VALUE_OPTIONAL, 'Site id', null);
+        $this->addOption('site', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Site id', null);
         $this->addOption('base-console', null, InputOption::VALUE_OPTIONAL, 'Base symfony console command', 'php app/console');
 
         $this->addOption('mode', null, InputOption::VALUE_OPTIONAL, 'Run the command asynchronously', 'sync');

--- a/Command/DumpPageCommand.php
+++ b/Command/DumpPageCommand.php
@@ -43,8 +43,6 @@ You can use the --extended option to dump block configuration
         $this->addArgument('manager', InputArgument::REQUIRED, 'The manager service id');
         $this->addArgument('page_id', InputArgument::REQUIRED, 'The page id');
         $this->addOption('extended', null, InputOption::VALUE_NONE, 'Extended information');
-
-
     }
 
     /**

--- a/Command/MigrateToJsonTypeCommand.php
+++ b/Command/MigrateToJsonTypeCommand.php
@@ -18,6 +18,9 @@ use Symfony\Component\Console\Output\Output;
 
 class MigrateToJsonTypeCommand extends BaseCommand
 {
+    /**
+     * {@inheritDoc}
+     */
     public function configure()
     {
         $this->setName('sonata:page:migrate-block-json');
@@ -25,6 +28,9 @@ class MigrateToJsonTypeCommand extends BaseCommand
         $this->setDescription('Migrate all block settings to the doctrine JsonType');
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function execute(InputInterface $input, OutputInterface $output)
     {
         $count = 0;

--- a/Command/UpdateCoreRoutesCommand.php
+++ b/Command/UpdateCoreRoutesCommand.php
@@ -34,7 +34,7 @@ class UpdateCoreRoutesCommand extends BaseCommand
         $this->setName('sonata:page:update-core-routes');
         $this->setDescription('Update core routes, from routing files to page manager');
         $this->addOption('all', null, InputOption::VALUE_NONE, 'Create snapshots for all sites');
-        $this->addOption('site', null, InputOption::VALUE_OPTIONAL, 'Site id', null);
+        $this->addOption('site', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Site id', null);
         $this->addOption('base-command', null, InputOption::VALUE_OPTIONAL, 'Site id', 'php app/console');
     }
 

--- a/Resources/doc/reference/command_line.rst
+++ b/Resources/doc/reference/command_line.rst
@@ -29,6 +29,12 @@ Page commands
 
     php app/console sonata:page:cleanup-snapshots --site=all --keep-snapshots=5
 
+Please note that you can also give multiple website identifiers for all those commands, this way:
+
+    php app/console sonata:page:update-core-routes --site=1 --site=2 --site=...
+    php app/console sonata:page:create-snapshots --site=1 --site=2 --site=...
+    php app/console sonata:page:cleanup-snapshots --site=1 --site=2 --site=...
+
 Debug Commands
 --------------
 

--- a/Tests/Command/BaseCommandTest.php
+++ b/Tests/Command/BaseCommandTest.php
@@ -1,0 +1,72 @@
+<?php
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+
+namespace Sonata\Test\PageBundle\Command;
+
+use Sonata\PageBundle\Command\BaseCommand;
+
+/**
+ * Class BaseCommandTest
+ *
+ * @author Vincent Composieux <vincent.composieux@gmail.com>
+ */
+class BaseCommandTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var BaseCommand
+     */
+    private $command;
+
+    /**
+     * Sets up a new BaseCommand instance
+     */
+    public function setUp()
+    {
+        $this->command = $this->getMockBuilder('Sonata\PageBundle\Command\BaseCommand')
+            ->disableOriginalConstructor()
+            ->setMethods(array('getSiteManager'))
+            ->getMock();
+    }
+
+    /**
+     * Tests the getSites() method with different parameters
+     */
+    public function testGetSites()
+    {
+        // Given
+        $method = new \ReflectionMethod($this->command, 'getSites');
+        $method->setAccessible(true);
+
+        $input = $this->getMock('Symfony\Component\Console\Input\InputInterface');
+
+        $siteManager = $this->getMockBuilder('Sonata\PageBundle\Entity\SiteManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->command->expects($this->any())->method('getSiteManager')->will($this->returnValue($siteManager));
+
+        // Test --site=all value
+        $input->expects($this->at(0))->method('getOption')->with('site')->will($this->returnValue(array('all')));
+        $siteManager->expects($this->at(0))->method('findBy')->with(array());
+
+        // Test --site=10 value
+        $input->expects($this->at(1))->method('getOption')->with('site')->will($this->returnValue(array('10')));
+        $siteManager->expects($this->at(1))->method('findBy')->with(array('id' => 10));
+
+        // Test --site=10 --site=11 value
+        $input->expects($this->at(2))->method('getOption')->with('site')->will($this->returnValue(array('10', '11')));
+        $siteManager->expects($this->at(2))->method('findBy')->with(array('id' => array(10, 11)));
+
+        $method->invoke($this->command, $input);
+        $method->invoke($this->command, $input);
+        $method->invoke($this->command, $input);
+    }
+}


### PR DESCRIPTION
Hi,

I've added the availability to give multiple website identifiers using SonataPageBundle commands.

This is not a BC break as it continues to work as today.
## Currently: following commands are available

**For a specific website:**

``` bash
$ php app/console sonata:page:update-core-routes --site=1
$ php app/console sonata:page:create-snapshots --site=1
$ php app/console sonata:page:cleanup-snapshots --site=1
```

**For all websites:**

``` bash
$ php app/console sonata:page:update-core-routes --site=all
$ php app/console sonata:page:create-snapshots --site=all
$ php app/console sonata:page:cleanup-snapshots --site=all
```
## Added: allows multiple websites identifiers

``` bash
$ php app/console sonata:page:update-core-routes --site=1 --site=2 --site=...
$ php app/console sonata:page:create-snapshots --site=1 --site=2 --site=...
$ php app/console sonata:page:cleanup-snapshots --site=1 --site=2 --site=...
```
