### PR TITLE
mark page as edited on batch block deleting

### DIFF
--- a/Admin/BaseBlockAdmin.php
+++ b/Admin/BaseBlockAdmin.php
@@ -14,6 +14,7 @@ namespace Sonata\PageBundle\Admin;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Route\RouteCollection;
 use Sonata\BlockBundle\Block\BlockServiceManagerInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
@@ -22,7 +23,6 @@ use Sonata\PageBundle\Entity\BaseBlock;
 use Sonata\PageBundle\Model\PageInterface;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 
 /**
  * Abstract admin class for the Block model.
@@ -199,6 +199,24 @@ abstract class BaseBlockAdmin extends AbstractAdmin
     /**
      * {@inheritdoc}
      */
+    public function preBatchAction($actionName, ProxyQueryInterface $query, array &$idx, $allElements)
+    {
+        $parent = $this->getParent();
+
+        if ($parent && in_array($actionName, array('delete'))) {
+            $subject = $parent->getSubject();
+
+            if ($subject instanceof PageInterface) {
+                $subject->setEdited(true);
+            }
+        }
+
+        parent::preBatchAction($actionName, $query, $idx, $allElements);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function configureRoutes(RouteCollection $collection)
     {
         $collection->add('view', $this->getRouterIdParameter().'/view');
@@ -257,22 +275,5 @@ abstract class BaseBlockAdmin extends AbstractAdmin
         $service->load($block);
 
         return $block;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function preBatchAction($actionName, ProxyQueryInterface $query, array &$idx, $allElements)
-    {
-        $parent = $this->getParent();
-
-        if ($parent && in_array($actionName, array('delete'))) {
-            $subject = $parent->getSubject();
-            if ($subject instanceof PageInterface) {
-                $subject->setEdited(true);
-            }
-        }
-
-        parent::preBatchAction($actionName, $query, $idx, $allElements);
     }
 }

--- a/Admin/BaseBlockAdmin.php
+++ b/Admin/BaseBlockAdmin.php
@@ -260,7 +260,7 @@ abstract class BaseBlockAdmin extends AbstractAdmin
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function preBatchAction($actionName, ProxyQueryInterface $query, array &$idx, $allElements)
     {

--- a/Admin/BaseBlockAdmin.php
+++ b/Admin/BaseBlockAdmin.php
@@ -266,7 +266,7 @@ abstract class BaseBlockAdmin extends AbstractAdmin
     {
         $parent = $this->getParent();
 
-        if (in_array($actionName, ['delete']) && $parent) {
+        if ($parent && in_array($actionName, array('delete'))) {
             $subject = $parent->getSubject();
             if ($subject instanceof PageInterface) {
                 $subject->setEdited(true);

--- a/Admin/BaseBlockAdmin.php
+++ b/Admin/BaseBlockAdmin.php
@@ -203,7 +203,7 @@ abstract class BaseBlockAdmin extends AbstractAdmin
     {
         $parent = $this->getParent();
 
-        if ($parent && in_array($actionName, array('delete'))) {
+        if ($parent && $actionName === 'delete') {
             $subject = $parent->getSubject();
 
             if ($subject instanceof PageInterface) {

--- a/Admin/BaseBlockAdmin.php
+++ b/Admin/BaseBlockAdmin.php
@@ -22,6 +22,7 @@ use Sonata\PageBundle\Entity\BaseBlock;
 use Sonata\PageBundle\Model\PageInterface;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 
 /**
  * Abstract admin class for the Block model.
@@ -256,5 +257,22 @@ abstract class BaseBlockAdmin extends AbstractAdmin
         $service->load($block);
 
         return $block;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function preBatchAction($actionName, ProxyQueryInterface $query, array &$idx, $allElements)
+    {
+        $parent = $this->getParent();
+
+        if (in_array($actionName, ['delete']) && $parent) {
+            $subject = $parent->getSubject();
+            if ($subject instanceof PageInterface) {
+                $subject->setEdited(true);
+            }
+        }
+
+        parent::preBatchAction($actionName, $query, $idx, $allElements);
     }
 }

--- a/Tests/Admin/BaseBlockAdminTest.php
+++ b/Tests/Admin/BaseBlockAdminTest.php
@@ -11,7 +11,9 @@
 
 namespace Sonata\PageBundle\Tests\Admin;
 
-class BaseBlockAdminTest extends \PHPUnit_Framework_TestCase
+use Sonata\PageBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
+
+class BaseBlockAdminTest extends PHPUnit_Framework_TestCase
 {
     public function testSettingAsEditedOnPreBatchDeleteAction()
     {

--- a/Tests/Admin/BaseBlockAdminTest.php
+++ b/Tests/Admin/BaseBlockAdminTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\PageBundle\Tests\Admin;
+
+class BaseBlockAdminTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSettingAsEditedOnPreBatchDeleteAction()
+    {
+        $page = $this->createMock('Sonata\PageBundle\Model\PageInterface');
+        $page->expects($this->once())->method('setEdited')->with(true);
+
+        $parent = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $parent->expects($this->once())->method('getSubject')->will($this->returnValue($page));
+
+        $blockAdmin = $this->getMockBuilder('Sonata\PageBundle\Admin\BaseBlockAdmin')
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+        $blockAdmin->setParent($parent);
+
+        $query = $this->createMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface');
+        $idx = array();
+        $blockAdmin->preBatchAction('delete', $query, $idx, true);
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

I am targetting this branch, because this is a BC fix

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->

``` markdown

### Fixed
- Batch blocks removing doesn't mark page as edited
```
## Subject

"Delete" batch action doesn't set page as edited and doesn't fire `preRemove` events. So, we can take page from parent admin and call `setEdited` in `preBatchAction` hook.

<!-- Describe your Pull Request content here -->
