### PR TITLE
Fixed wrong namespace for test classes

### DIFF
--- a/Tests/Command/BaseCommandTest.php
+++ b/Tests/Command/BaseCommandTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sonata\Test\PageBundle\Command;
+namespace Sonata\PageBundle\Tests\Command;
 
 use Sonata\PageBundle\Command\BaseCommand;
 

--- a/Tests/Controller/Api/AjaxControllerTest.php
+++ b/Tests/Controller/Api/AjaxControllerTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sonata\Test\PageBundle\Controller\Api;
+namespace Sonata\PageBundle\Tests\Controller\Api;
 
 use Sonata\PageBundle\Controller\AjaxController;
 use Symfony\Component\HttpFoundation\Request;

--- a/Tests/Controller/Api/BlockControllerTest.php
+++ b/Tests/Controller/Api/BlockControllerTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sonata\Test\PageBundle\Controller\Api;
+namespace Sonata\PageBundle\Tests\Controller\Api;
 
 use Sonata\PageBundle\Controller\Api\BlockController;
 use Symfony\Component\HttpFoundation\Request;

--- a/Tests/Controller/Api/PageControllerTest.php
+++ b/Tests/Controller/Api/PageControllerTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sonata\Test\PageBundle\Controller\Api;
+namespace Sonata\PageBundle\Tests\Controller\Api;
 
 use Sonata\PageBundle\Controller\Api\PageController;
 use Symfony\Component\HttpFoundation\Request;

--- a/Tests/Controller/Api/SiteControllerTest.php
+++ b/Tests/Controller/Api/SiteControllerTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sonata\Test\PageBundle\Controller\Api;
+namespace Sonata\PageBundle\Tests\Controller\Api;
 
 use Sonata\PageBundle\Controller\Api\SiteController;
 use Symfony\Component\HttpFoundation\Request;

--- a/Tests/Controller/Api/SnapshotControllerTest.php
+++ b/Tests/Controller/Api/SnapshotControllerTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sonata\Test\PageBundle\Controller\Api;
+namespace Sonata\PageBundle\Tests\Controller\Api;
 
 use Sonata\PageBundle\Controller\Api\SnapshotController;
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because…

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Subject

Some test classes had a wrong namespace.
