### PR TITLE
BlockAdmin template chooser

### DIFF
--- a/Resources/config/admin.xml
+++ b/Resources/config/admin.xml
@@ -73,6 +73,7 @@
             <argument />
             <argument>%sonata.page.admin.block.entity%</argument>
             <argument>%sonata.page.admin.block.controller%</argument>
+            <argument>%sonata_block.blocks%</argument>
 
             <call method="setCacheManager">
                 <argument type="service" id="sonata.cache.manager" />

--- a/Resources/doc/reference/page_composer.rst
+++ b/Resources/doc/reference/page_composer.rst
@@ -79,6 +79,19 @@ Configure
                   B: content_bottom
                   F: footer
 
+Template chooser
+^^^^^^^^^^^^^^^^
+
+If you have added some custom templates to a block for the ``SonataBlockBundle`` you get a template chooser.
+
+.. code-block:: yaml
+
+   sonata_block:
+          acme.demo.block.demo:
+              templates:
+                 - { name: 'Simple', template: 'AcmeDemoBundle:Block:demo_simple.html.twig' }
+                 - { name: 'Big',    template: 'AcmeDemoBundle:Block:demo_big.html.twig' }
+
 Javascript
 ----------
 


### PR DESCRIPTION
Added an optional template chooser to the block admin, where the original template is shown as _default_. If only one template is available no template chooser is visible. 

Before:
![bildschirmfoto 2015-11-07 um 16 41 24](https://cloud.githubusercontent.com/assets/3440437/11015856/6c9a7bfc-856e-11e5-82e4-5989ff016598.PNG)

After:
![bildschirmfoto 2015-11-07 um 16 41 01](https://cloud.githubusercontent.com/assets/3440437/11015855/6c98e09e-856e-11e5-8fac-a7270791f7ba.PNG)

```yaml
# config.yml
sonata_block:    
    blocks:
        core23.project.block.projects:
            templates:
              - { name: 'Custom', template: 'Core23ProjectBundle:Block:block_projects_custom.html.twig' }
              - { name: 'Foo', template: 'Core23ProjectBundle:Block:block_projects_foo.html.twig' }
```

This PR adds the missing template list to blocks https://github.com/sonata-project/SonataBlockBundle/pull/237 