### PR TITLE
Added null check if no site exists

### DIFF
--- a/Resources/translations/SonataPageBundle.bg.xliff
+++ b/Resources/translations/SonataPageBundle.bg.xliff
@@ -907,6 +907,14 @@
           <source>form.label_menu_template</source>
           <target>form.label_menu_template</target>
       </trans-unit>
+      <trans-unit id="226" resname="pages.label_no_sites">
+          <source>pages.label_no_sites</source>
+          <target>pages.label_no_sites</target>
+      </trans-unit>
+      <trans-unit id="227" resname="pages.label_no_site_selected">
+          <source>pages.label_no_site_selected</source>
+          <target>pages.label_no_site_selected</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/translations/SonataPageBundle.de.xliff
+++ b/Resources/translations/SonataPageBundle.de.xliff
@@ -906,6 +906,14 @@
           <source>form.label_menu_template</source>
           <target>Menü Template</target>
       </trans-unit>
+      <trans-unit id="226" resname="pages.label_no_sites">
+          <source>pages.label_no_sites</source>
+          <target>Keine Seiten konfiguriert</target>
+      </trans-unit>
+      <trans-unit id="227" resname="pages.label_no_site_selected">
+          <source>pages.label_no_site_selected</source>
+          <target>Keine Seiten ausgewählt</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/translations/SonataPageBundle.en.xliff
+++ b/Resources/translations/SonataPageBundle.en.xliff
@@ -907,6 +907,14 @@
           <source>form.label_menu_template</source>
           <target>Menu template</target>
       </trans-unit>
+      <trans-unit id="226" resname="pages.label_no_sites">
+          <source>pages.label_no_sites</source>
+          <target>No sites configured</target>
+      </trans-unit>
+      <trans-unit id="227" resname="pages.label_no_site_selected">
+          <source>pages.label_no_site_selected</source>
+          <target>No site selected</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/translations/SonataPageBundle.es.xliff
+++ b/Resources/translations/SonataPageBundle.es.xliff
@@ -907,6 +907,14 @@
           <source>form.label_menu_template</source>
           <target>form.label_menu_template</target>
       </trans-unit>
+      <trans-unit id="226" resname="pages.label_no_sites">
+          <source>pages.label_no_sites</source>
+          <target>pages.label_no_sites</target>
+      </trans-unit>
+      <trans-unit id="227" resname="pages.label_no_site_selected">
+          <source>pages.label_no_site_selected</source>
+          <target>pages.label_no_site_selected</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/translations/SonataPageBundle.fr.xliff
+++ b/Resources/translations/SonataPageBundle.fr.xliff
@@ -908,6 +908,14 @@
           <source>form.label_menu_template</source>
           <target>Modèle de page</target>
       </trans-unit>
+      <trans-unit id="226" resname="pages.label_no_sites">
+          <source>pages.label_no_sites</source>
+          <target>pages.label_no_sites</target>
+      </trans-unit>
+      <trans-unit id="227" resname="pages.label_no_site_selected">
+          <source>pages.label_no_site_selected</source>
+          <target>pages.label_no_site_selected</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/translations/SonataPageBundle.hu.xliff
+++ b/Resources/translations/SonataPageBundle.hu.xliff
@@ -902,6 +902,14 @@
                 <source>form.label_menu_template</source>
                 <target>form.label_menu_template</target>
             </trans-unit>
+            <trans-unit id="226" resname="pages.label_no_sites">
+                <source>pages.label_no_sites</source>
+                <target>pages.label_no_sites</target>
+            </trans-unit>
+            <trans-unit id="227" resname="pages.label_no_site_selected">
+                <source>pages.label_no_site_selected</source>
+                <target>pages.label_no_site_selected</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataPageBundle.ja.xliff
+++ b/Resources/translations/SonataPageBundle.ja.xliff
@@ -907,6 +907,14 @@
           <source>form.label_menu_template</source>
           <target>form.label_menu_template</target>
       </trans-unit>
+      <trans-unit id="226" resname="pages.label_no_sites">
+          <source>pages.label_no_sites</source>
+          <target>pages.label_no_sites</target>
+      </trans-unit>
+      <trans-unit id="227" resname="pages.label_no_site_selected">
+          <source>pages.label_no_site_selected</source>
+          <target>pages.label_no_site_selected</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/translations/SonataPageBundle.nl.xliff
+++ b/Resources/translations/SonataPageBundle.nl.xliff
@@ -907,6 +907,14 @@
           <source>form.label_menu_template</source>
           <target>form.label_menu_template</target>
       </trans-unit>
