### PR TITLE
Add documentation for JMS Serializer and DatagridBundle

### DIFF
--- a/Resources/doc/reference/api.rst
+++ b/Resources/doc/reference/api.rst
@@ -32,6 +32,12 @@ Here's the configuration we used, you may adapt it to your needs:
 
     twig:
         exception_controller: 'FOS\RestBundle\Controller\ExceptionController::showAction'
+    
+    # for SonataPageBundle > 2.3.6    
+    jms_serializer:
+        metadata:
+            directories:
+                - { path: %kernel.root_dir%/../vendor/sonata-project/datagrid-bundle/Resources/config/serializer, namespace_prefix: 'Sonata\DatagridBundle' }
 
 In order to activate the API's, you'll also need to add this to your routing:
 


### PR DESCRIPTION
`SonataPageBundle` uses `Pager` class from `DatagridBundle`. In order to have correct serialized output this config should be added to `config.yml` (copied from [config](https://github.com/sonata-project/sandbox/blob/2.3/app/config/config.yml) of Sonata Project sandbox)

Fixes https://github.com/sonata-project/SonataPageBundle/issues/510