### PR TITLE
Use the default admin template to render to top menu

### DIFF
--- a/Resources/views/PageAdmin/compose.html.twig
+++ b/Resources/views/PageAdmin/compose.html.twig
@@ -11,10 +11,6 @@ file that was distributed with this source code.
 
 {% extends 'SonataAdminBundle:CRUD:action.html.twig' %}
 
-{% block tab_menu %}
-    {{ knp_menu_render(admin.sidemenu(action), {'currentClass' : 'active'}, 'list') }}
-{% endblock %}
-
 {% block body_attributes %}class="sonata-bc skin-black fixed page-composer-page sonata-ba-no-side-menu"{% endblock %}
 
 {% block content %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because there is a bug when the compose action is rendered. The menu items are not rendered.

![screen shot 2016-09-02 at 10 19 30](https://cloud.githubusercontent.com/assets/14672/18199190/8b3410b4-70ff-11e6-9c27-e02799a87c88.PNG)


<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- top menu items not translated for the compose action
```


