### PR TITLE
API snapshot with get and delete methodes

### DIFF
--- a/Controller/Api/SnapshotController.php
+++ b/Controller/Api/SnapshotController.php
@@ -1,0 +1,174 @@
+<?php
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\PageBundle\Controller\Api;
+
+use FOS\RestBundle\Request\ParamFetcherInterface;
+use FOS\RestBundle\Controller\Annotations\QueryParam;
+use FOS\RestBundle\Controller\Annotations\View;
+use JMS\Serializer\SerializationContext;
+use Nelmio\ApiDocBundle\Annotation\ApiDoc;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpFoundation\Request;
+use FOS\RestBundle\View\View as FOSRestView;
+use Sonata\PageBundle\Model\SnapshotInterface;
+use Sonata\PageBundle\Model\SnapshotManagerInterface;
+
+/**
+ * Class SnapshotController
+ *
+ * @author Benoit de Jacobet <benoit.de-jacobet@ekino.com>
+ */
+class SnapshotController
+{
+    /**
+     * @var SnapshotManagerInterface
+     */
+    protected $snapshotManager;
+
+    /**
+     * Constructor
+     *
+     * @param SnapshotManagerInterface $snapshotManager
+     */
+    public function __construct(SnapshotManagerInterface $snapshotManager)
+    {
+        $this->snapshotManager = $snapshotManager;
+    }
+
+    /**
+     * Retrieves the list of snapshots (paginated)
+     *
+     * @ApiDoc(
+     *  resource=true,
+     *  output={"class"="Sonata\DatagridBundle\Pager\PagerInterface", "groups"="sonata_api_read"}
+     * )
+     *
+     * @QueryParam(name="page", requirements="\d+", default="1", description="Page for snapshots list pagination")
+     * @QueryParam(name="count", requirements="\d+", default="10", description="Maximum number of snapshots per page")
+     * @QueryParam(name="site", requirements="\d+", nullable=true, strict=true, description="Filter snapshots for a specific site's id")
+     * @QueryParam(name="page_id", requirements="\d+", nullable=true, strict=true, description="Filter snapshots for a specific page's id")
+     * @QueryParam(name="root", requirements="0|1", nullable=true, strict=true, description="Filter snapshots having no parent id")
+     * @QueryParam(name="parent", requirements="\d+", nullable=true, strict=true, description="Get snapshots being child of given snapshots id")
+     * @QueryParam(name="enabled", requirements="0|1", nullable=true, strict=true, description="Enabled/Disabled snapshots filter")
+     *
+     * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
+     *
+     * @param ParamFetcherInterface $paramFetcher
+     *
+     * @return Sonata\DatagridBundle\Pager\PagerInterface
+     */
+    public function getSnapshotsAction(ParamFetcherInterface $paramFetcher)
+    {
+        $supportedCriteria = array(
+            'enabled'   => '',
+            'site'      => '',
+            'page_id'   => '',
+            'root'      => '',
+            'parent'    => '',
+        );
+
+        $page    = $paramFetcher->get('page');
+        $limit   = $paramFetcher->get('count');
+        $sort    = $paramFetcher->get('orderBy');
+        $criteria = array_intersect_key($paramFetcher->all(), $supportedCriteria);
+
+        foreach ($criteria as $key => $value) {
+            if (null === $value) {
+                unset($criteria[$key]);
+            }
+        }
+
+        if (!$sort) {
+            $sort = array();
+        } elseif (!is_array($sort)) {
+            $sort = array($sort => 'asc');
+        }
+
+        $pager = $this->snapshotManager->getPager($criteria, $page, $limit, $sort);
+
+        return $pager;
+    }
+
+    /**
+     * Retrieves a specific snapshot
+     *
+     * @ApiDoc(
+     *  resource=true,
+     *  requirements={
+     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="snapshot id"}
+     *  },
+     *  output={"class"="Sonata\PageBundle\Model\SnapshotInterface", "groups"="sonata_api_read"},
+     *  statusCodes={
+     *      200="Returned when successful",
+     *      404="Returned when snapshots is not found"
+     *  }
+     * )
+     *
+     * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
+     *
+     * @param $id
+     *
+     * @return SnapshotInterface
+     */
+    public function getSnapshotAction($id)
+    {
+        return $this->getSnapshot($id);
+    }
+
+    /**
+     * Deletes a snapshot
+     *
+     * @ApiDoc(
+     *  requirements={
+     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="snapshot id"}
+     *  },
+     *  statusCodes={
+     *      200="Returned when snapshots is successfully deleted",
+     *      400="Returned when an error has occured while deleting the snapshots",
+     *      404="Returned when unable to find the snapshots"
+     *  }
+     * )
+     *
+     * @param integer $id A Snapshot identifier
+     *
+     * @return \FOS\RestBundle\View\View
+     *
+     * @throws NotFoundHttpException
+     */
+    public function deleteSnapshotAction($id)
+    {
+        $snapshots = $this->getSnapshot($id);
+
+        $this->snapshotManager->delete($snapshots);
+
+        return array('deleted' => true);
+    }
+
+    /**
+     * Retrieves Snapshot with id $id or throws an exception if it doesn't exist
+     *
+     * @param $id
+     *
+     * @return SnapshotInterface
+     *
+     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     */
+    protected function getSnapshot($id)
+    {
+        $snapshot = $this->snapshotManager->findOneBy(array('id' => $id));
+
+        if (null === $snapshot) {
+            throw new NotFoundHttpException(sprintf('Snapshot (%d) not found', $id));
+        }
+
+        return $snapshot;
+    }
+}

