### PR TITLE
add missing title

### DIFF
--- a/Resources/views/PageAdmin/compose.html.twig
+++ b/Resources/views/PageAdmin/compose.html.twig
@@ -11,6 +11,14 @@ file that was distributed with this source code.
 
 {% extends 'SonataAdminBundle:CRUD:action.html.twig' %}
 
+{% block title %}
+    {{ "title_edit"|trans({'%name%': admin.toString(object)|truncate(15) }, 'SonataAdminBundle') }}
+{% endblock %}
+
+{% block navbar_title %}
+    {{ block('title') }}
+{% endblock %}
+
 {% block body_attributes %}class="sonata-bc skin-black fixed page-composer-page sonata-ba-no-side-menu"{% endblock %}
 
 {% block content %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because the title was missing from the top menu:

<img width="679" alt="screen shot 2016-09-02 at 13 32 07" src="https://cloud.githubusercontent.com/assets/14672/18202699/1a82cc30-7112-11e6-8c9a-83371e62a7d2.PNG">
<img width="756" alt="screen shot 2016-09-02 at 13 32 23" src="https://cloud.githubusercontent.com/assets/14672/18202700/1a9a3168-7112-11e6-98dd-e27da2a0a89f.PNG">


<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #
Fixes #

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- add missing title in the compose action.
```


