### PR TITLE
Fixed tree view showing if no filter parameter is defined

### DIFF
--- a/Controller/PageAdminController.php
+++ b/Controller/PageAdminController.php
@@ -51,7 +51,7 @@ class PageAdminController extends Controller
      */
     public function listAction()
     {
-        if (!$this->getRequest()->get('filter')) {
+        if ($this->getRequest()->get('filter')) {
             return new RedirectResponse($this->admin->generateUrl('tree'));
         }
 

--- a/Resources/views/PageAdmin/list_tab_menu.html.twig
+++ b/Resources/views/PageAdmin/list_tab_menu.html.twig
@@ -1,10 +1,10 @@
 {{ knp_menu_render(admin.sidemenu(action), {'currentClass' : 'active'}, 'list') }}
 <p>
     <div class="btn-group">
-        <a type="button" class="btn {% if mode == 'list' %}btn-info active{% else %}btn-default{% endif %}" href="{{ admin.generateUrl('list', { 'filter': { 'site': { 'value': currentSite.id|default('') }}}) }}">
+        <a type="button" class="btn {% if mode == 'list' %}btn-info active{% else %}btn-default{% endif %}" href="{{ admin.generateUrl('list') }}">
             <i class="fa fa-list"></i> {{ 'pages.list_mode'|trans({}, 'SonataPageBundle') }}
         </a>
-        <a type="button" class="btn {% if mode == 'tree' %}btn-info active{% else %}btn-default{% endif %}" href="{{ admin.generateUrl('tree') }}">
+        <a type="button" class="btn {% if mode == 'tree' %}btn-info active{% else %}btn-default{% endif %}" href="{{ admin.generateUrl('tree',{ 'filter': { 'site': { 'value': currentSite.id|default('') }}}) }}">
             <i class="fa fa-sitemap"></i> {{ 'pages.tree_mode'|trans({}, 'SonataPageBundle') }}
         </a>
     </div>

--- a/Resources/views/PageAdmin/tree.html.twig
+++ b/Resources/views/PageAdmin/tree.html.twig
@@ -72,3 +72,7 @@ file that was distributed with this source code.
         </div>
     </div>
 {% endblock %}
+
+{% block list_filters %}
+
+{% endblock %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a BC break in 2.x.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #638 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Tree view showing if no filter is defined, show SonataAdminBundle list view instead. Caused a BC break with the form type: sonata_type_model_list.

```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [ ] Update the tests <???>

## Subject

Will fix tree view showing as default in the page admin. Showing the tree view as default breaks the sonata_type_model_list. Tree view has no select functionality. Also removed the filter from the tree view. The filter never worked for the tree view.
