### PR TITLE
Fix SnapshotManager enableSnapshots method to correctly end all previous snapshots

### DIFF
--- a/Entity/SnapshotManager.php
+++ b/Entity/SnapshotManager.php
@@ -63,19 +63,20 @@ class SnapshotManager extends BaseEntityManager implements SnapshotManagerInterf
     /**
      * {@inheritdoc}
      */
-    public function enableSnapshots(array $snapshots)
+    public function enableSnapshots(array $snapshots, \DateTime $date = null)
     {
         if (count($snapshots) == 0) {
             return;
         }
 
-        $now = new \DateTime;
+        $date = $date ?: new \DateTime();
         $pageIds = $snapshotIds = array();
+
         foreach ($snapshots as $snapshot) {
             $pageIds[]     = $snapshot->getPage()->getId();
             $snapshotIds[] = $snapshot->getId();
 
-            $snapshot->setPublicationDateStart($now);
+            $snapshot->setPublicationDateStart($date);
             $snapshot->setPublicationDateEnd(null);
 
             $this->getEntityManager()->persist($snapshot);
@@ -83,9 +84,9 @@ class SnapshotManager extends BaseEntityManager implements SnapshotManagerInterf
 
         $this->getEntityManager()->flush();
         //@todo: strange sql and low-level pdo usage: use dql or qb
-        $sql = sprintf("UPDATE %s SET publication_date_end = '%s' WHERE id NOT IN(%s) AND page_id IN (%s) AND publication_date_end IS NULL",
+        $sql = sprintf("UPDATE %s SET publication_date_end = '%s' WHERE id NOT IN(%s) AND page_id IN (%s)",
             $this->getTableName(),
-            $now->format('Y-m-d H:i:s'),
+            $date->format('Y-m-d H:i:s'),
             implode(',', $snapshotIds),
             implode(',', $pageIds)
         );

--- a/Model/SnapshotManagerInterface.php
+++ b/Model/SnapshotManagerInterface.php
@@ -28,9 +28,10 @@ interface SnapshotManagerInterface extends ManagerInterface, PageableManagerInte
     function findEnableSnapshot(array $criteria);
 
     /**
-     * @param array $snapshots
+     * @param array          $snapshots A snapshots array to enable
+     * @param \DateTime|null $date      A date instance
      */
-    function enableSnapshots(array $snapshots);
+    function enableSnapshots(array $snapshots, \DateTime $date = null);
 
     /**
      * Cleanups the deprecated snapshots

--- a/Tests/Entity/Snapshot.php
+++ b/Tests/Entity/Snapshot.php
@@ -1,0 +1,31 @@
+<?php
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\PageBundle\Tests\Entity;
+
+use Sonata\PageBundle\Entity\BaseSnapshot;
+
+class Snapshot extends BaseSnapshot
+{
+    /**
+     * @var integer $id
+     */
+    protected $id;
+
+    /**
+     * Get id
+     *
+     * @return integer $id
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+}

--- a/Tests/Entity/SnapshotManagerTest.php
+++ b/Tests/Entity/SnapshotManagerTest.php
@@ -127,4 +127,80 @@ class SnapshotManagerTest extends \PHPUnit_Framework_TestCase
             })
             ->getPager(array('site' => 13), 1);
     }
+
+    /**
+     * Tests the enableSnapshots() method to ensure execute queries are correct
+     */
+    public function testEnableSnapshots()
+    {
+        // Given
+        $page = $this->getMock('Sonata\PageBundle\Model\PageInterface');
+        $page->expects($this->once())->method('getId')->will($this->returnValue(456));
+
+        $snapshot = $this->getMock('Sonata\PageBundle\Tests\Entity\Snapshot');
+        $snapshot->expects($this->once())->method('getId')->will($this->returnValue(123));
+        $snapshot->expects($this->once())->method('getPage')->will($this->returnValue($page));
+
+        $connection = $this->getMockBuilder('Doctrine\DBAL\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $date = new \DateTime();
+
+        $connection
+            ->expects($this->once())
+            ->method('query')
+            ->with(sprintf("UPDATE page_snapshot SET publication_date_end = '%s' WHERE id NOT IN(123) AND page_id IN (456)", $date->format('Y-m-d H:i:s')));
+
+        $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $em->expects($this->once())->method('persist')->with($snapshot);
+        $em->expects($this->once())->method('flush');
+        $em->expects($this->once())->method('getConnection')->will($this->returnValue($connection));
+
+        $manager  = $this->getMockBuilder('Sonata\PageBundle\Entity\SnapshotManager')
+            ->disableOriginalConstructor()
+            ->setMethods(array('getEntityManager', 'getTableName'))
+            ->getMock();
+
+        $manager->expects($this->exactly(3))->method('getEntityManager')->will($this->returnValue($em));
+        $manager->expects($this->once())->method('getTableName')->will($this->returnValue('page_snapshot'));
+
+        // When calling method, expects calls
+        $manager->enableSnapshots(array($snapshot), $date);
+    }
+
+    /**
+     * Tests the enableSnapshots() method to ensure execute queries are not executed when no snapshots are given
+     */
+    public function testEnableSnapshotsWhenNoSnapshots()
+    {
+        // Given
+        $connection = $this->getMockBuilder('Doctrine\DBAL\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $connection->expects($this->never())->method('query');
+
+        $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $em->expects($this->never())->method('persist');
+        $em->expects($this->never())->method('flush');
+        $em->expects($this->never())->method('getConnection');
+
+        $manager  = $this->getMockBuilder('Sonata\PageBundle\Entity\SnapshotManager')
+            ->disableOriginalConstructor()
+            ->setMethods(array('getEntityManager', 'getTableName'))
+            ->getMock();
+
+        $manager->expects($this->never())->method('getEntityManager');
+        $manager->expects($this->never())->method('getTableName');
+
+        // When calling method, do not expects any calls
+        $manager->enableSnapshots(array());
+    }
 }


### PR DESCRIPTION
Currently, `SnapshotManager::enableSnapshots()` method is setting the actual date to all page snapshots that are not the current one (we just created) AND where the end publication date is null which is not correct as there are snapshots with an end date already set.

This can result in multiple active snapshots for a single page, which is not correct.

See actual query:

```php
UPDATE %s SET publication_date_end = '%s' WHERE id NOT IN(%s) AND page_id IN (%s) AND publication_date_end IS NULL
```

Main goal of this PR is to remove this part: `AND publication_date_end IS NULL`.

I've also added a second optional parameter to `enableSnapshots()` method with a date (mostly to unit test the date passed to the executed SQL query), but it also could be helpful if someone needs to enable snapshots after a given date.