### PR TITLE
Give more precision at UniqueUrlValidator

### DIFF
--- a/Resources/translations/validators.de.xliff
+++ b/Resources/translations/validators.de.xliff
@@ -3,9 +3,15 @@
     <file source-language="en" target-language="de" datatype="plaintext" original="file.ext">
         <header/>
         <body>
-            <trans-unit id="26" resname="error.uniq_url">
+            <trans-unit id="error.uniq_url" resname="error.uniq_url">
                 <source>error.uniq_url</source>
-                <target>Die URL '%url%' ist bereits mit einer anderen Seite verknüpft</target>
+                <target>Die URL '%url%' ist bereits mit einer anderen Seite verknüpft.</target>
+            </trans-unit>
+            <trans-unit id="error.uniq_url.parent_unselect" resname="error.uniq_url.parent_unselect">
+                <source>error.uniq_url.parent_unselect</source>
+                <target>Die Basis-URL '/' ist bereits mit einer anderen Seite verknüpft.
+                Bitte wählen Sie eine übergeordnet Seite.
+                </target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/validators.en.xliff
+++ b/Resources/translations/validators.en.xliff
@@ -3,9 +3,14 @@
     <file source-language="en" target-language="en" datatype="plaintext" original="file.ext">
         <header/>
         <body>
-            <trans-unit id="26" resname="error.uniq_url">
+            <trans-unit id="error.uniq_url" resname="error.uniq_url">
                 <source>error.uniq_url</source>
-                <target>The URL '%url%' is already associated with another page</target>
+                <target>The URL '%url%' is already associated with another page.</target>
+            </trans-unit>
+            <trans-unit id="error.uniq_url.parent_unselect" resname="error.uniq_url.parent_unselect">
+                <source>error.uniq_url.parent_unselect</source>
+                <target>The root URL '/' is already associated with another page of this site, please select a parent.
+                </target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/validators.es.xliff
+++ b/Resources/translations/validators.es.xliff
@@ -3,9 +3,14 @@
     <file source-language="en" target-language="es" datatype="plaintext" original="file.ext">
         <header/>
         <body>
-            <trans-unit id="26" resname="error.uniq_url">
+            <trans-unit id="error.uniq_url" resname="error.uniq_url">
                 <source>error.uniq_url</source>
-                <target>La URL '%url%' ya está asociada a otra página</target>
+                <target>La URL '%url%' ya está asociada a otra página.</target>
+            </trans-unit>
+            <trans-unit id="error.uniq_url.parent_unselect" resname="error.uniq_url.parent_unselect">
+                <source>error.uniq_url.parent_unselect</source>
+                <target>La URL raíz '/' ya está asociada a otra página de este sitio, por favor selecciona un padre.
+                </target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/validators.fr.xliff
+++ b/Resources/translations/validators.fr.xliff
@@ -3,9 +3,14 @@
     <file source-language="en" target-language="fr" datatype="plaintext" original="file.ext">
         <header/>
         <body>
-            <trans-unit id="26" resname="error.uniq_url">
+            <trans-unit id="error.uniq_url" resname="error.uniq_url">
                 <source>error.uniq_url</source>
-                <target>L'URL '%url%' est déjà associée à une autre page</target>
+                <target>L'URL '%url%' est déjà associée à une autre page.</target>
+            </trans-unit>
+            <trans-unit id="error.uniq_url.parent_unselect" resname="error.uniq_url.parent_unselect">
+                <source>error.uniq_url.parent_unselect</source>
+                <target>L'URL racine '/' est déjà associée à une autre page de ce site, veuillez sélectionner
+                un parent.</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/validators.hu.xliff
+++ b/Resources/translations/validators.hu.xliff
@@ -3,9 +3,13 @@
     <file source-language="en" target-language="hu" datatype="plaintext" original="validators.en.xliff">
         <header/>
         <body>
-            <trans-unit id="26" resname="error.uniq_url">
+            <trans-unit id="error.uniq_url" resname="error.uniq_url">
                 <source>error.uniq_url</source>
