### PR TITLE
Fixed duplicate translation in tab menu

### DIFF
--- a/Admin/PageAdmin.php
+++ b/Admin/PageAdmin.php
@@ -186,7 +186,8 @@ class PageAdmin extends Admin
         $actions = parent::getBatchActions();
 
         $actions['snapshot'] = array(
-            'label' => $this->trans('create_snapshot'),
+            'label' => 'create_snapshot',
+            'translation_domain' => $this->getTranslationDomain(),
             'ask_confirmation' => true,
         );
 
@@ -430,30 +431,25 @@ class PageAdmin extends Admin
 
         $id = $admin->getRequest()->get('id');
 
-        $menu->addChild(
-            $this->trans('sidemenu.link_edit_page'),
+        $menu->addChild('sidemenu.link_edit_page',
             array('uri' => $admin->generateUrl('edit', array('id' => $id)))
         );
 
-        $menu->addChild(
-            $this->trans('sidemenu.link_compose_page'),
+        $menu->addChild('sidemenu.link_compose_page',
             array('uri' => $admin->generateUrl('compose', array('id' => $id)))
         );
 
-        $menu->addChild(
-            $this->trans('sidemenu.link_list_blocks'),
+        $menu->addChild('sidemenu.link_list_blocks',
             array('uri' => $admin->generateUrl('sonata.page.admin.page|sonata.page.admin.block.list', array('id' => $id)))
         );
 
-        $menu->addChild(
-            $this->trans('sidemenu.link_list_snapshots'),
+        $menu->addChild('sidemenu.link_list_snapshots',
             array('uri' => $admin->generateUrl('sonata.page.admin.page|sonata.page.admin.snapshot.list', array('id' => $id)))
         );
 
         if (!$this->getSubject()->isHybrid() && !$this->getSubject()->isInternal()) {
             try {
-                $menu->addChild(
-                    $this->trans('view_page'),
+                $menu->addChild('view_page',
                     array('uri' => $this->getRouteGenerator()->generate('page_slug', array('path' => $this->getSubject()->getUrl())))
                 );
             } catch (\Exception $e) {

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "symfony/security": "^2.3",
         "symfony/templating": "^2.3",
         "symfony/validator": "^2.3",
-        "sonata-project/admin-bundle": "^3.0",
+        "sonata-project/admin-bundle": "^3.4",
         "sonata-project/block-bundle": "^3.1.1",
         "sonata-project/seo-bundle": "^2.0",
         "sonata-project/doctrine-extensions" : "^1.0",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a BC fix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
 - Fixed duplicate translation in tab menu
 - Fixed duplicate translation of batch actions
```

## Subject

Since the 3.4 release of the admin bundle, the menu items are translated in the twig templates by the knp menu bundle.
