### PR TITLE
[FIX] Missing files Composer & Tree Page CSS

### DIFF
--- a/Resources/views/PageAdmin/compose.html.twig
+++ b/Resources/views/PageAdmin/compose.html.twig
@@ -11,6 +11,16 @@ file that was distributed with this source code.
 
 {% extends 'SonataAdminBundle:CRUD:action.html.twig' %}
 
+{% block stylesheets %}
+    {{ parent() }}
+    <link rel="stylesheet" href="{{ asset('bundles/sonatapage/sonata-page.back.css') }}" type="text/css" media="all" />
+{% endblock %}
+
+{% block javascripts %}
+    {{ parent() }}
+    <script src="{{ asset('bundles/sonatapage/sonata-page.back.js') }}" type="text/javascript"></script>
+{% endblock %}
+
 {% block tab_menu %}
     {{ knp_menu_render(admin.sidemenu(action), {'currentClass' : 'active'}, 'list') }}
 {% endblock %}

--- a/Resources/views/PageAdmin/tree.html.twig
+++ b/Resources/views/PageAdmin/tree.html.twig
@@ -11,6 +11,11 @@ file that was distributed with this source code.
 
 {% extends 'SonataAdminBundle:CRUD:base_list.html.twig' %}
 
+{% block stylesheets %}
+    {{ parent() }}
+    <link rel="stylesheet" href="{{ asset('bundles/sonatapage/sonata-page.back.css') }}" type="text/css" media="all" />
+{% endblock %}
+
 {% import _self as tree %}
 {% macro pages(pages, admin, rootPages) %}
     <ul{% if rootPages %} class="page-tree"{% endif %}>


### PR DESCRIPTION
After migration to `2.3.*@dev` for some interesting features on snap and block editing,
i've noticed that missing the include of new sonata-page.back files.

Tree view and composer page are broken.
