### PR TITLE
sort snapshots by publicationDateStart desc

### DIFF
--- a/Entity/SnapshotManager.php
+++ b/Entity/SnapshotManager.php
@@ -133,6 +133,7 @@ class SnapshotManager extends BaseEntityManager implements SnapshotManagerInterf
             throw new \RuntimeException('please provide a `pageId`, `url`, `routeName` or `name` as criteria key');
         }
 
+        $query->orderBy('s.publicationDateStart', 'DESC');
         $query->setMaxResults(1);
         $query->setParameters($parameters);
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Replaces #387

### Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Remove unneeded sections.
    Follow this schema: http://keepachangelog.com/
-->

```markdown
### Changed
- Sort snapshots by `publicationDateStart`
```

### Subject

It is counterintuitive that if more then one snapshot matches the date criteria, the one that was created first is selected, it should be the one with the newest startDate.