### PR TITLE
Failed to create object: AppBundle\Entity\Site 

### DIFF
--- a/Resources/config/validation.xml
+++ b/Resources/config/validation.xml
@@ -36,6 +36,10 @@
         <property name="name">
            <constraint name="NotNull" />
         </property>
+
+        <property name="host">
+            <constraint name="NotNull" />
+        </property>
     </class>
 </constraint-mapping>
 


### PR DESCRIPTION
[2/4] PDOException: SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'host' cannot be null