### PR TITLE
Call `getRelativePath()` on `null`

### DIFF
--- a/Twig/Extension/PageExtension.php
+++ b/Twig/Extension/PageExtension.php
@@ -278,7 +278,7 @@ class PageExtension extends \Twig_Extension implements \Twig_Extension_InitRunti
         $globals = $this->environment->getGlobals();
 
         if (!isset($attributes['pathInfo'])) {
-            $sitePath = $this->siteSelector->retrieve()->getRelativePath();
+            $sitePath = (null !== $site = $this->siteSelector->retrieve()) ? $site->getRelativePath() : '';
             $currentPathInfo = $globals['app']->getRequest()->getPathInfo();
 
             $attributes['pathInfo'] = $sitePath.$currentPathInfo;


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because…

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #
Fixes #

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added some `Class::newMethod` to do great stuff

### Changed

### Deprecated

### Removed

### Fixed

### Security
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [ ] Update the tests
- [ ] Update the documentation
- [ ] Add an upgrade note

## Subject

<!-- Describe your Pull Request content here -->

To avoid PHP fatal error I added the check.
```
PHP Fatal error:  Call to a member function getRelativePath() on null in [...]/vendor/sonata-project/page-bundle/Twig/Extension/PageExtension.php on line 281
```