### PR TITLE
added missing  property in SnapshotPageProxy

### DIFF
--- a/Model/SnapshotPageProxy.php
+++ b/Model/SnapshotPageProxy.php
@@ -46,6 +46,11 @@ class SnapshotPageProxy implements PageInterface, Serializable
     private $parents;
 
     /**
+     * @var TransformerInterface
+     */
+    private $transformer;
+
+    /**
      * Constructor.
      *
      * @param SnapshotManagerInterface $manager     Snapshot manager


### PR DESCRIPTION
### Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Remove unneeded sections.
    Follow this schema: http://keepachangelog.com/
-->

```markdown
### Fixed
- Fix missing `$transformer` property in `SnapshotPageProxy`
```

### Subject

`$this->transformer` is used here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/Model/SnapshotPageProxy.php#L59