### PR TITLE
Prevent Exception when sonata.page.page.class dont exists

### DIFF
--- a/SonataPageBundle.php
+++ b/SonataPageBundle.php
@@ -44,10 +44,12 @@ class SonataPageBundle extends Bundle
         $container = $this->container;
         $class     = $this->container->getParameter('sonata.page.page.class');
 
-        call_user_func(array($class, 'setSlugifyMethod'), function($text) use ($container) {
-            $service = $container->get($container->getParameter('sonata.page.slugify_service'));
+        if(class_exists($class)){
+            call_user_func(array($class, 'setSlugifyMethod'), function($text) use ($container) {
+                $service = $container->get($container->getParameter('sonata.page.slugify_service'));
 
-            return $service->slugify($text);
-        });
+                return $service->slugify($text);
+            });
+        }
     }
 }


### PR DESCRIPTION
when i try to easy-extends it throw a reflection error Application\Sonata\PageBundle\Entity\Post don't exist and it denied me to create the extended bundle so it loop in continue error, with this it fix that.