### PR TITLE
Remove deprecation warning for admin classes

### DIFF
--- a/Admin/BaseBlockAdmin.php
+++ b/Admin/BaseBlockAdmin.php
@@ -11,7 +11,7 @@
 
 namespace Sonata\PageBundle\Admin;
 
-use Sonata\AdminBundle\Admin\Admin;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Route\RouteCollection;
@@ -28,7 +28,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-abstract class BaseBlockAdmin extends Admin
+abstract class BaseBlockAdmin extends AbstractAdmin
 {
     /**
      * @var BlockServiceManagerInterface

--- a/Admin/Extension/CreateSnapshotAdminExtension.php
+++ b/Admin/Extension/CreateSnapshotAdminExtension.php
@@ -11,13 +11,13 @@
 
 namespace Sonata\PageBundle\Admin\Extension;
 
-use Sonata\AdminBundle\Admin\AdminExtension;
+use Sonata\AdminBundle\Admin\AbstractAdminExtension;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\NotificationBundle\Backend\BackendInterface;
 use Sonata\PageBundle\Model\PageInterface;
 
-class CreateSnapshotAdminExtension extends AdminExtension
+class CreateSnapshotAdminExtension extends AbstractAdminExtension
 {
     /**
      * @var BackendInterface

--- a/Admin/PageAdmin.php
+++ b/Admin/PageAdmin.php
@@ -12,7 +12,7 @@
 namespace Sonata\PageBundle\Admin;
 
 use Knp\Menu\ItemInterface as MenuItemInterface;
-use Sonata\AdminBundle\Admin\Admin;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
@@ -32,7 +32,7 @@ use Sonata\PageBundle\Model\SiteManagerInterface;
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class PageAdmin extends Admin
+class PageAdmin extends AbstractAdmin
 {
     /**
      * @var PageManagerInterface

--- a/Admin/SiteAdmin.php
+++ b/Admin/SiteAdmin.php
@@ -11,7 +11,7 @@
 
 namespace Sonata\PageBundle\Admin;
 
-use Sonata\AdminBundle\Admin\Admin;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
@@ -24,7 +24,7 @@ use Sonata\PageBundle\Route\RoutePageGenerator;
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class SiteAdmin extends Admin
+class SiteAdmin extends AbstractAdmin
 {
     /**
      * @var RoutePageGenerator

--- a/Admin/SnapshotAdmin.php
+++ b/Admin/SnapshotAdmin.php
@@ -11,7 +11,7 @@
 
 namespace Sonata\PageBundle\Admin;
 
-use Sonata\AdminBundle\Admin\Admin;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
@@ -22,7 +22,7 @@ use Sonata\Cache\CacheManagerInterface;
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class SnapshotAdmin extends Admin
+class SnapshotAdmin extends AbstractAdmin
 {
     /**
      * @var CacheManagerInterface


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataFormatterBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a BC patch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
 - Removed deprecation warning for `Admin` usage.
 - Removed deprecation warning for `AdminExtension` usage.
```

## Subject

Uses the new `AbstractAdmin` and `AbstractAdminExtension` classes.

