### PR TITLE
Configure admin template only if AdminBundle is present

### DIFF
--- a/DependencyInjection/SonataPageExtension.php
+++ b/DependencyInjection/SonataPageExtension.php
@@ -54,6 +54,8 @@ class SonataPageExtension extends Extension
             if (!$config['direct_publication']) {
                 $container->removeDefinition('sonata.page.admin.extension.snapshot');
             }
+
+            $this->configureTemplatesAdmin($container, $config);
         }
 
         $loader->load('block.xml');
@@ -68,7 +70,6 @@ class SonataPageExtension extends Extension
         $this->configureMultisite($container, $config);
         $this->configureCache($container, $config);
         $this->configureTemplates($container, $config);
-        $this->configureTemplatesAdmin($container, $config);
         $this->configureExceptions($container, $config);
         $this->configurePageDefaults($container, $config);
         $this->configurePageServices($container, $config);


### PR DESCRIPTION
I am targeting this branch, because this is a non-BC fix

## Changelog

```markdown
### Fixed
- Service definition `sonata.page.admin.page` does not exist

```

## Subject

Custom templates for admin are trying to access the ``sonata.page.admin.page`` service in all cases, but this service is only in the container if AdminBundle is loaded in the AppKernel. 

In this PR, admin templates configuration is done only if the AdminBundle is present.