### PR TITLE
Use the page name if the page has no SEO titel

### DIFF
--- a/Page/Service/DefaultPageService.php
+++ b/Page/Service/DefaultPageService.php
@@ -73,9 +73,7 @@ class DefaultPageService extends BasePageService
             return;
         }
 
-        if ($page->getTitle()) {
-            $this->seoPage->setTitle($page->getTitle() ?: $page->getName());
-        }
+        $this->seoPage->setTitle($page->getTitle() ?: $page->getName());
 
         if ($page->getMetaDescription()) {
             $this->seoPage->addMeta('name', 'description', $page->getMetaDescription());

--- a/Tests/Page/Service/DefaultPageServiceTest.php
+++ b/Tests/Page/Service/DefaultPageServiceTest.php
@@ -60,7 +60,7 @@ class DefaultPageServiceTest extends \PHPUnit_Framework_TestCase
 
         // mock a page instance
         $page = $this->getMock('Sonata\PageBundle\Model\PageInterface');
-        $page->expects($this->exactly(2))->method('getTitle')->will($this->returnValue('page title'));
+        $page->expects($this->any())->method('getTitle')->will($this->returnValue('page title'));
         $page->expects($this->atLeastOnce())->method('getMetaDescription')->will($this->returnValue('page meta description'));
         $page->expects($this->atLeastOnce())->method('getMetaKeyword')->will($this->returnValue('page meta keywords'));
         $page->expects($this->once())->method('getTemplateCode')->will($this->returnValue('template code'));


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Rebase of #420

### Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Remove unneeded sections.
    Follow this schema: http://keepachangelog.com/
-->

```markdown
### Fixed
- The page name is now correctly used as a page title fallback
```

### Subject

The page name fallback could never be reached because of the surrounding if-statement.

### To do

<!--
    Complete the tasks.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->

- [X] Update the tests