### PR TITLE
Keep exception context in ExceptionListener

### DIFF
--- a/Listener/ExceptionListener.php
+++ b/Listener/ExceptionListener.php
@@ -287,9 +287,9 @@ class ExceptionListener
 
         if (null !== $this->logger) {
             if (!$originalException instanceof HttpExceptionInterface || $originalException->getStatusCode() >= 500) {
-                $this->logger->crit($message);
+                $this->logger->crit($message, array( 'exception' => $originalException ));
             } else {
-                $this->logger->err($message);
+                $this->logger->err($message, array( 'exception' => $originalException ));
             }
         } else {
             error_log($message);


### PR DESCRIPTION
When using the Monolog fingers_crossed handler with "excluded_404s", the context must passed to ignore the configured routes.