### PR TITLE
cascade persist for block parent

### DIFF
--- a/DependencyInjection/SonataPageExtension.php
+++ b/DependencyInjection/SonataPageExtension.php
@@ -261,7 +261,7 @@ class SonataPageExtension extends Extension
             'fieldName' => 'parent',
             'targetEntity' => $config['class']['block'],
             'cascade' => array(
-                'persist'
+                'persist',
             ),
             'mappedBy' => null,
             'inversedBy' => 'children',

--- a/DependencyInjection/SonataPageExtension.php
+++ b/DependencyInjection/SonataPageExtension.php
@@ -261,6 +261,7 @@ class SonataPageExtension extends Extension
             'fieldName' => 'parent',
             'targetEntity' => $config['class']['block'],
             'cascade' => array(
+                'persist'
             ),
             'mappedBy' => null,
             'inversedBy' => 'children',


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

I am targetting this branch, because this is a non-BC fix

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->

``` markdown
### Fixed
- missing cascade persistence for parent block.
```
## Subject

<!-- Describe your Pull Request content here -->

For now, we can't create block with its new parent, besause cascade persistence not enabled.
But it is enabled for page's parent.
(For example, it is very important feature for moving pages from another cms solution).
