### PR TITLE
mark page as edited on block removing

### DIFF
--- a/Admin/BaseBlockAdmin.php
+++ b/Admin/BaseBlockAdmin.php
@@ -146,9 +146,10 @@ abstract class BaseBlockAdmin extends AbstractAdmin
     public function preRemove($object)
     {
         $this->blockManager->get($object)->preRemove($object);
+        $page = $object->getPage();
 
-        if ($object->getPage() instanceof PageInterface) {
-            $object->getPage()->setEdited(true);
+        if ($page instanceof PageInterface) {
+            $page->setEdited(true);
         }
     }
 

--- a/Admin/BaseBlockAdmin.php
+++ b/Admin/BaseBlockAdmin.php
@@ -146,6 +146,10 @@ abstract class BaseBlockAdmin extends AbstractAdmin
     public function preRemove($object)
     {
         $this->blockManager->get($object)->preRemove($object);
+
+        if ($object->getPage() instanceof PageInterface) {
+            $object->getPage()->setEdited(true);
+        }
     }
 
     /**

--- a/Tests/Admin/BaseBlockAdminTest.php
+++ b/Tests/Admin/BaseBlockAdminTest.php
@@ -32,4 +32,27 @@ class BaseBlockAdminTest extends PHPUnit_Framework_TestCase
         $idx = array();
         $blockAdmin->preBatchAction('delete', $query, $idx, true);
     }
+
+    public function testSettingAsEditedOnPreRemove()
+    {
+        $page = $this->getMock('Sonata\PageBundle\Model\PageInterface');
+        $page->expects($this->once())->method('setEdited')->with(true);
+
+        $block = $this->getMock('Sonata\PageBundle\Model\PageBlockInterface');
+        $block->expects($this->once())->method('getPage')->will($this->returnValue($page));
+
+        $blockService = $this->getMockBuilder('Sonata\BlockBundle\Block\Service\AbstractAdminBlockService')
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+        $blockService->expects($this->any())->method('preRemove')->with($block);
+
+        $blockServiceManager = $this->getMock('Sonata\BlockBundle\Block\BlockServiceManagerInterface');
+        $blockServiceManager->expects($this->once())->method('get')->with($block)->will($this->returnValue($blockService));
+
+        $blockAdmin = $this->getMockBuilder('Sonata\PageBundle\Admin\BaseBlockAdmin')
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+        $blockAdmin->setBlockManager($blockServiceManager);
+        $blockAdmin->preRemove($block);
+    }
 }

--- a/Tests/Admin/BaseBlockAdminTest.php
+++ b/Tests/Admin/BaseBlockAdminTest.php
@@ -35,18 +35,16 @@ class BaseBlockAdminTest extends PHPUnit_Framework_TestCase
 
     public function testSettingAsEditedOnPreRemove()
     {
-        $page = $this->getMock('Sonata\PageBundle\Model\PageInterface');
+        $page = $this->createMock('Sonata\PageBundle\Model\PageInterface');
         $page->expects($this->once())->method('setEdited')->with(true);
 
-        $block = $this->getMock('Sonata\PageBundle\Model\PageBlockInterface');
+        $block = $this->createMock('Sonata\PageBundle\Model\PageBlockInterface');
         $block->expects($this->once())->method('getPage')->will($this->returnValue($page));
 
-        $blockService = $this->getMockBuilder('Sonata\BlockBundle\Block\Service\AbstractAdminBlockService')
-            ->disableOriginalConstructor()
-            ->getMockForAbstractClass();
+        $blockService = $this->createMock('Sonata\BlockBundle\Block\Service\AbstractAdminBlockService');
         $blockService->expects($this->any())->method('preRemove')->with($block);
 
-        $blockServiceManager = $this->getMock('Sonata\BlockBundle\Block\BlockServiceManagerInterface');
+        $blockServiceManager = $this->createMock('Sonata\BlockBundle\Block\BlockServiceManagerInterface');
         $blockServiceManager->expects($this->once())->method('get')->with($block)->will($this->returnValue($blockService));
 
         $blockAdmin = $this->getMockBuilder('Sonata\PageBundle\Admin\BaseBlockAdmin')


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

I am targetting this branch, because this is a BC fix

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->

``` markdown
### Fixed
- Removing blocks doesn't mark page as edited
```
## Subject

For now, this code included in `prePersist` and `preUpdate` events and missing in `prePremove`.

<!-- Describe your Pull Request content here -->
