### PR TITLE
Update old symfony_cmf_routing_extra mention to new cmf_routing

### DIFF
--- a/Resources/doc/reference/advanced_configuration.rst
+++ b/Resources/doc/reference/advanced_configuration.rst
@@ -8,7 +8,7 @@ Full configuration options (config.yml file):
     #
     # more information can be found here http://sonata-project.org/bundles/page
     #
-    symfony_cmf_routing_extra:
+    cmf_routing:
         chain:
             routers_by_id:
                 # enable the DynamicRouter with high priority to allow overwriting configured routes with content


### PR DESCRIPTION
I think this part of the documentation was not updated yet. It's mentioned correctly in the configuration: http://sonata-project.org/bundles/page/master/doc/reference/installation.html#configuration