### PR TITLE
Fixes on shared block block service

### DIFF
--- a/Block/SharedBlockBlockService.php
+++ b/Block/SharedBlockBlockService.php
@@ -148,7 +148,8 @@ class SharedBlockBlockService extends BaseBlockService
                 'sonata_field_description' => $fieldDescription,
                 'class'                    => $this->getSharedBlockAdmin()->getClass(),
                 'model_manager'            => $this->getSharedBlockAdmin()->getModelManager(),
-                'label'                    => 'block'
+                'label'                    => 'block',
+                'required'                 => false
             ));
     }
 


### PR DESCRIPTION
This PR activate translation on the `SharedBlockBlockService` and fix empty block validation.
