### PR TITLE
Fix composer preview

### DIFF
--- a/Resources/views/BlockAdmin/compose_preview.html.twig
+++ b/Resources/views/BlockAdmin/compose_preview.html.twig
@@ -28,7 +28,7 @@
         <div class="page-composer__container__child__switch-enabled"
              data-label-enable="{{ ('composer.enable'|trans({}, 'SonataPageBundle') ~ ' <i class="fa fa-toggle-on"></i>')|e }}"
              data-label-disable="{{ ('composer.disable'|trans({}, 'SonataPageBundle') ~ ' <i class="fa fa-toggle-off"></i>')|e }}">
-            <a class="badge bg-{{ child.enabled ? 'yellow' : 'green' }}" href="{{ url('sonata_admin_set_object_field_value', {'objectId': child.id, 'context': 'list', 'field': 'enabled', 'code': 'sonata.page.admin.block', 'value': not child.enabled|default('0') }) }}">{% if child.enabled %}{{ 'composer.disable'|trans({}, 'SonataPageBundle') }} <i class="fa fa-toggle-off"></i>{% else %}{{ 'composer.enable'|trans({}, 'SonataPageBundle') }} <i class="fa fa-toggle-on"></i>{% endif %}</a>
+            <a class="badge bg-{{ child.enabled ? 'yellow' : 'green' }}" href="{{ path('sonata_admin_set_object_field_value', {'objectId': child.id, 'context': 'list', 'field': 'enabled', 'code': 'sonata.page.admin.block', 'value': not child.enabled|default('0') }) }}">{% if child.enabled %}{{ 'composer.disable'|trans({}, 'SonataPageBundle') }} <i class="fa fa-toggle-off"></i>{% else %}{{ 'composer.enable'|trans({}, 'SonataPageBundle') }} <i class="fa fa-toggle-on"></i>{% endif %}</a>
         </div>
 
         <div class="page-composer__container__child__enabled">


### PR DESCRIPTION
By replacing in twig `url` with `path` we allow user to use the protocol https (because path doesn't render the protocol, so it's the one currently used)