### PR TITLE
Fix Unique Url Validator for Dynamic pages

### DIFF
--- a/Tests/Validator/UniqueUrlValidatorTest.php
+++ b/Tests/Validator/UniqueUrlValidatorTest.php
@@ -64,4 +64,25 @@ class UniqueUrlValidatorTest extends \PHPUnit_Framework_TestCase
 
         $validator->validate($page, new UniqueUrl());
     }
+
+    public function testValidateWithPageDynamic()
+    {
+        $site = $this->getMock('Sonata\PageBundle\Model\SiteInterface');
+
+        $page = $this->getMock('Sonata\PageBundle\Model\PageInterface');
+        $page->expects($this->once())->method('getSite')->will($this->returnValue($site));
+        $page->expects($this->once())->method('isError')->will($this->returnValue(false));
+        $page->expects($this->once())->method('isDynamic')->will($this->returnValue(true));
+        $page->expects($this->any())->method('getUrl')->will($this->returnValue('/salut'));
+
+        $manager = $this->getMock('Sonata\PageBundle\Model\PageManagerInterface');
+
+        $context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
+        $context->expects($this->never())->method('addViolation');
+
+        $validator = new UniqueUrlValidator($manager);
+        $validator->initialize($context);
+
+        $validator->validate($page, new UniqueUrl());
+    }
 }

--- a/Validator/UniqueUrlValidator.php
+++ b/Validator/UniqueUrlValidator.php
@@ -49,8 +49,8 @@ class UniqueUrlValidator extends ConstraintValidator
             return;
         }
 
-        // do not validated error page
-        if ($value->isError()) {
+        // do not validate error or dynamic pages
+        if ($value->isError() || $value->isDynamic()) {
             return;
         }
 


### PR DESCRIPTION
## Changelog

```markdown
### Changed
- UniqueUrl validation isn't checked for Dynamic pages anymore
```
## Subject

The goal of this is to allow saving Dynamic pages even if the Url already exists.
On Dynamic pages, if we have parameters in the URL, we can have multiples pages with the same url.

