### PR TITLE
[FIX] Missing block translation in composer

### DIFF
--- a/Resources/views/PageAdmin/compose_container_show.html.twig
+++ b/Resources/views/PageAdmin/compose_container_show.html.twig
@@ -9,7 +9,7 @@
         <label>{{ 'composer.block.add.type'|trans({}, 'SonataPageBundle') }}</label>
         <select class="page-composer__block-type-selector__select" style="width: auto">
             {% for blockServiceId, blockService in blockServices %}
-                <option value="{{ blockServiceId }}">{{ blockService.name }}</option>
+                <option value="{{ blockServiceId }}">{{ blockService.blockMetadata.title|trans({}, blockService.blockMetadata.domain|default('SonataPageBundle')) }}</option>
             {% endfor %}
         </select>
         <a class="btn btn-action btn-small page-composer__block-type-selector__confirm"


### PR DESCRIPTION
The block translation is missing for the type chooser

![bildschirmfoto 2015-11-08 um 11 17 10](https://cloud.githubusercontent.com/assets/3440437/11019794/50633928-860a-11e5-846e-81cfea8c7c51.PNG)
