### PR TITLE
Added command to create block container

### DIFF
--- a/Command/CreateBlockContainerCommand.php
+++ b/Command/CreateBlockContainerCommand.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\PageBundle\Command;
+
+use Sonata\PageBundle\Entity\BlockInteractor;
+use Sonata\PageBundle\Model\PageInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Creates block containers for all pages.
+ *
+ * @author Christian Gripp <mail@core23.de>
+ */
+final class CreateBlockContainerCommand extends BaseCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->setName('sonata:page:create-block-container');
+
+        $this->addArgument('templateCode', InputArgument::REQUIRED, 'Template name according to sonata_page.yml (e.g. default)');
+        $this->addArgument('blockCode', InputArgument::REQUIRED, 'Block alias (e.g. content_bottom)');
+        $this->addArgument('blockName', InputArgument::OPTIONAL, 'Block name (e.g. Bottom container)');
+
+        $this->setDescription('Creates a block container in all pages for specified template code');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $blockCode = $input->getArgument('blockCode');
+
+        $pageManager = $this->getPageManager();
+        $blockInteractor = $this->getBlockInteractor();
+
+        $pages = $pageManager->findBy(array(
+            'templateCode' => $input->getArgument('templateCode'),
+        ));
+
+        /** @var PageInterface $page */
+        foreach ($pages as $page) {
+            $output->writeln(sprintf('Adding to page <info>%s</info>', $page->getName()));
+
+            $block = $blockInteractor->createNewContainer(array(
+                'name' => $input->getArgument('blockName'),
+                'enabled' => true,
+                'page' => $page,
+                'code' => $blockCode,
+            ));
+
+            $page->addBlocks($block);
+
+            $pageManager->save($page);
+        }
+
+        $output->writeln(sprintf(
+            'Don\'t forget to add block <comment>%s</comment> into your <comment>sonata_page.yml</comment>',
+            $blockCode
+        ));
+
+        $output->writeln('<info>done!</info>');
+    }
+
+    /**
+     * @return BlockInteractor
+     */
+    private function getBlockInteractor()
+    {
+        return $this->getContainer()->get('sonata.page.block_interactor');
+    }
+}

--- a/Resources/doc/reference/command_line.rst
+++ b/Resources/doc/reference/command_line.rst
@@ -29,7 +29,11 @@ Page commands
 
     $ php app/console sonata:page:cleanup-snapshots --site=all --keep-snapshots=5
 
-Please note that you can also give multiple website identifiers for all those commands, this way::
+- Create blocks::
+
+    $ php app/console sonata:page:create-block-container --templateCode=default --blockCode=content_bottom --blockName="Left Content"
+
+Please note that you can also give multiple website identifiers to some commands, this way::
 
     $ php app/console sonata:page:update-core-routes --site=1 --site=2 --site=...
     $ php app/console sonata:page:create-snapshots --site=1 --site=2 --site=...

--- a/Tests/Command/CreateBlockContainerCommandTest.php
+++ b/Tests/Command/CreateBlockContainerCommandTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\Tests\PageBundle\Command;
+
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sonata\PageBundle\Command\CreateBlockContainerCommand;
+use Sonata\PageBundle\Entity\BlockInteractor;
+use Sonata\PageBundle\Entity\BlockManager;
+use Sonata\PageBundle\Entity\PageManager;
+use Sonata\PageBundle\Tests\Model\Page;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class CreateBlockContainerCommandTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ObjectProphecy|BlockInteractor
+     */
+    protected $blockInteractor;
+
+    /**
+     * @var ObjectProphecy|PageManager
+     */
+    protected $pageManager;
+
+    /**
+     * @var ObjectProphecy|BlockManager
+     */
+    protected $blockManager;
+
+    /**
+     * @var ObjectProphecy|ContainerInterface
+     */
+    protected $container;
+
+    public function setUp()
+    {
+        $this->blockInteractor = $this->prophesize('Sonata\PageBundle\Entity\BlockInteractor');
+
+        $this->pageManager = $this->prophesize('Sonata\PageBundle\Entity\PageManager');
+
+        $this->blockManager = $this->prophesize('Sonata\PageBundle\Entity\BlockManager');
+
+        $this->container = $this->prophesize('Symfony\Component\DependencyInjection\ContainerInterface');
+        $this->container->get('sonata.page.block_interactor')->willReturn($this->blockInteractor);
+        $this->container->get('sonata.page.manager.page')->willReturn($this->pageManager);
+        $this->container->get('sonata.page.manager.block')->willReturn($this->blockManager);
+    }
+
+    /**
+     * Tests that Block is added into Page's blocks field.
+     */
+    public function testCreateBlock()
+    {
+        $block = $this->prophesize('Sonata\PageBundle\Model\PageBlockInterface');
+        $this->blockInteractor->createNewContainer(Argument::any())->willReturn($block->reveal());
+
+        $page = new Page();
+        $this->pageManager->findBy(array('templateCode' => 'foo'))->willReturn(array($page));
+        $this->pageManager->save($page)->willReturn($page);
+
+        $command = new CreateBlockContainerCommand();
+        $command->setContainer($this->container->reveal());
+
+        $input = $this->prophesize('Symfony\Component\Console\Input\InputInterface');
+        $input->getArgument('templateCode')->willReturn('foo');
+        $input->getArgument('blockCode')->willReturn('content_bar');
+        $input->getArgument('blockName')->willReturn('Baz!');
+
+        $output = $this->prophesize('Symfony\Component\Console\Output\OutputInterface');
+
+        $method = new \ReflectionMethod($command, 'execute');
+        $method->setAccessible(true);
+        $method->invoke($command, $input->reveal(), $output->reveal());
+
+        $this->assertEquals($page->getBlocks(), array($block->reveal()));
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because it's a new feature.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Rebase of #629

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added new command to create block container for all pages
```

## Subject

This command allows you to create new blocks for all pages.
