### PR TITLE
Use proper menu helper to generate top menu link

### DIFF
--- a/Admin/PageAdmin.php
+++ b/Admin/PageAdmin.php
@@ -432,19 +432,19 @@ class PageAdmin extends AbstractAdmin
         $id = $admin->getRequest()->get('id');
 
         $menu->addChild('sidemenu.link_edit_page',
-            array('uri' => $admin->generateUrl('edit', array('id' => $id)))
+            $admin->generateMenuUrl('edit', array('id' => $id))
         );
 
         $menu->addChild('sidemenu.link_compose_page',
-            array('uri' => $admin->generateUrl('compose', array('id' => $id)))
+            $admin->generateMenuUrl('compose', array('id' => $id))
         );
 
         $menu->addChild('sidemenu.link_list_blocks',
-            array('uri' => $admin->generateUrl('sonata.page.admin.page|sonata.page.admin.block.list', array('id' => $id)))
+            $admin->generateMenuUrl('sonata.page.admin.block.list', array('id' => $id))
         );
 
         $menu->addChild('sidemenu.link_list_snapshots',
-            array('uri' => $admin->generateUrl('sonata.page.admin.page|sonata.page.admin.snapshot.list', array('id' => $id)))
+            $admin->generateMenuUrl('sonata.page.admin.snapshot.list', array('id' => $id))
         );
 
         if (!$this->getSubject()->isHybrid() && !$this->getSubject()->isInternal()) {
@@ -454,7 +454,7 @@ class PageAdmin extends AbstractAdmin
                 );
             } catch (\Exception $e) {
                 // avoid crashing the admin if the route is not setup correctly
-//                throw $e;
+                // throw $e;
             }
         }
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because the current top menu is not preselected

<img width="756" alt="screen shot 2016-09-02 at 13 32 23" src="https://cloud.githubusercontent.com/assets/14672/18202877/66559b14-7113-11e6-9d75-293aea98e6c5.PNG">
<img width="718" alt="screen shot 2016-09-02 at 13 41 17" src="https://cloud.githubusercontent.com/assets/14672/18202878/666ea99c-7113-11e6-9766-1acaee5d109d.PNG">

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Top menu links for edit/compose action are now highlighted,
```

