### PR TITLE
Add blockId options to setDefaultSettings()

### DIFF
--- a/Block/SharedBlockBlockService.php
+++ b/Block/SharedBlockBlockService.php
@@ -167,7 +167,8 @@ class SharedBlockBlockService extends BaseBlockService
     public function setDefaultSettings(OptionsResolverInterface $resolver)
     {
         $resolver->setDefaults(array(
-            'template' => 'SonataPageBundle:Block:block_shared_block.html.twig'
+            'template' => 'SonataPageBundle:Block:block_shared_block.html.twig',
+            'blockId' => null // prevent error when adding shared block to page
         ));
     }
 


### PR DESCRIPTION
Adding shared block to page is now returning error without this fix.