### PR TITLE
Fix RedirectResponse bug caused by HostPathSiteSelector::onKernelRequestRedirect

### DIFF
--- a/Site/HostPathSiteSelector.php
+++ b/Site/HostPathSiteSelector.php
@@ -84,7 +84,9 @@ class HostPathSiteSelector extends BaseSiteSelector
         }
 
         if ('Symfony\\Bundle\\FrameworkBundle\\Controller\\RedirectController::urlRedirectAction' == $request->get('_controller')) {
-            $request->attributes->set('path', $this->site->getRelativePath().$request->attributes->get('path'));
+            if (!preg_match('/^http(s)?:\/\//', $request->attributes->get('path'))) {
+                $request->attributes->set('path', $this->site->getRelativePath().$request->attributes->get('path'));
+            }
         }
     }
 


### PR DESCRIPTION
I have been using the RedirectController to create url redirects to external urls, but using the HostPathSiteSelector ruins the absolute urls. In case the path is http://www.google.com the calculated url is the following: 

`/enhttp://www.google.com`

In order to fix this, an additional condition should be added.