### PR TITLE
Call `getRelativePath()` on `null`

### DIFF
--- a/Tests/Twig/Extension/PageExtensionTest.php
+++ b/Tests/Twig/Extension/PageExtensionTest.php
@@ -59,7 +59,7 @@ class PageExtensionTest extends \PHPUnit_Framework_TestCase
         ;
         $globals->method('getRequest')->willReturn($request);
         $env = $this->getMock('Twig_Environment');
-        $env->method('getGlobals')->willReturn(['app' => $globals]);
+        $env->method('getGlobals')->willReturn(array('app' => $globals));
         $HttpKernelExtension = $this->getMockBuilder('Symfony\Bridge\Twig\Extension\HttpKernelExtension')
             ->disableOriginalConstructor()
             ->getMock()
@@ -68,8 +68,8 @@ class PageExtensionTest extends \PHPUnit_Framework_TestCase
         $extension->initRuntime($env);
         $HttpKernelExtension->expects($this->once())->method('controller')->with(
             'foo',
-            ['pathInfo' => '/foo/bar/'],
-            []
+            array('pathInfo' => '/foo/bar/'),
+            array()
         )
         ;
         $extension->controller('foo');
@@ -92,14 +92,14 @@ class PageExtensionTest extends \PHPUnit_Framework_TestCase
         ;
         $globals->method('getRequest')->willReturn($request);
         $env = $this->getMock('Twig_Environment');
-        $env->method('getGlobals')->willReturn(['app' => $globals]);
+        $env->method('getGlobals')->willReturn(array('app' => $globals));
         $HttpKernelExtension = $this->getMockBuilder('Symfony\Bridge\Twig\Extension\HttpKernelExtension')
             ->disableOriginalConstructor()
             ->getMock()
         ;
         $extension = new PageExtension($cmsManager, $siteSelector, $router, $blockHelper, $HttpKernelExtension);
         $extension->initRuntime($env);
-        $HttpKernelExtension->expects($this->once())->method('controller')->with('bar', [], []);
+        $HttpKernelExtension->expects($this->once())->method('controller')->with('bar', array(), array());
         $extension->controller('bar');
     }
 }

--- a/Tests/Twig/Extension/PageExtensionTest.php
+++ b/Tests/Twig/Extension/PageExtensionTest.php
@@ -38,7 +38,7 @@ class PageExtensionTest extends \PHPUnit_Framework_TestCase
         $extension = new PageExtension($cmsManager, $siteSelector, $router, $blockHelper, $HttpKernelExtension);
         $this->assertEquals('/foo/bar', $extension->ajaxUrl($block));
     }
-    
+
     public function testController()
     {
         $cmsManager = $this->getMock('Sonata\PageBundle\CmsManager\CmsManagerSelectorInterface');

--- a/Tests/Twig/Extension/PageExtensionTest.php
+++ b/Tests/Twig/Extension/PageExtensionTest.php
@@ -38,4 +38,70 @@ class PageExtensionTest extends \PHPUnit_Framework_TestCase
         $extension = new PageExtension($cmsManager, $siteSelector, $router, $blockHelper, $HttpKernelExtension);
         $this->assertEquals('/foo/bar', $extension->ajaxUrl($block));
     }
+    
+    public function testController()
+    {
+        $cmsManager = $this->getMock('Sonata\PageBundle\CmsManager\CmsManagerSelectorInterface');
+        $site = $this->getMock('Sonata\PageBundle\Model\SiteInterface');
+        $site->method('getRelativePath')->willReturn('/foo/bar');
+        $siteSelector = $this->getMock('Sonata\PageBundle\Site\SiteSelectorInterface');
+        $siteSelector->method('retrieve')->willReturn($site);
+        
+        $router = $this->getMock('Symfony\Component\Routing\RouterInterface');
+        $blockHelper = $this->getMockBuilder('Sonata\BlockBundle\Templating\Helper\BlockHelper')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $request = $this->getMock('Symfony\Component\HttpFoundation\Request');
+        $request->method('getPathInfo')->willReturn('/');
+        $globals = $this->getMockBuilder('Symfony\Bundle\FrameworkBundle\Templating\GlobalVariables')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $globals->method('getRequest')->willReturn($request);
+        $env = $this->getMock('Twig_Environment');
+        $env->method('getGlobals')->willReturn(array('app' => $globals));
+
+        $HttpKernelExtension = $this->getMockBuilder('Symfony\Bridge\Twig\Extension\HttpKernelExtension')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $extension = new PageExtension($cmsManager, $siteSelector, $router, $blockHelper, $HttpKernelExtension);
+        $extension->initRuntime($env);
+        
+        $HttpKernelExtension->expects($this->once())->method('controller')->with('foo', array('pathInfo' => '/foo/bar/'), array());
+        $extension->controller('foo');
+    }
+
+    public function testControllerWithoutSite()
+    {
+        $cmsManager = $this->getMock('Sonata\PageBundle\CmsManager\CmsManagerSelectorInterface');
+        $siteSelector = $this->getMock('Sonata\PageBundle\Site\SiteSelectorInterface');
+        $router = $this->getMock('Symfony\Component\Routing\RouterInterface');
+        $blockHelper = $this->getMockBuilder('Sonata\BlockBundle\Templating\Helper\BlockHelper')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $request = $this->getMock('Symfony\Component\HttpFoundation\Request');
+        $request->method('getPathInfo')->willReturn('/');
+        $globals = $this->getMockBuilder('Symfony\Bundle\FrameworkBundle\Templating\GlobalVariables')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $globals->method('getRequest')->willReturn($request);
+        $env = $this->getMock('Twig_Environment');
+        $env->method('getGlobals')->willReturn(array('app' => $globals));
+
+        $HttpKernelExtension = $this->getMockBuilder('Symfony\Bridge\Twig\Extension\HttpKernelExtension')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $extension = new PageExtension($cmsManager, $siteSelector, $router, $blockHelper, $HttpKernelExtension);
+        $extension->initRuntime($env);
+        
+        $HttpKernelExtension->expects($this->once())->method('controller')->with('bar', array(), array());
+        $extension->controller('bar');
+    }
 }