-                <target>A(z) '%url%' URL már társítva lett egy másik oldalhoz</target>
+                <target>A(z) '%url%' URL már társítva lett egy másik oldalhoz.</target>
+            </trans-unit>
+            <trans-unit id="error.uniq_url.parent_unselect" resname="error.uniq_url.parent_unselect">
+                <source>error.uniq_url.parent_unselect</source>
+                <target>error.uniq_url.parent_unselect</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/validators.ja.xliff
+++ b/Resources/translations/validators.ja.xliff
@@ -3,9 +3,13 @@
     <file source-language="en" target-language="ja" datatype="plaintext" original="file.ext">
         <header/>
         <body>
-            <trans-unit id="26" resname="error.uniq_url">
+            <trans-unit id="error.uniq_url" resname="error.uniq_url">
                 <source>error.uniq_url</source>
                 <target>URL '%url%' はすでに他のページに関連づけられています</target>
+            </trans-unit>
+            <trans-unit id="error.uniq_url.parent_unselect" resname="error.uniq_url.parent_unselect">
+                <source>error.uniq_url.parent_unselect</source>
+                <target>error.uniq_url.parent_unselect</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/validators.nl.xliff
+++ b/Resources/translations/validators.nl.xliff
@@ -3,9 +3,13 @@
     <file source-language="en" target-language="nl" datatype="plaintext" original="file.ext">
         <header/>
         <body>
-            <trans-unit id="26" resname="error.uniq_url">
+            <trans-unit id="error.uniq_url" resname="error.uniq_url">
                 <source>error.uniq_url</source>
-                <target>De URL '%url%' is al gekoppeld aan een andere pagina</target>
+                <target>De URL '%url%' is al gekoppeld aan een andere pagina.</target>
+            </trans-unit>
+            <trans-unit id="error.uniq_url.parent_unselect" resname="error.uniq_url.parent_unselect">
+                <source>error.uniq_url.parent_unselect</source>
+                <target>error.uniq_url.parent_unselect</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/validators.pt_BR.xliff
+++ b/Resources/translations/validators.pt_BR.xliff
@@ -3,9 +3,13 @@
     <file source-language="en" target-language="pt" datatype="plaintext" original="file.ext">
         <header/>
         <body>
-            <trans-unit id="26" resname="error.uniq_url">
+            <trans-unit id="error.uniq_url" resname="error.uniq_url">
                 <source>error.uniq_url</source>
-                <target>A URL '%url%' já está associada a outra página</target>
+                <target>A URL '%url%' já está associada a outra página.</target>
+            </trans-unit>
+            <trans-unit id="error.uniq_url.parent_unselect" resname="error.uniq_url.parent_unselect">
+                <source>error.uniq_url.parent_unselect</source>
+                <target>error.uniq_url.parent_unselect</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/validators.sk.xliff
+++ b/Resources/translations/validators.sk.xliff
@@ -3,9 +3,13 @@
     <file source-language="en" target-language="sk" datatype="plaintext" original="file.ext">
         <header/>
         <body>
-            <trans-unit id="26" resname="error.uniq_url">
+            <trans-unit id="error.uniq_url" resname="error.uniq_url">
                 <source>error.uniq_url</source>
-                <target>URL '%url%' je už prepojená s inou stránku</target>
+                <target>URL '%url%' je už prepojená s inou stránku.</target>
+            </trans-unit>
+            <trans-unit id="error.uniq_url.parent_unselect" resname="error.uniq_url.parent_unselect">
+                <source>error.uniq_url.parent_unselect</source>
+                <target>error.uniq_url.parent_unselect</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/validators.sl.xliff
+++ b/Resources/translations/validators.sl.xliff
@@ -3,9 +3,13 @@
     <file source-language="en" target-language="sl" datatype="plaintext" original="file.ext">
         <header/>
         <body>