+      <trans-unit id="226" resname="pages.label_no_sites">
+          <source>pages.label_no_sites</source>
+          <target>pages.label_no_sites</target>
+      </trans-unit>
+      <trans-unit id="227" resname="pages.label_no_site_selected">
+          <source>pages.label_no_site_selected</source>
+          <target>pages.label_no_site_selected</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/translations/SonataPageBundle.pt_BR.xliff
+++ b/Resources/translations/SonataPageBundle.pt_BR.xliff
@@ -907,6 +907,14 @@
           <source>form.label_menu_template</source>
           <target>form.label_menu_template</target>
       </trans-unit>
+      <trans-unit id="226" resname="pages.label_no_sites">
+          <source>pages.label_no_sites</source>
+          <target>pages.label_no_sites</target>
+      </trans-unit>
+      <trans-unit id="227" resname="pages.label_no_site_selected">
+          <source>pages.label_no_site_selected</source>
+          <target>pages.label_no_site_selected</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/translations/SonataPageBundle.sk.xliff
+++ b/Resources/translations/SonataPageBundle.sk.xliff
@@ -907,6 +907,14 @@
           <source>form.label_menu_template</source>
           <target>form.label_menu_template</target>
       </trans-unit>
+      <trans-unit id="226" resname="pages.label_no_sites">
+          <source>pages.label_no_sites</source>
+          <target>pages.label_no_sites</target>
+      </trans-unit>
+      <trans-unit id="227" resname="pages.label_no_site_selected">
+          <source>pages.label_no_site_selected</source>
+          <target>pages.label_no_site_selected</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/translations/SonataPageBundle.sl.xliff
+++ b/Resources/translations/SonataPageBundle.sl.xliff
@@ -907,6 +907,14 @@
           <source>form.label_menu_template</source>
           <target>form.label_menu_template</target>
       </trans-unit>
+      <trans-unit id="226" resname="pages.label_no_sites">
+          <source>pages.label_no_sites</source>
+          <target>pages.label_no_sites</target>
+      </trans-unit>
+      <trans-unit id="227" resname="pages.label_no_site_selected">
+          <source>pages.label_no_site_selected</source>
+          <target>pages.label_no_site_selected</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/views/PageAdmin/select_site.html.twig
+++ b/Resources/views/PageAdmin/select_site.html.twig
@@ -25,19 +25,22 @@ file that was distributed with this source code.
     {{ 'message_create_page'|trans({}, 'SonataPageBundle')}}
     </p>
 
-    <ul>
-        {% for site in sites %}
-            <li>
-                {% if current and site.id == current.id %}
-                    <img src="{{ asset('bundles/sonataadmin/famfamfam/accept.png') }}">
-                {% endif %}
+    {% if sites|length > 0 %}
+        <ul>
+            {% for site in sites %}
+                <li>
+                    {% if current and site.id == current.id %}
+                        <img src="{{ asset('bundles/sonataadmin/famfamfam/accept.png') }}">
+                    {% endif %}
 
-                <a href="{{ admin.generateUrl('create', {'siteId': site.id, 'uniqid': admin.uniqid}) }}">
-
-                {{ site.name }}
-                </a>
-                - {{ site.url }}
-            </li>
-        {% endfor%}
-    </ul>
+                    <a href="{{ admin.generateUrl('create', {'siteId': site.id, 'uniqid': admin.uniqid}) }}">
+                    {{ site.name }}
+                    </a>
+                    - {{ site.url }}
+                </li>
+            {% endfor %}
+        </ul>
+    {% else %}
+        {{ 'pages.label_no_sites'|trans({}, 'SonataPageBundle') }}
+    {% endif %}
 {% endblock %}

--- a/Resources/views/PageAdmin/tree.html.twig
+++ b/Resources/views/PageAdmin/tree.html.twig
@@ -49,7 +49,17 @@ file that was distributed with this source code.
                     {{ 'pages.tree_site_label'|trans({}, 'SonataPageBundle') }}
                     <div class="btn-group">
                         <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
-                            <strong class="text-info">{{ currentSite.name }}</strong> <span class="caret"></span>
+                            <strong class="text-info">
+                                {%- if sites and sites|length > 0 -%}
+                                    {% if currentSite %}
+                                        {{ currentSite.name }}
+                                    {% else %}
+                                        {{ 'pages.label_no_site_selected'|trans({}, 'SonataPageBundle') }}
+                                    {% endif %}
+                                {%- else -%}
+                                    {{ 'pages.label_no_sites'|trans({}, 'SonataPageBundle') }}
+                                {%- endif -%}
+                            </strong> <span class="caret"></span>
                         </button>
                         <ul class="dropdown-menu" role="menu">
                             {% for site in sites %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #601 
Rebase of https://github.com/sonata-project/SonataPageBundle/pull/603

### Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Remove unneeded sections.
    Follow this schema: http://keepachangelog.com/
-->

```markdown
### Fixed
- Fixed missing null check when rendering tree view without any site
```

### Subject

Added null check and shows a message when no site exists.

### To do

<!--
    Complete the tasks.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->

- [X] Update translation