### PR TITLE
Condition for enabled field on selecting enabled snapshots

### DIFF
--- a/Entity/SnapshotManager.php
+++ b/Entity/SnapshotManager.php
@@ -107,7 +107,9 @@ class SnapshotManager extends BaseEntityManager implements SnapshotManagerInterf
 
         $query = $this->getRepository()
             ->createQueryBuilder('s')
-            ->andWhere('s.publicationDateStart <= :publicationDateStart AND ( s.publicationDateEnd IS NULL OR s.publicationDateEnd >= :publicationDateEnd )');
+            ->andWhere('s.publicationDateStart <= :publicationDateStart AND ( s.publicationDateEnd IS NULL OR s.publicationDateEnd >= :publicationDateEnd )')
+            ->andWhere('s.enabled = 1')
+        ;
 
         if (isset($criteria['site'])) {
             $query->andWhere('s.site = :site');

--- a/Entity/SnapshotManager.php
+++ b/Entity/SnapshotManager.php
@@ -108,7 +108,7 @@ class SnapshotManager extends BaseEntityManager implements SnapshotManagerInterf
         $query = $this->getRepository()
             ->createQueryBuilder('s')
             ->andWhere('s.publicationDateStart <= :publicationDateStart AND ( s.publicationDateEnd IS NULL OR s.publicationDateEnd >= :publicationDateEnd )')
-            ->andWhere('s.enabled = 1')
+            ->andWhere('s.enabled = true')
         ;
 
         if (isset($criteria['site'])) {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a BC fix

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- disabled snapshots are available for users
```

## Subject

<!-- Describe your Pull Request content here -->

`Entity\SnapshotManager::findEnableSnapshot` returning a snapshot even if it is disabled.

So, users can see disabled state of a page. I just added obvious condition for it.