### PR TITLE
Api page fixes

### DIFF
--- a/Resources/config/serializer/Model.Page.xml
+++ b/Resources/config/serializer/Model.Page.xml
@@ -21,8 +21,8 @@
 
         <property name="routeName"     type="string"  expose="true" since-version="1.0" groups="sonata_api_read,sonata_search" />
         <property name="edited"        type="boolean" expose="true" since-version="1.0" groups="sonata_api_read,sonata_search" />
-        <property name="slug"          type="string"  expose="true" since-version="1.0" groups="sonata_api_read,sonata_search" />
-        <property name="customUrl"     type="string"  expose="true" since-version="1.0" groups="sonata_api_read,sonata_search" />
+        <property name="slug"          type="string"  expose="true" since-version="1.0" groups="sonata_api_read,sonata_api_write,sonata_search" />
+        <property name="customUrl"     type="string"  expose="true" since-version="1.0" groups="sonata_api_read,sonata_api_write,sonata_search" />
         <property name="requestMethod" type="string"  expose="true" since-version="1.0" groups="sonata_api_read,sonata_search" />
 
         <property name="parent" serialized-name="parent_id" type="sonata_page_page_id" expose="true" since-version="1.0" groups="sonata_api_read,sonata_api_write,sonata_search" />

--- a/Resources/config/validation.xml
+++ b/Resources/config/validation.xml
@@ -30,6 +30,18 @@
            <constraint name="NotNull" />
         </property>
     </class>
+
+    <class name="Sonata\PageBundle\Model\Page">
+        <property name="name">
+            <constraint name="NotNull" />
+        </property>
+        <property name="position">
+            <constraint name="NotNull" />
+        </property>
+        <property name="templateCode">
+            <constraint name="NotNull" />
+        </property>
+    </class>
 </constraint-mapping>
 
 


### PR DESCRIPTION
* add validations to api form of page for properties that can not be null
* add the group " sonata_api_write " properties " slug " and " customUrl " of the page to make them editable