--- a/Entity/SnapshotManager.php
+++ b/Entity/SnapshotManager.php
@@ -15,8 +15,9 @@ use Doctrine\Common\Persistence\ManagerRegistry;
 use Sonata\CoreBundle\Model\BaseEntityManager;
 use Sonata\PageBundle\Model\PageInterface;
 use Sonata\PageBundle\Model\SnapshotManagerInterface;
-
 use Sonata\PageBundle\Model\SnapshotPageProxy;
+use Sonata\DatagridBundle\Pager\Doctrine\Pager;
+use Sonata\DatagridBundle\ProxyQuery\Doctrine\ProxyQuery;
 
 /**
  * This class manages SnapshotInterface persistency with the Doctrine ORM
@@ -260,5 +261,59 @@ class SnapshotManager extends BaseEntityManager implements SnapshotManagerInterf
         }
 
         throw new \RuntimeException(sprintf('The %s database platform has not been tested yet. Please report us if it works and feel free to create a pull request to handle it ;-)', $platform));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPager(array $criteria, $page, $limit = 10, array $sort = array())
+    {
+        $query = $this->getRepository()
+            ->createQueryBuilder('s')
+            ->select('s');
+
+        $parameters = array();
+
+        if (isset($criteria['enabled'])) {
+            $query->andWhere('s.enabled = :enabled');
+            $parameters['enabled'] = $criteria['enabled'];
+        }
+
+        if (isset($criteria['site'])) {
+            $query->join('s.site', 'si');
+            $query->andWhere('si.id = :siteId');
+            $parameters['siteId'] = $criteria['site'];
+        }
+
+        if (isset($criteria['page_id'])) {
+            $query->join('s.page', 'p');
+            $query->andWhere('p.id = :pageId');
+            $parameters['pageId'] = $criteria['page_id'];
+        }
+
+        if (isset($criteria['parent'])) {
+            $query->join('s.parent', 'pa');
+            $query->andWhere('pa.id = :parentId');
+            $parameters['parentId'] = $criteria['parent'];
+        }
+
+        if (isset($criteria['root'])) {
+            $isRoot = (bool) $criteria['root'];
+            if ($isRoot) {
+                $query->andWhere('s.parent IS NULL');
+            } else {
+                $query->andWhere('s.parent IS NOT NULL');
+            }
+        }
+
+        $query->setParameters($parameters);
+
+        $pager = new Pager();
+        $pager->setMaxPerPage($limit);
+        $pager->setQuery(new ProxyQuery($query));
+        $pager->setPage($page);
+        $pager->init();
+
+        return $pager;
     }
 }

--- a/Model/SnapshotManagerInterface.php
+++ b/Model/SnapshotManagerInterface.php
@@ -11,13 +11,14 @@
 namespace Sonata\PageBundle\Model;
 
 use Sonata\CoreBundle\Model\ManagerInterface;
+use Sonata\CoreBundle\Model\PageableManagerInterface;
 
 /**
  * Defines methods to interact with the persistency layer of a SnapshotInterface
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-interface SnapshotManagerInterface extends ManagerInterface
+interface SnapshotManagerInterface extends ManagerInterface, PageableManagerInterface
 {
     /**
      * @param array $criteria

--- a/Resources/config/api_controllers.xml
+++ b/Resources/config/api_controllers.xml
@@ -22,5 +22,9 @@
             <argument type="service" id="sonata.page.manager.site" />
             <argument type="service" id="form.factory" />
         </service>
+
+        <service id="sonata.page.controller.api.snapshot" class="Sonata\PageBundle\Controller\Api\SnapshotController">
+            <argument type="service" id="sonata.page.manager.snapshot" />
+        </service>
     </services>
 </container>

--- a/Resources/config/routing/api.xml
+++ b/Resources/config/routing/api.xml
@@ -4,8 +4,9 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://friendsofsymfony.github.com/schema/rest https://raw.github.com/FriendsOfSymfony/FOSRestBundle/master/Resources/config/schema/routing/rest_routing-1.0.xsd">
 
-    <import type="rest" resource="sonata.page.controller.api.block" name-prefix="sonata_api_block_" />
-    <import type="rest" resource="sonata.page.controller.api.page"  name-prefix="sonata_api_page_" />
-    <import type="rest" resource="sonata.page.controller.api.site"  name-prefix="sonata_api_site_" />
+    <import type="rest" resource="sonata.page.controller.api.block"     name-prefix="sonata_api_block_" />
+    <import type="rest" resource="sonata.page.controller.api.page"      name-prefix="sonata_api_page_" />
+    <import type="rest" resource="sonata.page.controller.api.site"      name-prefix="sonata_api_site_" />
+    <import type="rest" resource="sonata.page.controller.api.snapshot"  name-prefix="sonata_api_snapshot_" />
 
 </routes>

--- a/Resources/config/serializer.xml
+++ b/Resources/config/serializer.xml
@@ -21,6 +21,11 @@
             <argument type="service" id="sonata.page.manager.site" />
         </service>
 
+        <service id="sonata.page.serializer.handler.snapshot" class="Sonata\PageBundle\Serializer\SnapshotSerializerHandler">
+            <tag name="jms_serializer.subscribing_handler" />
+            <argument type="service" id="sonata.page.manager.snapshot" />
+        </service>
+
     </services>
 
 </container>

--- a/Serializer/SnapshotSerializerHandler.php
+++ b/Serializer/SnapshotSerializerHandler.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\PageBundle\Serializer;
+
+use Sonata\CoreBundle\Serializer\BaseSerializerHandler;
+
+/**
+ * @author Benoit de JAcobet <benoit.de-jacobet@ekino.com>
+ */
+class SnapshotSerializerHandler extends BaseSerializerHandler
+{
+    /**
+     * {@inheritdoc}
+     */
+    public static function getType()
+    {
+        return 'sonata_page_snapshot_id';
+    }
+}

