### PR TITLE
Fixed duplicate translation

### DIFF
--- a/Admin/PageAdmin.php
+++ b/Admin/PageAdmin.php
@@ -280,6 +280,7 @@ class PageAdmin extends Admin
                         'hybrid' => $this->trans('hybrid'),
                         'cms' => $this->trans('cms'),
                     ),
+                    'choice_translation_domain' => false,
                 ),
                 'field_type' => 'choice',
             ))
@@ -412,7 +413,7 @@ class PageAdmin extends Admin
         ;
 
         $formMapper->setHelps(array(
-            'name' => $this->trans('help_page_name'),
+            'name' => 'help_page_name',
         ));
     }
 

--- a/Form/Type/PageSelectorType.php
+++ b/Form/Type/PageSelectorType.php
@@ -53,6 +53,7 @@ class PageSelectorType extends AbstractType
             'choice_list' => function (Options $opts, $previousValue) use ($that) {
                 return new SimpleChoiceList($that->getChoices($opts));
             },
+            'choice_translation_domain' => false,
             'filter_choice' => array(
                 'current_page' => false,
                 'request_method' => 'GET',

--- a/Form/Type/PageTypeChoiceType.php
+++ b/Form/Type/PageTypeChoiceType.php
@@ -43,6 +43,7 @@ class PageTypeChoiceType extends AbstractType
     {
         $resolver->setDefaults(array(
             'choices' => $this->getPageTypes(),
+            'choice_translation_domain' => false,
         ));
     }
 

--- a/Form/Type/TemplateChoiceType.php
+++ b/Form/Type/TemplateChoiceType.php
@@ -43,6 +43,7 @@ class TemplateChoiceType extends AbstractType
     {
         $resolver->setDefaults(array(
             'choices' => $this->getTemplates(),
+            'choice_translation_domain' => false,
         ));
     }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a patch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed duplicate translation on admin pages
```

## Subject

Some options in a choice list were translated two times, once in the php classes and a second time in the twig template. 

