### PR TITLE
[ADD] Customizable templates for sonata page controller

### DIFF
--- a/Controller/PageAdminController.php
+++ b/Controller/PageAdminController.php
@@ -94,7 +94,7 @@ class PageAdminController extends Controller
 
         $this->get('twig')->getExtension('form')->renderer->setTheme($formView, $this->admin->getFilterTheme());
 
-        return $this->render('SonataPageBundle:PageAdmin:tree.html.twig', array(
+        return $this->render($this->admin->getTemplate('tree'), array(
             'action'      => 'tree',
             'sites'       => $sites,
             'currentSite' => $currentSite,
@@ -131,7 +131,7 @@ class PageAdminController extends Controller
                 $current = false;
             }
 
-            return $this->render('SonataPageBundle:PageAdmin:select_site.html.twig', array(
+            return $this->render($this->admin->getTemplate('select_site'), array(
                 'sites'   => $sites,
                 'current' => $current,
             ));
@@ -207,7 +207,7 @@ class PageAdminController extends Controller
 
         $csrfProvider = $this->get('form.csrf_provider');
 
-        return $this->render('SonataPageBundle:PageAdmin:compose.html.twig', array(
+        return $this->render($this->admin->getTemplate('compose'), array(
             'object'           => $page,
             'action'           => 'edit',
             'template'         => $template,
@@ -240,7 +240,7 @@ class PageAdminController extends Controller
 
         $blockServices = $this->get('sonata.block.manager')->getServicesByContext('sonata_page_bundle', false);
 
-        return $this->render('SonataPageBundle:PageAdmin:compose_container_show.html.twig', array(
+        return $this->render($this->admin->getTemplate('compose_container_show'), array(
             'blockServices' => $blockServices,
             'container'     => $block,
             'page'          => $block->getPage(),

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -184,6 +184,17 @@ class Configuration implements ConfigurationInterface
                 ->end()
             ->end()
 
+            ->arrayNode('templates_admin')
+                ->addDefaultsIfNotSet()
+                ->children()
+                    ->scalarNode('list')->defaultValue('SonataPageBundle:PageAdmin:list.html.twig')->cannotBeEmpty()->end()
+                    ->scalarNode('tree')->defaultValue('SonataPageBundle:PageAdmin:tree.html.twig')->cannotBeEmpty()->end()
+                    ->scalarNode('compose')->defaultValue('SonataPageBundle:PageAdmin:compose.html.twig')->cannotBeEmpty()->end()
+                    ->scalarNode('compose_container_show')->defaultValue('SonataPageBundle:PageAdmin:compose_container_show.html.twig')->cannotBeEmpty()->end()
+                    ->scalarNode('select_site')->defaultValue('SonataPageBundle:PageAdmin:select_site.html.twig')->cannotBeEmpty()->end()
+                ->end()
+            ->end()
+
             ->arrayNode('page_defaults')
                 ->useAttributeAsKey('id')
                 ->prototype('array')

--- a/DependencyInjection/SonataPageExtension.php
+++ b/DependencyInjection/SonataPageExtension.php
@@ -67,6 +67,7 @@ class SonataPageExtension extends Extension
         $this->configureMultisite($container, $config);
         $this->configureCache($container, $config);
         $this->configureTemplates($container, $config);
+        $this->configureTemplatesAdmin($container, $config);
         $this->configureExceptions($container, $config);
         $this->configurePageDefaults($container, $config);
         $this->configurePageServices($container, $config);
@@ -402,6 +403,21 @@ class SonataPageExtension extends Extension
 
         // set default template
         $templateManager->addMethodCall('setDefaultTemplateCode', array($config['default_template']));
+    }
+
+    /**
+     * Configure the page admin templates.
+     *
+     * @param ContainerBuilder $container Container builder
+     * @param array            $config    Array of configuration
+     */
+    public function configureTemplatesAdmin(ContainerBuilder $container, array $config)
+    {
+        $templateManager = $container->getDefinition('sonata.page.admin.page');
+
+        $definitions = $config['templates_admin'];
+
+        $templateManager->addMethodCall('setTemplates', array($definitions));
     }
 
     /**

--- a/Resources/config/admin.xml
+++ b/Resources/config/admin.xml
@@ -60,12 +60,6 @@
             <call method="setTranslationDomain">
                 <argument>%sonata.page.admin.page.translation_domain%</argument>
             </call>
-
-            <call method="setTemplates">
-                <argument type="collection">
-                    <argument key="list">SonataPageBundle:PageAdmin:list.html.twig</argument>
-                </argument>
-            </call>
         </service>
 
         <service id="sonata.page.admin.block" class="%sonata.page.admin.block.class%">

--- a/Resources/doc/reference/advanced_configuration.rst
+++ b/Resources/doc/reference/advanced_configuration.rst
@@ -50,6 +50,13 @@ Full configuration options (config.yml file):
         templates:
             default: { path: 'SonataPageBundle::layout.html.twig', name: 'default' }
 
+        templates_admin:
+            list:                       SonataPageBundle:PageAdmin:list.html.twig
+            tree:                       SonataPageBundle:PageAdmin:tree.html.twig
+            compose:                    SonataPageBundle:PageAdmin:compose.html.twig
+            compose_container_show:     SonataPageBundle:PageAdmin:compose_container_show.html.twig
+            select_site:                SonataPageBundle:PageAdmin:select_site.html.twig
+
         # Assets loaded by default in template
         assets:
             stylesheets:

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -61,6 +61,13 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                     ),
                 ),
             ),
+            'templates_admin' => array(
+                'tree'                   => 'SonataPageBundle:PageAdmin:tree.html.twig',
+                'list'                   => 'SonataPageBundle:PageAdmin:list.html.twig',
+                'compose'                => 'SonataPageBundle:PageAdmin:compose.html.twig',
+                'select_site'            => 'SonataPageBundle:PageAdmin:select_site.html.twig',
+                'compose_container_show' => 'SonataPageBundle:PageAdmin:compose_container_show.html.twig',
+            ),
             'assets' => array(
                 'stylesheets' => array(
                     'bundles/sonataadmin/vendor/bootstrap/dist/css/bootstrap.min.css',
@@ -137,6 +144,13 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                     'name'       => 'default',
                     'containers' => array(),
                 ),
+            ),
+            'templates_admin' => array(
+                'tree'                   => 'SonataPageBundle:PageAdmin:tree.html.twig',
+                'list'                   => 'SonataPageBundle:PageAdmin:list.html.twig',
+                'compose'                => 'SonataPageBundle:PageAdmin:compose.html.twig',
+                'select_site'            => 'SonataPageBundle:PageAdmin:select_site.html.twig',
+                'compose_container_show' => 'SonataPageBundle:PageAdmin:compose_container_show.html.twig',
             ),
             'assets' => array(
                 'stylesheets' => array(


### PR DESCRIPTION
Add flexibility for extend templates (available since 2.3.10)