--- a/Tests/Controller/Api/SnapshotControllerTest.php
+++ b/Tests/Controller/Api/SnapshotControllerTest.php
@@ -1,0 +1,93 @@
+<?php
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+
+namespace Sonata\Test\PageBundle\Controller\Api;
+
+use Sonata\PageBundle\Controller\Api\SnapshotController;
+
+/**
+ * Class SnapshotControllerTest
+ *
+ * @package Sonata\Test\PageBundle\Controller\Api
+ *
+ * @author Benoit de Jacobet <benoit.de-jacobet@ekino.com>
+ */
+class SnapshotControllerTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function testGetSnapshotsAction()
+    {
+        $snapshotManager = $this->getMock('Sonata\PageBundle\Model\SnapshotManagerInterface');
+        $snapshotManager->expects($this->once())->method('getPager')->will($this->returnValue(array()));
+
+        $paramFetcher = $this->getMock('FOS\RestBundle\Request\ParamFetcherInterface');
+        $paramFetcher->expects($this->exactly(3))->method('get');
+        $paramFetcher->expects($this->once())->method('all')->will($this->returnValue(array()));
+
+        $this->assertEquals(array(), $this->createSnapshotController(null, $snapshotManager)->getSnapshotsAction($paramFetcher));
+    }
+
+    public function testGetSnapshotAction()
+    {
+        $snapshot = $this->getMock('Sonata\PageBundle\Model\SnapshotInterface');
+
+        $this->assertEquals($snapshot, $this->createSnapshotController($snapshot)->getSnapshotAction(1));
+    }
+
+    /**
+     * @expectedException        \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     * @expectedExceptionMessage Snapshot (1) not found
+     */
+    public function testGetSnapshotActionNotFoundException()
+    {
+        $this->createSnapshotController()->getSnapshotAction(1);
+    }
+
+    public function testDeleteSnapshotAction()
+    {
+        $snapshot = $this->getMock('Sonata\PageBundle\Model\SnapshotInterface');
+
+        $snapshotManager = $this->getMock('Sonata\PageBundle\Model\SnapshotManagerInterface');
+        $snapshotManager->expects($this->once())->method('delete');
+
+        $view = $this->createSnapshotController($snapshot, $snapshotManager)->deleteSnapshotAction(1);
+
+        $this->assertEquals(array('deleted' => true), $view);
+    }
+
+    public function testDeletePageInvalidAction()
+    {
+        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
+
+        $snapshotManager = $this->getMock('Sonata\PageBundle\Model\SnapshotManagerInterface');
+        $snapshotManager->expects($this->never())->method('delete');
+
+        $this->createSnapshotController(null, $snapshotManager)->deleteSnapshotAction(1);
+    }
+
+    /**
+     * @param $snapshot
+     * @param $snapshotManager
+     *
+     * @return SnapshotController
+     */
+    public function createSnapshotController($snapshot = null, $snapshotManager = null)
+    {
+        if (null === $snapshotManager) {
+            $snapshotManager = $this->getMock('Sonata\PageBundle\Model\SnapshotManagerInterface');
+        }
+        if (null !== $snapshot) {
+            $snapshotManager->expects($this->once())->method('findOneBy')->will($this->returnValue($snapshot));
+        }
+
+        return new SnapshotController($snapshotManager);
+    }
+}

