### PR TITLE
Added new BlockService to list all pages

### DIFF
--- a/Block/PageListBlockService.php
+++ b/Block/PageListBlockService.php
@@ -1,0 +1,111 @@
+<?php
+
+/*
+ * This file is part of the Sonata project.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\PageBundle\Block;
+
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\BlockBundle\Block\BaseBlockService;
+use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\CoreBundle\Model\Metadata;
+use Sonata\PageBundle\Model\Page;
+use Sonata\PageBundle\Model\PageManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class PageListBlockService extends BaseBlockService
+{
+    /**
+     * @var PageManagerInterface
+     */
+    protected $pageManager;
+
+    /**
+     * @param string               $name
+     * @param EngineInterface      $templating
+     * @param PageManagerInterface $pageManager
+     */
+    public function __construct($name, EngineInterface $templating, PageManagerInterface $pageManager)
+    {
+        parent::__construct($name, $templating);
+
+        $this->pageManager = $pageManager;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildEditForm(FormMapper $formMapper, BlockInterface $block)
+    {
+        $formMapper->add('settings', 'sonata_type_immutable_array', array(
+            'keys' => array(
+                array('title', 'text', array(
+                    'label'    => 'form.label_title',
+                    'required' => false,
+                )),
+                array('mode', 'choice', array(
+                    'label'   => 'form.label_mode',
+                    'choices' => array(
+                        'public' => 'form.choice_public',
+                        'admin'  => 'form.choice_admin',
+                    ),
+                )),
+            ),
+            'translation_domain' => 'SonataPageBundle',
+        ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function execute(BlockContextInterface $blockContext, Response $response = null)
+    {
+        $pageList = $this->pageManager->findBy(array(
+            'routeName' => Page::PAGE_ROUTE_CMS_NAME,
+        ));
+
+        $systemElements = $this->pageManager->findBy(array(
+            'url'    => null,
+            'parent' => null,
+        ));
+
+        return $this->renderResponse($blockContext->getTemplate(), array(
+            'context'        => $blockContext,
+            'block'          => $blockContext->getBlock(),
+            'settings'       => $blockContext->getSettings(),
+            'elements'       => $pageList,
+            'systemElements' => $systemElements,
+        ), $response);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureSettings(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'mode'     => 'public',
+            'title'    => 'List Pages',
+            'template' => 'SonataPageBundle:Block:block_pagelist.html.twig',
+        ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockMetadata($code = null)
+    {
+        return new Metadata($this->getName(), (!is_null($code) ? $code : $this->getName()), false, 'SonataPageBundle', array(
+            'class' => 'fa fa-home',
+        ));
+    }
+}

--- a/Resources/config/block.xml
+++ b/Resources/config/block.xml
@@ -9,6 +9,7 @@
         <parameter key="sonata.page.block.ajax.class">Sonata\PageBundle\Controller\AjaxController</parameter>
         <parameter key="sonata.page.block.breadcrumb.class">Sonata\PageBundle\Block\BreadcrumbBlockService</parameter>
         <parameter key="sonata.page.block.shared_block.class">Sonata\PageBundle\Block\SharedBlockBlockService</parameter>
+        <parameter key="sonata.page.block.pagelist.class">Sonata\PageBundle\Block\PageListBlockService</parameter>
     </parameters>
 
     <services>
@@ -55,6 +56,13 @@
             <argument type="service" id="templating" />
             <argument type="service" id="service_container" />
             <argument type="service" id="sonata.page.manager.block" />
+        </service>
+
+        <service id="sonata.page.block.pages" class="%sonata.page.block.pagelist.class%">
+            <tag name="sonata.block" />
+            <argument>sonata.page.block.pagelist</argument>
+            <argument type="service" id="templating" />
+            <argument type="service" id="sonata.page.manager.page" />
         </service>
     </services>
 </container>

--- a/Resources/translations/SonataPageBundle.bg.xliff
+++ b/Resources/translations/SonataPageBundle.bg.xliff
@@ -799,6 +799,46 @@
           <source>message_page_does_not_exist</source>
           <target>message_page_does_not_exist</target>
       </trans-unit>
+      <trans-unit id="199" resname="title_content_pages">
+          <source>title_content_pages</source>
+          <target>title_content_pages</target>
+      </trans-unit>
+      <trans-unit id="200" resname="label_page_enabled">
+          <source>label_page_enabled</source>
+          <target>label_page_enabled</target>
+      </trans-unit>
+      <trans-unit id="201" resname="label_page_disabled">
+          <source>label_page_disabled</source>
+          <target>label_page_disabled</target>
+      </trans-unit>
+      <trans-unit id="202" resname="title_system_pages">
+          <source>title_system_pages</source>
+          <target>title_system_pages</target>
+      </trans-unit>
+      <trans-unit id="203" resname="no_pages_found">
+          <source>no_pages_found</source>
+          <target>no_pages_found</target>
+      </trans-unit>
+      <trans-unit id="204" resname="view_all_pages">
+          <source>view_all_pages</source>
+          <target>view_all_pages</target>
+      </trans-unit>
+      <trans-unit id="205" resname="form.label_mode">
+          <source>form.label_mode</source>
+          <target>form.label_mode</target>
+      </trans-unit>
+      <trans-unit id="206" resname="form.label_mode_public">
+          <source>form.label_mode_public</source>
+          <target>form.label_mode_public</target>
+      </trans-unit>
+      <trans-unit id="207" resname="form.label_mode_admin">
+          <source>form.label_mode_admin</source>
+          <target>form.label_mode_admin</target>
+      </trans-unit>
+      <trans-unit id="208" resname="sonata.page.block.pagelist">
+          <source>sonata.page.block.pagelist</source>
+          <target>sonata.page.block.pagelist</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/translations/SonataPageBundle.de.xliff
+++ b/Resources/translations/SonataPageBundle.de.xliff
@@ -798,6 +798,46 @@
           <source>message_page_does_not_exist</source>
           <target>Diese Seite existiert nicht.</target>
       </trans-unit>
+      <trans-unit id="199" resname="title_content_pages">
+          <source>title_content_pages</source>
+          <target>Inhaltsseiten</target>
+      </trans-unit>
+      <trans-unit id="200" resname="label_page_enabled">
+          <source>label_page_enabled</source>
+          <target>Aktiviert</target>
+      </trans-unit>
+      <trans-unit id="201" resname="label_page_disabled">
+          <source>label_page_disabled</source>
+          <target>Deaktiviert</target>
+      </trans-unit>
+      <trans-unit id="202" resname="title_system_pages">
+          <source>title_system_pages</source>
+          <target>Systemseiten</target>
+      </trans-unit>
+      <trans-unit id="203" resname="no_pages_found">
+          <source>no_pages_found</source>
+          <target>Keine Seiten vorhanden</target>
+      </trans-unit>
+      <trans-unit id="204" resname="view_all_pages">
+          <source>view_all_pages</source>
+          <target>Alle Seiten anzeigen</target>
+      </trans-unit>
+      <trans-unit id="205" resname="form.label_mode">
+          <source>form.label_mode</source>
+          <target>Modus</target>
+      </trans-unit>
+      <trans-unit id="206" resname="form.label_mode_public">
+          <source>form.label_mode_public</source>
+          <target>Öffentlich</target>
+      </trans-unit>
+      <trans-unit id="207" resname="form.label_mode_admin">
+          <source>form.label_mode_admin</source>
+          <target>Administrativ</target>
+      </trans-unit>
+      <trans-unit id="208" resname="sonata.page.block.pagelist">
+          <source>sonata.page.block.pagelist</source>
+          <target>Seitenliste</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/translations/SonataPageBundle.en.xliff
+++ b/Resources/translations/SonataPageBundle.en.xliff
@@ -799,6 +799,46 @@
           <source>message_page_does_not_exist</source>
           <target>This page does not exist.</target>
       </trans-unit>
+      <trans-unit id="199" resname="title_content_pages">
+          <source>title_content_pages</source>
+          <target>Content Pages</target>
+      </trans-unit>
+      <trans-unit id="200" resname="label_page_enabled">
+          <source>label_page_enabled</source>
+          <target>enabled</target>
+      </trans-unit>
+      <trans-unit id="201" resname="label_page_disabled">
+          <source>label_page_disabled</source>
+          <target>disabled</target>
+      </trans-unit>
+      <trans-unit id="202" resname="title_system_pages">
+          <source>title_system_pages</source>
+          <target>System pages</target>
+      </trans-unit>
+      <trans-unit id="203" resname="no_pages_found">
+          <source>no_pages_found</source>
+          <target>No pages found.</target>
+      </trans-unit>
+      <trans-unit id="204" resname="view_all_pages">
+          <source>view_all_pages</source>
+          <target>View all pages</target>
+      </trans-unit>
+      <trans-unit id="205" resname="form.label_mode">
+          <source>form.label_mode</source>
+          <target>Mode</target>
+      </trans-unit>
+      <trans-unit id="206" resname="form.label_mode_public">
+          <source>form.label_mode_public</source>
+          <target>public</target>
+      </trans-unit>
+      <trans-unit id="207" resname="form.label_mode_admin">
+          <source>form.label_mode_admin</source>
+          <target>admin</target>
+      </trans-unit>
+      <trans-unit id="208" resname="sonata.page.block.pagelist">
+          <source>sonata.page.block.pagelist</source>
+          <target>Page List</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/translations/SonataPageBundle.es.xliff
+++ b/Resources/translations/SonataPageBundle.es.xliff
@@ -799,6 +799,46 @@
           <source>message_page_does_not_exist</source>
           <target>message_page_does_not_exist</target>
       </trans-unit>
+      <trans-unit id="199" resname="title_content_pages">
+          <source>title_content_pages</source>
+          <target>title_content_pages</target>
+      </trans-unit>
+      <trans-unit id="200" resname="label_page_enabled">
+          <source>label_page_enabled</source>
+          <target>label_page_enabled</target>
+      </trans-unit>
+      <trans-unit id="201" resname="label_page_disabled">
+          <source>label_page_disabled</source>
+          <target>label_page_disabled</target>
+      </trans-unit>
+      <trans-unit id="202" resname="title_system_pages">
+          <source>title_system_pages</source>
+          <target>title_system_pages</target>
+      </trans-unit>
+      <trans-unit id="203" resname="no_pages_found">
+          <source>no_pages_found</source>
+          <target>no_pages_found</target>
+      </trans-unit>
+      <trans-unit id="204" resname="view_all_pages">
+          <source>view_all_pages</source>
+          <target>view_all_pages</target>
+      </trans-unit>
+      <trans-unit id="205" resname="form.label_mode">
+          <source>form.label_mode</source>
+          <target>form.label_mode</target>
+      </trans-unit>
+      <trans-unit id="206" resname="form.label_mode_public">
+          <source>form.label_mode_public</source>
+          <target>form.label_mode_public</target>
+      </trans-unit>
+      <trans-unit id="207" resname="form.label_mode_admin">
+          <source>form.label_mode_admin</source>
+          <target>form.label_mode_admin</target>
+      </trans-unit>
+      <trans-unit id="208" resname="sonata.page.block.pagelist">
+          <source>sonata.page.block.pagelist</source>
+          <target>sonata.page.block.pagelist</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/translations/SonataPageBundle.fr.xliff
+++ b/Resources/translations/SonataPageBundle.fr.xliff
@@ -800,6 +800,46 @@
           <source>message_page_does_not_exist</source>
           <target>Cette page n'existe pas.</target>
       </trans-unit>
+      <trans-unit id="199" resname="title_content_pages">
+          <source>title_content_pages</source>
+          <target>title_content_pages</target>
+      </trans-unit>
+      <trans-unit id="200" resname="label_page_enabled">
+          <source>label_page_enabled</source>
+          <target>label_page_enabled</target>
+      </trans-unit>
+      <trans-unit id="201" resname="label_page_disabled">
+          <source>label_page_disabled</source>
+          <target>label_page_disabled</target>
+      </trans-unit>
+      <trans-unit id="202" resname="title_system_pages">
+          <source>title_system_pages</source>
+          <target>title_system_pages</target>
+      </trans-unit>
+      <trans-unit id="203" resname="no_pages_found">
+          <source>no_pages_found</source>
+          <target>no_pages_found</target>
+      </trans-unit>
+      <trans-unit id="204" resname="view_all_pages">
+          <source>view_all_pages</source>
+          <target>view_all_pages</target>
+      </trans-unit>
+      <trans-unit id="205" resname="form.label_mode">
+          <source>form.label_mode</source>
+          <target>form.label_mode</target>
+      </trans-unit>
+      <trans-unit id="206" resname="form.label_mode_public">
+          <source>form.label_mode_public</source>
+          <target>form.label_mode_public</target>
+      </trans-unit>
+      <trans-unit id="207" resname="form.label_mode_admin">
+          <source>form.label_mode_admin</source>
+          <target>form.label_mode_admin</target>
+      </trans-unit>
+      <trans-unit id="208" resname="sonata.page.block.pagelist">
+          <source>sonata.page.block.pagelist</source>
+          <target>sonata.page.block.pagelist</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/translations/SonataPageBundle.hu.xliff
+++ b/Resources/translations/SonataPageBundle.hu.xliff
@@ -794,6 +794,46 @@
                 <source>message_page_does_not_exist</source>
                 <target>message_page_does_not_exist</target>
             </trans-unit>
+            <trans-unit id="199" resname="title_content_pages">
+                <source>title_content_pages</source>
+                <target>title_content_pages</target>
+            </trans-unit>
+            <trans-unit id="200" resname="label_page_enabled">
+                <source>label_page_enabled</source>
+                <target>label_page_enabled</target>
+            </trans-unit>
+            <trans-unit id="201" resname="label_page_disabled">
+                <source>label_page_disabled</source>
+                <target>label_page_disabled</target>
+            </trans-unit>
+            <trans-unit id="202" resname="title_system_pages">
+                <source>title_system_pages</source>
+                <target>title_system_pages</target>
+            </trans-unit>
+            <trans-unit id="203" resname="no_pages_found">
+                <source>no_pages_found</source>
+                <target>no_pages_found</target>
+            </trans-unit>
+            <trans-unit id="204" resname="view_all_pages">
+                <source>view_all_pages</source>
+                <target>view_all_pages</target>
+            </trans-unit>
+            <trans-unit id="205" resname="form.label_mode">
+                <source>form.label_mode</source>
+                <target>form.label_mode</target>
+            </trans-unit>
+            <trans-unit id="206" resname="form.label_mode_public">
+                <source>form.label_mode_public</source>
+                <target>form.label_mode_public</target>
+            </trans-unit>
+            <trans-unit id="207" resname="form.label_mode_admin">
+                <source>form.label_mode_admin</source>
+                <target>form.label_mode_admin</target>
+            </trans-unit>
+            <trans-unit id="208" resname="sonata.page.block.pagelist">
+                <source>sonata.page.block.pagelist</source>
+                <target>sonata.page.block.pagelist</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataPageBundle.ja.xliff
+++ b/Resources/translations/SonataPageBundle.ja.xliff
@@ -799,6 +799,46 @@
           <source>message_page_does_not_exist</source>
           <target>message_page_does_not_exist</target>
       </trans-unit>
+      <trans-unit id="199" resname="title_content_pages">
+          <source>title_content_pages</source>
+          <target>title_content_pages</target>
+      </trans-unit>
+      <trans-unit id="200" resname="label_page_enabled">
+          <source>label_page_enabled</source>
+          <target>label_page_enabled</target>
+      </trans-unit>
+      <trans-unit id="201" resname="label_page_disabled">
+          <source>label_page_disabled</source>
+          <target>label_page_disabled</target>
+      </trans-unit>
+      <trans-unit id="202" resname="title_system_pages">
+          <source>title_system_pages</source>
+          <target>title_system_pages</target>
+      </trans-unit>
+      <trans-unit id="203" resname="no_pages_found">
+          <source>no_pages_found</source>
+          <target>no_pages_found</target>
+      </trans-unit>
+      <trans-unit id="204" resname="view_all_pages">
+          <source>view_all_pages</source>
+          <target>view_all_pages</target>
+      </trans-unit>
+      <trans-unit id="205" resname="form.label_mode">
+          <source>form.label_mode</source>
+          <target>form.label_mode</target>
+      </trans-unit>
+      <trans-unit id="206" resname="form.label_mode_public">
+          <source>form.label_mode_public</source>
+          <target>form.label_mode_public</target>
+      </trans-unit>
+      <trans-unit id="207" resname="form.label_mode_admin">
+          <source>form.label_mode_admin</source>
+          <target>form.label_mode_admin</target>
+      </trans-unit>
+      <trans-unit id="208" resname="sonata.page.block.pagelist">
+          <source>sonata.page.block.pagelist</source>
+          <target>sonata.page.block.pagelist</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/translations/SonataPageBundle.nl.xliff
+++ b/Resources/translations/SonataPageBundle.nl.xliff
@@ -799,6 +799,46 @@
           <source>message_page_does_not_exist</source>
           <target>message_page_does_not_exist</target>
       </trans-unit>
+      <trans-unit id="199" resname="title_content_pages">
+          <source>title_content_pages</source>
+          <target>title_content_pages</target>
+      </trans-unit>
+      <trans-unit id="200" resname="label_page_enabled">
+          <source>label_page_enabled</source>
+          <target>label_page_enabled</target>
+      </trans-unit>
+      <trans-unit id="201" resname="label_page_disabled">
+          <source>label_page_disabled</source>
+          <target>label_page_disabled</target>
+      </trans-unit>
+      <trans-unit id="202" resname="title_system_pages">
+          <source>title_system_pages</source>
+          <target>title_system_pages</target>
+      </trans-unit>
+      <trans-unit id="203" resname="no_pages_found">
+          <source>no_pages_found</source>
+          <target>no_pages_found</target>
+      </trans-unit>
+      <trans-unit id="204" resname="view_all_pages">
+          <source>view_all_pages</source>
+          <target>view_all_pages</target>
+      </trans-unit>
+      <trans-unit id="205" resname="form.label_mode">
+          <source>form.label_mode</source>
+          <target>form.label_mode</target>
+      </trans-unit>
+      <trans-unit id="206" resname="form.label_mode_public">
+          <source>form.label_mode_public</source>
+          <target>form.label_mode_public</target>
+      </trans-unit>
+      <trans-unit id="207" resname="form.label_mode_admin">
+          <source>form.label_mode_admin</source>
+          <target>form.label_mode_admin</target>
+      </trans-unit>
+      <trans-unit id="208" resname="sonata.page.block.pagelist">
+          <source>sonata.page.block.pagelist</source>
+          <target>sonata.page.block.pagelist</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/translations/SonataPageBundle.pt_BR.xliff
+++ b/Resources/translations/SonataPageBundle.pt_BR.xliff
@@ -799,6 +799,46 @@
           <source>message_page_does_not_exist</source>
           <target>message_page_does_not_exist</target>
       </trans-unit>
+      <trans-unit id="199" resname="title_content_pages">
+          <source>title_content_pages</source>
+          <target>title_content_pages</target>
+      </trans-unit>
+      <trans-unit id="200" resname="label_page_enabled">
+          <source>label_page_enabled</source>
+          <target>label_page_enabled</target>
+      </trans-unit>
+      <trans-unit id="201" resname="label_page_disabled">
+          <source>label_page_disabled</source>
+          <target>label_page_disabled</target>
+      </trans-unit>
+      <trans-unit id="202" resname="title_system_pages">
+          <source>title_system_pages</source>
+          <target>title_system_pages</target>
+      </trans-unit>
+      <trans-unit id="203" resname="no_pages_found">
+          <source>no_pages_found</source>
+          <target>no_pages_found</target>
+      </trans-unit>
+      <trans-unit id="204" resname="view_all_pages">
+          <source>view_all_pages</source>
+          <target>view_all_pages</target>
+      </trans-unit>
+      <trans-unit id="205" resname="form.label_mode">
+          <source>form.label_mode</source>
+          <target>form.label_mode</target>
+      </trans-unit>
+      <trans-unit id="206" resname="form.label_mode_public">
+          <source>form.label_mode_public</source>
+          <target>form.label_mode_public</target>
+      </trans-unit>
+      <trans-unit id="207" resname="form.label_mode_admin">
+          <source>form.label_mode_admin</source>
+          <target>form.label_mode_admin</target>
+      </trans-unit>
+      <trans-unit id="208" resname="sonata.page.block.pagelist">
+          <source>sonata.page.block.pagelist</source>
+          <target>sonata.page.block.pagelist</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/translations/SonataPageBundle.sk.xliff
+++ b/Resources/translations/SonataPageBundle.sk.xliff
@@ -799,6 +799,46 @@
           <source>message_page_does_not_exist</source>
           <target>message_page_does_not_exist</target>
       </trans-unit>
+      <trans-unit id="199" resname="title_content_pages">
+          <source>title_content_pages</source>
+          <target>title_content_pages</target>
+      </trans-unit>
+      <trans-unit id="200" resname="label_page_enabled">
+          <source>label_page_enabled</source>
+          <target>label_page_enabled</target>
+      </trans-unit>
+      <trans-unit id="201" resname="label_page_disabled">
+          <source>label_page_disabled</source>
+          <target>label_page_disabled</target>
+      </trans-unit>
+      <trans-unit id="202" resname="title_system_pages">
+          <source>title_system_pages</source>
+          <target>title_system_pages</target>
+      </trans-unit>
+      <trans-unit id="203" resname="no_pages_found">
+          <source>no_pages_found</source>
+          <target>no_pages_found</target>
+      </trans-unit>
+      <trans-unit id="204" resname="view_all_pages">
+          <source>view_all_pages</source>
+          <target>view_all_pages</target>
+      </trans-unit>
+      <trans-unit id="205" resname="form.label_mode">
+          <source>form.label_mode</source>
+          <target>form.label_mode</target>
+      </trans-unit>
+      <trans-unit id="206" resname="form.label_mode_public">
+          <source>form.label_mode_public</source>
+          <target>form.label_mode_public</target>
+      </trans-unit>
+      <trans-unit id="207" resname="form.label_mode_admin">
+          <source>form.label_mode_admin</source>
+          <target>form.label_mode_admin</target>
+      </trans-unit>
+      <trans-unit id="208" resname="sonata.page.block.pagelist">
+          <source>sonata.page.block.pagelist</source>
+          <target>sonata.page.block.pagelist</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/translations/SonataPageBundle.sl.xliff
+++ b/Resources/translations/SonataPageBundle.sl.xliff
@@ -799,6 +799,46 @@
           <source>message_page_does_not_exist</source>
           <target>message_page_does_not_exist</target>
       </trans-unit>
+      <trans-unit id="199" resname="title_content_pages">
+          <source>title_content_pages</source>
+          <target>title_content_pages</target>
+      </trans-unit>
+      <trans-unit id="200" resname="label_page_enabled">
+          <source>label_page_enabled</source>
+          <target>label_page_enabled</target>
+      </trans-unit>
+      <trans-unit id="201" resname="label_page_disabled">
+          <source>label_page_disabled</source>
+          <target>label_page_disabled</target>
+      </trans-unit>
+      <trans-unit id="202" resname="title_system_pages">
+          <source>title_system_pages</source>
+          <target>title_system_pages</target>
+      </trans-unit>
+      <trans-unit id="203" resname="no_pages_found">
+          <source>no_pages_found</source>
+          <target>no_pages_found</target>
+      </trans-unit>
+      <trans-unit id="204" resname="view_all_pages">
+          <source>view_all_pages</source>
+          <target>view_all_pages</target>
+      </trans-unit>
+      <trans-unit id="205" resname="form.label_mode">
+          <source>form.label_mode</source>
+          <target>form.label_mode</target>
+      </trans-unit>
+      <trans-unit id="206" resname="form.label_mode_public">
+          <source>form.label_mode_public</source>
+          <target>form.label_mode_public</target>
+      </trans-unit>
+      <trans-unit id="207" resname="form.label_mode_admin">
+          <source>form.label_mode_admin</source>
+          <target>form.label_mode_admin</target>
+      </trans-unit>
+      <trans-unit id="208" resname="sonata.page.block.pagelist">
+          <source>sonata.page.block.pagelist</source>
+          <target>sonata.page.block.pagelist</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/views/Block/block_pagelist.html.twig
+++ b/Resources/views/Block/block_pagelist.html.twig
@@ -1,0 +1,58 @@
+{% extends sonata_block.templates.block_base %}
+
+{% block block %}
+    <div class="panel panel-default panel-page-list">
+        {% if settings.title is not empty %}
+            <div class="panel-heading">
+                <h4 class="panel-title"><i class="fa fa-globe"></i> {{ settings.title }}</h4>
+            </div>
+        {% endif %}
+
+        <div class="panel-body">
+            <h4>{{ 'title_content_pages'|trans({}, 'SonataPageBundle') }}</h4>
+
+            <div class="list-group">
+                {% for page in elements %}
+                    {% if settings.mode == 'admin' and sonata_admin is defined %}
+                        <a href="{{ sonata_admin.url('sonata.page.admin.page', 'compose', { 'id': page.id }) }}" class="list-group-item">
+                            {% if page.enabled %}
+                                <span class="label label-success pull-right">{{ 'label_page_enabled'|trans({}, 'SonataPageBundle') }}</span>
+                            {% else %}
+                                <span class="label label-danger pull-right">{{ 'label_page_disabled'|trans({}, 'SonataPageBundle') }}</span>
+                            {% endif %}
+                            {{ page.name }}
+                        </a>
+                    {% else %}
+                        <a href="{{ path('page_slug', { 'path': page.url }) }}" class="list-group-item">
+                            {{ page.name }}
+                        </a>
+                    {% endif %}
+                {% else %}
+                    <li>{{ 'no_pages_found'|trans({}, 'SonataPageBundle') }}</li>
+                {% endfor %}
+            </div>
+
+            {% if settings.mode == 'admin' and sonata_admin is defined %}
+                <h4>{{ 'title_system_pages'|trans({}, 'SonataPageBundle') }}</h4>
+                <div class="list-group">
+                    {% for page in systemElements %}
+                        <a href="{{ sonata_admin.url('sonata.page.admin.page', 'compose', { 'id': page.id }) }}" class="list-group-item">
+                            {% if page.enabled %}
+                                <span class="label label-success pull-right">{{ 'label_page_enabled'|trans({}, 'SonataPageBundle') }}</span>
+                            {% else %}
+                                <span class="label label-danger pull-right">{{ 'label_page_disabled'|trans({}, 'SonataPageBundle') }}</span>
+                            {% endif %}
+                            {{ page.name }}
+                        </a>
+                    {% endfor %}
+                </div>
+            {% endif %}
+
+            {% if settings.mode == 'admin' and sonata_admin is defined %}
+                <a href="{{ sonata_admin.url('sonata.page.admin.page', 'compose', {filter:{hybrid:{value:'cms' }}}) }}" class="btn btn-primary btn-block">
+                    <i class="fa fa-list"></i> {{ 'view_all_pages'|trans({}, 'SonataPageBundle') }}
+                </a>
+            {% endif %}
+        </div>
+    </div>
+{% endblock %}

--- a/Tests/Block/PageListBlockServiceTest.php
+++ b/Tests/Block/PageListBlockServiceTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Sonata\PageBundle\Tests\Block;
+
+use Sonata\BlockBundle\Block\BlockContext;
+use Sonata\BlockBundle\Model\Block;
+use Sonata\BlockBundle\Tests\Block\AbstractBlockServiceTest;
+use Sonata\BlockBundle\Tests\Block\Service\FakeTemplating;
+use Sonata\PageBundle\Block\PageListBlockService;
+use Sonata\PageBundle\Model\Page;
+use Sonata\PageBundle\Model\PageManagerInterface;
+
+class PageListBlockServiceTest extends AbstractBlockServiceTest
+{
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|PageManagerInterface
+     */
+    protected $pageManager;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->pageManager = $this->getMock('Sonata\PageBundle\Model\PageManagerInterface');
+        $this->templating      = new FakeTemplating();
+    }
+
+    public function testDefaultSettings()
+    {
+        $blockService = new PageListBlockService('block.service', $this->templating, $this->pageManager);
+        $blockContext = $this->getBlockContext($blockService);
+
+        $this->assertSettings(array(
+            'mode'     => 'public',
+            'title'    => 'List Pages',
+            'template' => 'SonataPageBundle:Block:block_pagelist.html.twig',
+        ), $blockContext);
+    }
+
+    public function testExecute()
+    {
+        $page1 = $this->getMock('Sonata\PageBundle\Model\PageInterface');
+        $page2 = $this->getMock('Sonata\PageBundle\Model\PageInterface');
+        $systemPage = $this->getMock('Sonata\PageBundle\Model\PageInterface');
+
+        $this->pageManager->expects($this->at(0))->method('findBy')
+            ->with($this->equalTo(array(
+                'routeName' => Page::PAGE_ROUTE_CMS_NAME,
+            )))
+            ->will($this->returnValue(array($page1, $page2)));
+        $this->pageManager->expects($this->at(1))->method('findBy')
+            ->with($this->equalTo(array(
+                'url'    => null,
+                'parent' => null,
+            )))
+            ->will($this->returnValue(array($systemPage)));
+
+        $block = new Block();
+
+        $blockContext = new BlockContext($block, array(
+            'mode'     => 'public',
+            'title'    => 'List Pages',
+            'template' => 'SonataPageBundle:Block:block_pagelist.html.twig',
+        ));
+
+        $blockService = new PageListBlockService('block.service', $this->templating, $this->pageManager);
+        $blockService->execute($blockContext);
+
+        $this->assertSame('SonataPageBundle:Block:block_pagelist.html.twig', $this->templating->view);
+
+        $this->assertSame($blockContext, $this->templating->parameters['context']);
+        $this->assertInternalType('array', $this->templating->parameters['settings']);
+        $this->assertInstanceOf('Sonata\BlockBundle\Model\BlockInterface', $this->templating->parameters['block']);
+        $this->assertCount(2, $this->templating->parameters['elements']);
+        $this->assertContains($page1, $this->templating->parameters['elements']);
+        $this->assertContains($page2, $this->templating->parameters['elements']);
+        $this->assertCount(1, $this->templating->parameters['systemElements']);
+        $this->assertContains($systemPage, $this->templating->parameters['systemElements']);
+    }
+}


### PR DESCRIPTION
This block could help you on your admin dashboard to show all content pages. It could also been used for displaying a conent list in the frontend.

![bildschirmfoto 2015-11-21 um 08 52 36](https://cloud.githubusercontent.com/assets/3440437/11317377/4a1e62fe-902d-11e5-9fda-981445fefeca.PNG)
