### PR TITLE
add support for cocur/slugify 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "symfony-cmf/routing-bundle": "^1.1",
         "sonata-project/notification-bundle": "^3.0",
         "sonata-project/datagrid-bundle": "^2.2",
-        "cocur/slugify": "^1.0"
+        "cocur/slugify": "^1.0 || ^2.0"
     },
     "require-dev": {
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

### Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Remove unneeded sections.
    Follow this schema: http://keepachangelog.com/
-->

```markdown
### Added
- Support version 2.x for `cocur/slugify` dependency
```

### Subject

Support `cocur/slugify` 2.x

SonataCoreBundle already supports it: https://github.com/sonata-project/SonataCoreBundle/blob/3.x/composer.json#L27
