### PR TITLE
Add PostSiteAction and fixe PutSiteAction methodes

### DIFF
--- a/Controller/Api/SiteController.php
+++ b/Controller/Api/SiteController.php
@@ -121,13 +121,36 @@ class SiteController
     }
 
     /**
+     * Adds a site
+     *
+     * @ApiDoc(
+     *  input={"class"="sonata_page_api_form_site", "name"="", "groups"={"sonata_api_write"}},
+     *  output={"class"="Sonata\PageBundle\Model\Site", "groups"={"sonata_api_read"}},
+     *  statusCodes={
+     *      200="Returned when successful",
+     *      400="Returned when an error has occurred while site creation"
+     *  }
+     * )
+     *
+     * @param Request $request A Symfony request
+     *
+     * @return SiteInterface
+     *
+     * @throws NotFoundHttpException
+     */
+    public function postSiteAction(Request $request)
+    {
+        return $this->handleWriteSite($request);
+    }
+
+    /**
      * Updates a site
      *
      * @ApiDoc(
      *  requirements={
      *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="site id"},
      *  },
-     *  input={"class"="sonata_page_api_form_block", "name"="", "groups"={"sonata_api_write"}},
+     *  input={"class"="sonata_page_api_form_site", "name"="", "groups"={"sonata_api_write"}},
      *  output={"class"="Sonata\PageBundle\Model\Site", "groups"={"sonata_api_read"}},
      *  statusCodes={
      *      200="Returned when successful",
@@ -145,29 +168,7 @@ class SiteController
      */
     public function putSiteAction($id, Request $request)
     {
-        $site = $id ? $this->getSite($id) : null;
-
-        $form = $this->formFactory->createNamed(null, 'sonata_page_api_form_site', $site, array(
-            'csrf_protection' => false,
-        ));
-
-        $form->bind($request);
-
-        if ($form->isValid()) {
-            $site = $form->getData();
-
-            $this->siteManager->save($site);
-
-            $view = FOSRestView::create($site);
-            $serializationContext = SerializationContext::create();
-            $serializationContext->setGroups(array('sonata_api_read'));
-            $serializationContext->enableMaxDepthChecks();
-            $view->setSerializationContext($serializationContext);
-
-            return $view;
-        }
-
-        return $form;
+        return $this->handleWriteSite($request, $id);
     }
 
     /**
@@ -217,5 +218,40 @@ class SiteController
         }
 
         return $site;
+    }
+
+    /**
+     * Write a site, this method is used by both POST and PUT action methods
+     *
+     * @param Request      $request Symfony request
+     * @param integer|null $id      A post identifier
+     *
+     * @return FormInterface
+     */
+    protected function handleWriteSite($request, $id = null)
+    {
+        $site = $id ? $this->getSite($id) : null;
+
+        $form = $this->formFactory->createNamed(null, 'sonata_page_api_form_site', $site, array(
+            'csrf_protection' => false,
+        ));
+
+        $form->bind($request);
+
+        if ($form->isValid()) {
+            $site = $form->getData();
+
+            $this->siteManager->save($site);
+
+            $view = FOSRestView::create($site);
+            $serializationContext = SerializationContext::create();
+            $serializationContext->setGroups(array('sonata_api_read'));
+            $serializationContext->enableMaxDepthChecks();
+            $view->setSerializationContext($serializationContext);
+
+            return $view;
+        }
+
+        return $form;
     }
 }

--- a/Resources/config/api_form.xml
+++ b/Resources/config/api_form.xml
@@ -5,6 +5,17 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
+
+        <service id="sonata.page.api.form.type.site" class="Sonata\CoreBundle\Form\Type\DoctrineORMSerializationType">
+            <tag name="form.type" alias="sonata_page_api_form_site" />
+
+            <argument type="service" id="jms_serializer.metadata_factory" />
+            <argument type="service" id="doctrine" />
+            <argument>sonata_page_api_form_site</argument>
+            <argument>%sonata.page.admin.site.entity%</argument>
+            <argument>sonata_api_write</argument>
+        </service>
+
         <service id="sonata.page.api.form.type.page" class="Sonata\CoreBundle\Form\Type\DoctrineORMSerializationType">
             <tag name="form.type" alias="sonata_page_api_form_page" />
 

--- a/Tests/Controller/Api/SiteControllerTest.php
+++ b/Tests/Controller/Api/SiteControllerTest.php
@@ -12,6 +12,7 @@
 namespace Sonata\Test\PageBundle\Controller\Api;
 
 use Sonata\PageBundle\Controller\Api\SiteController;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Class SiteControllerTest