--- a/Tests/Entity/SnapshotManagerTest.php
+++ b/Tests/Entity/SnapshotManagerTest.php
@@ -1,0 +1,130 @@
+<?php
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\PageBundle\Tests\Entity;
+
+use Sonata\PageBundle\Entity\SnapshotManager;
+
+/**
+ * Class SnapshotManagerTest
+ *
+ */
+class SnapshotManagerTest extends \PHPUnit_Framework_TestCase
+{
+    protected function getSnapshotManager($qbCallback)
+    {
+        $query = $this->getMockForAbstractClass('Doctrine\ORM\AbstractQuery', array(), '', false, true, true, array('execute'));
+        $query->expects($this->any())->method('execute')->will($this->returnValue(true));
+
+
+        $qb = $this->getMock('Doctrine\ORM\QueryBuilder', array(), array(
+            $this->getMockBuilder('Doctrine\ORM\EntityManager')->disableOriginalConstructor()->getMock()
+        ));
+
+        $qb->expects($this->any())->method('select')->will($this->returnValue($qb));
+        $qb->expects($this->any())->method('getQuery')->will($this->returnValue($query));
+
+        $qbCallback($qb);
+
+        $repository = $this->getMockBuilder('Doctrine\ORM\EntityRepository')->disableOriginalConstructor()->getMock();
+        $repository->expects($this->any())->method('createQueryBuilder')->will($this->returnValue($qb));
+
+        $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')->disableOriginalConstructor()->getMock();
+        $em->expects($this->any())->method('getRepository')->will($this->returnValue($repository));
+
+        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry->expects($this->any())->method('getManagerForClass')->will($this->returnValue($em));
+
+        return new SnapshotManager('Sonata\PageBundle\Entity\BaseSnapshot', $registry);
+    }
+
+    public function testGetPager()
+    {
+        $self = $this;
+        $this
+            ->getSnapshotManager(function ($qb) use ($self) {
+                $qb->expects($self->never())->method('andWhere');
+                $qb->expects($self->once())->method('setParameters')->with(array());
+            })
+            ->getPager(array(), 1);
+    }
+
+    public function testGetPagerWithEnabledSnapshots()
+    {
+        $self = $this;
+        $this
+            ->getSnapshotManager(function ($qb) use ($self) {
+                $qb->expects($self->once())->method('andWhere')->with($self->equalTo('s.enabled = :enabled'));
+                $qb->expects($self->once())->method('setParameters')->with($self->equalTo(array('enabled' => true)));
+            })
+            ->getPager(array('enabled' => true), 1);
+    }
+
+    public function testGetPagerWithDisabledSnapshots()
+    {
+        $self = $this;
+        $this
+            ->getSnapshotManager(function ($qb) use ($self) {
+                $qb->expects($self->once())->method('andWhere')->with($self->equalTo('s.enabled = :enabled'));
+                $qb->expects($self->once())->method('setParameters')->with($self->equalTo(array('enabled' => false)));
+            })
+            ->getPager(array('enabled' => false), 1);
+    }
+
+    public function testGetPagerWithRootSnapshots()
+    {
+        $self = $this;
+        $this
+            ->getSnapshotManager(function ($qb) use ($self) {
+                $qb->expects($self->once())->method('andWhere')->with($self->equalTo('s.parent IS NULL'));
+            })
+            ->getPager(array('root' => true), 1);
+    }
+
+    public function testGetPagerWithNonRootSnapshots()
+    {
+        $self = $this;
+        $this
+            ->getSnapshotManager(function ($qb) use ($self) {
+                $qb->expects($self->once())->method('andWhere')->with($self->equalTo('s.parent IS NOT NULL'));
+            })
+            ->getPager(array('root' => false), 1);
+    }
+
+    public function testGetPagerWithParentChildSnapshots()
+    {
+        $self = $this;
+        $this
+            ->getSnapshotManager(function ($qb) use ($self) {
+                $qb->expects($self->once())->method('join')->with(
+                    $self->equalTo('s.parent'),
+                    $self->equalTo('pa')
+                );
+                $qb->expects($self->once())->method('andWhere')->with($self->equalTo('pa.id = :parentId'));
+                $qb->expects($self->once())->method('setParameters')->with($self->equalTo(array('parentId' => 13)));
+            })
+            ->getPager(array('parent' => 13), 1);
+    }
+
+    public function testGetPagerWithSiteSnapshots()
+    {
+        $self = $this;
+        $this
+            ->getSnapshotManager(function ($qb) use ($self) {
+                $qb->expects($self->once())->method('join')->with(
+                    $self->equalTo('s.site'),
+                    $self->equalTo('si')
+                );
+                $qb->expects($self->once())->method('andWhere')->with($self->equalTo('si.id = :siteId'));
+                $qb->expects($self->once())->method('setParameters')->with($self->equalTo(array('siteId' => 13)));
+            })
+            ->getPager(array('site' => 13), 1);
+    }
+}


### PR DESCRIPTION
New API for snapshots with new routes : 
 * sonata_api_snapshot_get_snapshots    GET        /api/page/snapshots.{_format}                                                                                   
 * sonata_api_snapshot_get_snapshot      GET        /api/page/snapshots/{id}.{_format}                                                                                
 * sonata_api_snapshot_delete_snapshot DELETE  /api/page/snapshots/{id}.{_format} 

There is already a routes to generate a snapshot of a page
* sonata_api_page_post_pages_snapshots POST /api/page/pages/snapshots.{_format}