-            <trans-unit id="26" resname="error.uniq_url">
+            <trans-unit id="error.uniq_url" resname="error.uniq_url">
                 <source>error.uniq_url</source>
                 <target>Naslov '%url%' je že v uporabi.</target>
+            </trans-unit>
+            <trans-unit id="error.uniq_url.parent_unselect" resname="error.uniq_url.parent_unselect">
+                <source>error.uniq_url.parent_unselect</source>
+                <target>error.uniq_url.parent_unselect</target>
             </trans-unit>
         </body>
     </file>

--- a/Tests/Validator/UniqueUrlValidatorTest.php
+++ b/Tests/Validator/UniqueUrlValidatorTest.php
@@ -32,7 +32,7 @@ class UniqueUrlValidatorTest extends \PHPUnit_Framework_TestCase
         $manager->expects($this->once())->method('findBy')->will($this->returnValue(array($page)));
 
         $context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
-        $context->expects($this->never())->method('addViolation');
+        $context->expects($this->never())->method('addViolationAt');
 
         $validator = new UniqueUrlValidator($manager);
         $validator->initialize($context);
@@ -57,7 +57,39 @@ class UniqueUrlValidatorTest extends \PHPUnit_Framework_TestCase
         $manager->expects($this->once())->method('findBy')->will($this->returnValue(array($page, $pageFound)));
 
         $context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
-        $context->expects($this->once())->method('addViolation');
+        $context
+            ->expects($this->once())
+            ->method('addViolationAt')
+            ->with($this->equalTo('url'), $this->equalTo('error.uniq_url'));
+
+        $validator = new UniqueUrlValidator($manager);
+        $validator->initialize($context);
+
+        $validator->validate($page, new UniqueUrl());
+    }
+
+    public function testValidateWithRootUrlAndNoParent()
+    {
+        $site = $this->getMock('Sonata\PageBundle\Model\SiteInterface');
+
+        $page = $this->getMock('Sonata\PageBundle\Model\PageInterface');
+        $page->expects($this->exactly(2))->method('getSite')->will($this->returnValue($site));
+        $page->expects($this->exactly(2))->method('isError')->will($this->returnValue(false));
+        $page->expects($this->exactly(1))->method('getParent')->will($this->returnValue(null));
+        $page->expects($this->any())->method('getUrl')->will($this->returnValue('/'));
+
+        $pageFound = $this->getMock('Sonata\PageBundle\Model\PageInterface');
+        $pageFound->expects($this->any())->method('getUrl')->will($this->returnValue('/'));
+
+        $manager = $this->getMock('Sonata\PageBundle\Model\PageManagerInterface');
+        $manager->expects($this->once())->method('fixUrl');
+        $manager->expects($this->once())->method('findBy')->will($this->returnValue(array($page, $pageFound)));
+
+        $context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
+        $context
+            ->expects($this->once())
+            ->method('addViolationAt')
+            ->with($this->equalTo('parent'), $this->equalTo('error.uniq_url.parent_unselect'));
 
         $validator = new UniqueUrlValidator($manager);
         $validator->initialize($context);
@@ -78,7 +110,7 @@ class UniqueUrlValidatorTest extends \PHPUnit_Framework_TestCase
         $manager = $this->getMock('Sonata\PageBundle\Model\PageManagerInterface');
 
         $context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
-        $context->expects($this->never())->method('addViolation');
+        $context->expects($this->never())->method('addViolationAt');
 
         $validator = new UniqueUrlValidator($manager);
         $validator->initialize($context);


### PR DESCRIPTION
I am targetting 3.x because no BC Break

Fixes at part https://github.com/sonata-project/SonataAdminBundle/issues/4099

## Changelog

```markdown
### Changed
- `UniqueUrlValidator` is now more specific with the error, and the error is attached to a field
```

## To do

- [x] Update the tests

## Subject

The error should be attached to a field, and forgetting to select a parent is now indicated

See [#4099](https://github.com/sonata-project/SonataAdminBundle/issues/4099)