@@ -49,6 +50,84 @@ class SiteControllerTest extends \PHPUnit_Framework_TestCase
     public function testGetSiteActionNotFoundException()
     {
         $this->createSiteController()->getSiteAction(1);
+    }
+
+    public function testPostSiteAction()
+    {
+        $site = $this->getMock('Sonata\PageBundle\Model\SiteInterface');
+
+        $siteManager = $this->getMock('Sonata\PageBundle\Model\SiteManagerInterface');
+        $siteManager->expects($this->once())->method('save')->will($this->returnValue($site));
+
+        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form->expects($this->once())->method('bind');
+        $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
+        $form->expects($this->once())->method('getData')->will($this->returnValue($site));
+
+        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
+
+        $view = $this->createSiteController(null, $siteManager, $formFactory)->postSiteAction(new Request());
+
+        $this->assertInstanceOf('FOS\RestBundle\View\View', $view);
+    }
+
+    public function testPostSiteInvalidAction()
+    {
+        $site = $this->getMock('Sonata\PageBundle\Model\SiteInterface');
+
+        $siteManager = $this->getMock('Sonata\PageBundle\Model\SiteManagerInterface');
+        $siteManager->expects($this->never())->method('save')->will($this->returnValue($site));
+
+        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form->expects($this->once())->method('bind');
+        $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
+
+        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
+
+        $view = $this->createSiteController(null, $siteManager, $formFactory)->postSiteAction(new Request());
+
+        $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $view);
+    }
+
+    public function testPutSiteAction()
+    {
+        $site = $this->getMock('Sonata\PageBundle\Model\SiteInterface');
+
+        $siteManager = $this->getMock('Sonata\PageBundle\Model\SiteManagerInterface');
+        $siteManager->expects($this->once())->method('save')->will($this->returnValue($site));
+
+        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form->expects($this->once())->method('bind');
+        $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
+        $form->expects($this->once())->method('getData')->will($this->returnValue($site));
+
+        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
+
+        $view = $this->createSiteController($site, $siteManager, $formFactory)->putSiteAction(1, new Request());
+
+        $this->assertInstanceOf('FOS\RestBundle\View\View', $view);
+    }
+
+    public function testPutSiteInvalidAction()
+    {
+        $site = $this->getMock('Sonata\PageBundle\Model\SiteInterface');
+
+        $siteManager = $this->getMock('Sonata\PageBundle\Model\SiteManagerInterface');
+        $siteManager->expects($this->never())->method('save')->will($this->returnValue($site));
+
+        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form->expects($this->once())->method('bind');
+        $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
+
+        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
+
+        $view = $this->createSiteController($site, $siteManager, $formFactory)->putSiteAction(1, new Request());
+
+        $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $view);
     }
 
     public function testDeleteSiteAction()

--- a/Tests/Controller/Api/SiteControllerTest.php
+++ b/Tests/Controller/Api/SiteControllerTest.php
@@ -1,0 +1,97 @@
+<?php
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+
+namespace Sonata\Test\PageBundle\Controller\Api;
+
+use Sonata\PageBundle\Controller\Api\SiteController;
+
+/**
+ * Class SiteControllerTest
+ *
+ * @package Sonata\Test\PageBundle\Controller\Api
+ *
+ * @author Benoit de Jacobet <benoit.de-jacobet@ekino.com>
+ */
+class SiteControllerTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function testGetSitesAction()
+    {
+        $siteManager = $this->getMock('Sonata\PageBundle\Model\SiteManagerInterface');
+        $siteManager->expects($this->once())->method('getPager')->will($this->returnValue(array()));
+
+        $paramFetcher = $this->getMock('FOS\RestBundle\Request\ParamFetcherInterface');
+        $paramFetcher->expects($this->exactly(2))->method('get');
+        $paramFetcher->expects($this->once())->method('all')->will($this->returnValue(array()));
+
+        $this->assertEquals(array(), $this->createSiteController(null, $siteManager)->getSitesAction($paramFetcher));
+    }
+
+    public function testGetSiteAction()
+    {
+        $site = $this->getMock('Sonata\PageBundle\Model\SiteInterface');
+
+        $this->assertEquals($site, $this->createSiteController($site)->getSiteAction(1));
+    }
+
+    /**
+     * @expectedException        \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     * @expectedExceptionMessage Site (1) not found
+     */
+    public function testGetSiteActionNotFoundException()
+    {
+        $this->createSiteController()->getSiteAction(1);
+    }
+
+    public function testDeleteSiteAction()
+    {
+        $site = $this->getMock('Sonata\PageBundle\Model\SiteInterface');
+
+        $siteManager = $this->getMock('Sonata\PageBundle\Model\SiteManagerInterface');
+        $siteManager->expects($this->once())->method('delete');
+
+        $view = $this->createSiteController($site, $siteManager)->deleteSiteAction(1);
+
+        $this->assertEquals(array('deleted' => true), $view);
+    }
+
+    public function testDeleteSiteInvalidAction()
+    {
+        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
+
+        $siteManager = $this->getMock('Sonata\PageBundle\Model\SiteManagerInterface');
+        $siteManager->expects($this->never())->method('delete');
+
+        $this->createSiteController(null, $siteManager)->deleteSiteAction(1);
+    }
+
+    /**
+     * @param $site
+     * @param $siteManager
+     * @param $formFactory
+     *
+     * @return SiteController
+     */
+    public function createSiteController($site = null, $siteManager = null, $formFactory = null)
+    {
+        if (null === $siteManager) {
+            $siteManager = $this->getMock('Sonata\PageBundle\Model\SiteManagerInterface');
+        }
+        if (null !== $site) {
+            $siteManager->expects($this->once())->method('findOneBy')->will($this->returnValue($site));
+        }
+        if (null === $formFactory) {
+            $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        }
+
+        return new SiteController($siteManager, $formFactory);
+    }
+}


### PR DESCRIPTION
new route to create a site
*  sonata_api_site_post_site POST /api/page/sites.{_format}
                                                                                       
fixe update a site with the route
*  sonata_api_site_put_site PUT /api/page/sites/{id}.{_format} 

Add unit tests