### PR TITLE
Remove inexistent function from twig PageExtension

### DIFF
--- a/Twig/Extension/PageExtension.php
+++ b/Twig/Extension/PageExtension.php
@@ -104,7 +104,6 @@ class PageExtension extends \Twig_Extension implements \Twig_Extension_InitRunti
     {
         return array(
             new \Twig_SimpleFunction('sonata_page_ajax_url', array($this, 'ajaxUrl')),
-            new \Twig_SimpleFunction('sonata_page_url', array($this, 'url')),
             new \Twig_SimpleFunction('sonata_page_breadcrumb', array($this, 'breadcrumb'), array('is_safe' => array('html'))),
             new \Twig_SimpleFunction('sonata_page_render_container', array($this, 'renderContainer'), array('is_safe' => array('html'))),
             new \Twig_SimpleFunction('sonata_page_render_block', array($this, 'renderBlock'), array('is_safe' => array('html'))),


### PR DESCRIPTION
Deprecated function "url" was removed in https://github.com/sonata-project/SonataPageBundle/commit/878abecab152773499bd181358bb5973e068ed20#diff-21e2678af7dafe7c997ac47caf275483 commit, but was not removed from the "getFunctions" function.