--- a/Tests/Twig/Extension/PageExtensionTest.php
+++ b/Tests/Twig/Extension/PageExtensionTest.php
@@ -46,7 +46,6 @@ class PageExtensionTest extends \PHPUnit_Framework_TestCase
         $site->method('getRelativePath')->willReturn('/foo/bar');
         $siteSelector = $this->getMock('Sonata\PageBundle\Site\SiteSelectorInterface');
         $siteSelector->method('retrieve')->willReturn($site);
-        
         $router = $this->getMock('Symfony\Component\Routing\RouterInterface');
         $blockHelper = $this->getMockBuilder('Sonata\BlockBundle\Templating\Helper\BlockHelper')
             ->disableOriginalConstructor()
@@ -60,17 +59,19 @@ class PageExtensionTest extends \PHPUnit_Framework_TestCase
         ;
         $globals->method('getRequest')->willReturn($request);
         $env = $this->getMock('Twig_Environment');
-        $env->method('getGlobals')->willReturn(array('app' => $globals));
-
+        $env->method('getGlobals')->willReturn(['app' => $globals]);
         $HttpKernelExtension = $this->getMockBuilder('Symfony\Bridge\Twig\Extension\HttpKernelExtension')
             ->disableOriginalConstructor()
             ->getMock()
         ;
-
         $extension = new PageExtension($cmsManager, $siteSelector, $router, $blockHelper, $HttpKernelExtension);
         $extension->initRuntime($env);
-        
-        $HttpKernelExtension->expects($this->once())->method('controller')->with('foo', array('pathInfo' => '/foo/bar/'), array());
+        $HttpKernelExtension->expects($this->once())->method('controller')->with(
+            'foo',
+            ['pathInfo' => '/foo/bar/'],
+            []
+        )
+        ;
         $extension->controller('foo');
     }
 
@@ -91,17 +92,14 @@ class PageExtensionTest extends \PHPUnit_Framework_TestCase
         ;
         $globals->method('getRequest')->willReturn($request);
         $env = $this->getMock('Twig_Environment');
-        $env->method('getGlobals')->willReturn(array('app' => $globals));
-
+        $env->method('getGlobals')->willReturn(['app' => $globals]);
         $HttpKernelExtension = $this->getMockBuilder('Symfony\Bridge\Twig\Extension\HttpKernelExtension')
             ->disableOriginalConstructor()
             ->getMock()
         ;
-
         $extension = new PageExtension($cmsManager, $siteSelector, $router, $blockHelper, $HttpKernelExtension);
         $extension->initRuntime($env);
-        
-        $HttpKernelExtension->expects($this->once())->method('controller')->with('bar', array(), array());
+        $HttpKernelExtension->expects($this->once())->method('controller')->with('bar', [], []);
         $extension->controller('bar');
     }
 }

--- a/Twig/Extension/PageExtension.php
+++ b/Twig/Extension/PageExtension.php
@@ -275,13 +275,15 @@ class PageExtension extends \Twig_Extension implements \Twig_Extension_InitRunti
      */
     public function controller($controller, $attributes = array(), $query = array())
     {
-        $globals = $this->environment->getGlobals();
-
         if (!isset($attributes['pathInfo'])) {
-            $sitePath = (null !== $site = $this->siteSelector->retrieve()) ? $site->getRelativePath() : '';
-            $currentPathInfo = $globals['app']->getRequest()->getPathInfo();
+            $site = $this->siteSelector->retrieve();
+            if ($site) {
+                $sitePath = $site->getRelativePath();
+                $globals = $this->environment->getGlobals();
+                $currentPathInfo = $globals['app']->getRequest()->getPathInfo();
 
-            $attributes['pathInfo'] = $sitePath.$currentPathInfo;
+                $attributes['pathInfo'] = $sitePath.$currentPathInfo;
+            }
         }
 
         return $this->httpKernelExtension->controller($controller, $attributes, $query);

--- a/Twig/Extension/PageExtension.php
+++ b/Twig/Extension/PageExtension.php
@@ -278,7 +278,7 @@ class PageExtension extends \Twig_Extension implements \Twig_Extension_InitRunti
         $globals = $this->environment->getGlobals();
 
         if (!isset($attributes['pathInfo'])) {
-            $sitePath = $this->siteSelector->retrieve()->getRelativePath();
+            $sitePath = (null !== $site = $this->siteSelector->retrieve()) ? $site->getRelativePath() : '';
             $currentPathInfo = $globals['app']->getRequest()->getPathInfo();
 
             $attributes['pathInfo'] = $sitePath.$currentPathInfo;


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because I want to propose a patch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Fixes #676 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed PHP Fatal error:  Call to a member function getRelativePath() on null
```

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

## Subject

<!-- Describe your Pull Request content here -->

To avoid PHP fatal error I added the check.
`PageExtension` is checking if the `pathInfo` attribute is defined. If not, it's retrieved from the relative path of the site selector. Since my route excluded from `sonata_page`, it couldn't be retrieved.
```
PHP Fatal error:  Call to a member function getRelativePath() on null in [...]/vendor/sonata-project/page-bundle/Twig/Extension/PageExtension.php on line 281
```