### PR TITLE
Remove the beta tag on `Composer` functionality

### DIFF
--- a/Resources/translations/SonataPageBundle.bg.xliff
+++ b/Resources/translations/SonataPageBundle.bg.xliff
@@ -637,7 +637,7 @@
             </trans-unit>
             <trans-unit id="158" resname="sidemenu.link_compose_page">
                 <source>sidemenu.link_compose_page</source>
-                <target>Composer (beta)</target>
+                <target>Composer</target>
             </trans-unit>
             <trans-unit id="159" resname="sidemenu.link_list_pages">
                 <source>sidemenu.link_list_pages</source>

--- a/Resources/translations/SonataPageBundle.en.xliff
+++ b/Resources/translations/SonataPageBundle.en.xliff
@@ -637,7 +637,7 @@
             </trans-unit>
             <trans-unit id="158" resname="sidemenu.link_compose_page">
                 <source>sidemenu.link_compose_page</source>
-                <target>Composer (beta)</target>
+                <target>Composer</target>
             </trans-unit>
             <trans-unit id="159" resname="sidemenu.link_list_pages">
                 <source>sidemenu.link_list_pages</source>

--- a/Resources/translations/SonataPageBundle.es.xliff
+++ b/Resources/translations/SonataPageBundle.es.xliff
@@ -637,7 +637,7 @@
             </trans-unit>
             <trans-unit id="158" resname="sidemenu.link_compose_page">
                 <source>sidemenu.link_compose_page</source>
-                <target>Componer (Beta)</target>
+                <target>Componer</target>
             </trans-unit>
             <trans-unit id="159" resname="sidemenu.link_list_pages">
                 <source>sidemenu.link_list_pages</source>

--- a/Resources/translations/SonataPageBundle.fr.xliff
+++ b/Resources/translations/SonataPageBundle.fr.xliff
@@ -638,7 +638,7 @@
             </trans-unit>
             <trans-unit id="158" resname="sidemenu.link_compose_page">
                 <source>sidemenu.link_compose_page</source>
-                <target>Organiser (beta)</target>
+                <target>Organiser</target>
             </trans-unit>
             <trans-unit id="159" resname="sidemenu.link_list_pages">
                 <source>sidemenu.link_list_pages</source>

--- a/Resources/translations/SonataPageBundle.ja.xliff
+++ b/Resources/translations/SonataPageBundle.ja.xliff
@@ -637,7 +637,7 @@
             </trans-unit>
             <trans-unit id="158" resname="sidemenu.link_compose_page">
                 <source>sidemenu.link_compose_page</source>
-                <target>コンポーザ (beta)</target>
+                <target>コンポーザ</target>
             </trans-unit>
             <trans-unit id="159" resname="sidemenu.link_list_pages">
                 <source>sidemenu.link_list_pages</source>


### PR DESCRIPTION
I'm targeting 3.x branch because, this translation corrections must be added on the production version.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- The `beta` tag onto the `Composer` functionality 
```

## Subject

This feature exists for over 18 months and she's functional.
The beta tag isn't present on all languages, moreover this tag should be added with an event listener and preg_matching, or directly in the template, but not in the translations files.