### PR TITLE
Assets: Removed sourceMap generation

### DIFF
--- a/Resources/assets_src/gulp/tasks/css.js
+++ b/Resources/assets_src/gulp/tasks/css.js
@@ -17,7 +17,8 @@ gulp.task('css', _.map(config.groups.css, function (files, name) {
                 // isolate each group files
                 // because the plugin puts all
                 // generated css in a single tmp dir
-                container: name
+                container: name,
+                "sourcemap=none": true
             }))
             .pipe(concat('sonata-page.' + name + '.css'))
             .pipe(banner())


### PR DESCRIPTION
Fixes https://github.com/sonata-project/SonataPageBundle/pull/569

It's an issue in the ruby-sass plugin (https://github.com/sindresorhus/gulp-ruby-sass/issues/156) which will be fixed in the 1.0 release of the plugin.