### PR TITLE
Replaced deprecated doctrine methods

### DIFF
--- a/Admin/SharedBlockAdmin.php
+++ b/Admin/SharedBlockAdmin.php
@@ -52,8 +52,9 @@ class SharedBlockAdmin extends BaseBlockAdmin
         $query = parent::createQuery($context);
 
         // Filter on blocks without page and parents
-        $query->andWhere($query->expr()->isNull($query->getRootAlias().'.page'));
-        $query->andWhere($query->expr()->isNull($query->getRootAlias().'.parent'));
+        $rootAlias = current($query->getRootAliases());
+        $query->andWhere($query->expr()->isNull($rootAlias.'.page'));
+        $query->andWhere($query->expr()->isNull($rootAlias.'.parent'));
 
         return $query;
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because…

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

```markdown
### Fixed
 - Fixed deprecated doctrine methods
```

## Subject

Replaced deprecated `getRootAlias` with `getRootAliases`method.
