### PR TITLE
Fix exception list template overwriting wrong block

### DIFF
--- a/Resources/views/Exceptions/list.html.twig
+++ b/Resources/views/Exceptions/list.html.twig
@@ -12,7 +12,7 @@ file that was distributed with this source code.
 
 {% block title %}{{ 'title_list_exceptions'|trans({}, 'SonataPageBundle')}}{% endblock %}
 
-{% block content %}
+{% block body %}
     <div>
         <h2>{{ 'title_list_exceptions'|trans([], 'SonataPageBundle') }}</h2>
 


### PR DESCRIPTION
See https://github.com/sonata-project/SonataPageBundle/issues/592