### PR TITLE
Added trigger_error for native slugify (sonata.core.slugify.native)

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -90,7 +90,10 @@ EOF;
                 ->prototype('scalar')->end()
             ->end()
             ->scalarNode('slugify_service')
+                // NEXT_MAJOR: reword this info message
                 ->info('You should use: sonata.core.slugify.cocur, but for BC we keep \'sonata.core.slugify.native\' as default')
+
+                // NEXT_MAJOR: use "sonata.core.slugify.cocur" instead of "sonata.core.slugify.native" as default value
                 ->defaultValue('sonata.core.slugify.native')
             ->end()
             ->arrayNode('ignore_routes')

--- a/SonataPageBundle.php
+++ b/SonataPageBundle.php
@@ -59,10 +59,18 @@ class SonataPageBundle extends Bundle
         }
 
         call_user_func(array($class, 'setSlugifyMethod'), function ($text) use ($container) {
+            // NEXT_MAJOR: remove this check
             if ($container->hasParameter('sonata.page.slugify_service')) {
                 $id = $container->getParameter('sonata.page.slugify_service');
             } else {
-                $id = 'sonata.core.slugify.native'; // default BC value, you should use sonata.core.slugify.cocur
+                @trigger_error(
+                    'The "sonata.core.slugify.native" service is deprecated since 2.3.9, to be removed in 4.0. '.
+                    'Use "sonata.core.slugify.cocur" service through config instead.',
+                    E_USER_DEPRECATED
+                );
+
+                // default BC value, you should use sonata.core.slugify.cocur
+                $id = 'sonata.core.slugify.native';
             }
 
             $service = $container->get($id);

--- a/Tests/Model/PageTest.php
+++ b/Tests/Model/PageTest.php
@@ -13,6 +13,11 @@ namespace Sonata\PageBundle\Tests\Model;
 
 class PageTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * NEXT_MAJOR: remove the legacy group from this test.
+     *
+     * @group legacy
+     */
     public function testSlugify()
     {
         setlocale(LC_ALL, 'en_US.utf8');


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

### Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Remove unneeded sections.
    Follow this schema: http://keepachangelog.com/
-->

```markdown
### Fixed
- `trigger_error` for deprecated `sonata.core.slugify.native`
```

### Subject

`sonata.core.slugify.native` service is already deprecated,
but the trigger_error was missing.