### PR TITLE
Save custom options on redirect

### DIFF
--- a/Controller/PageAdminController.php
+++ b/Controller/PageAdminController.php
@@ -117,12 +117,14 @@ class PageAdminController extends Controller
             $sites = $this->get('sonata.page.manager.site')->findBy(array());
 
             if (count($sites) == 1) {
-                return $this->redirect($this->admin->generateUrl('create', array(
+                $options = array_merge(array(
                     'siteId' => $sites[0]->getId(),
                     'uniqid' => $this->admin->getUniqid(),
-                )));
-            }
+                ), $request->query->all());
 
+                return $this->redirect($this->admin->generateUrl('create', $options));
+            }
+            
             try {
                 $current = $this->get('sonata.page.site.selector')->retrieve();
             } catch (\RuntimeException $e) {

--- a/Controller/PageAdminController.php
+++ b/Controller/PageAdminController.php
@@ -124,7 +124,7 @@ class PageAdminController extends Controller
 
                 return $this->redirect($this->admin->generateUrl('create', $options));
             }
-            
+
             try {
                 $current = $this->get('sonata.page.site.selector')->retrieve();
             } catch (\RuntimeException $e) {

--- a/Controller/PageAdminController.php
+++ b/Controller/PageAdminController.php
@@ -117,12 +117,10 @@ class PageAdminController extends Controller
             $sites = $this->get('sonata.page.manager.site')->findBy(array());
 
             if (count($sites) == 1) {
-                $options = array_merge(array(
+                return $this->redirect($this->admin->generateUrl('create', array(
                     'siteId' => $sites[0]->getId(),
                     'uniqid' => $this->admin->getUniqid(),
-                ), $request->query->all());
-
-                return $this->redirect($this->admin->generateUrl('create', $options));
+                ) + $request->query->all()));
             }
 
             try {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a non-BC fix

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Fixed
 - losing custom query on redirect
```

## Subject

Currently, If I am passing some custom query option, like here
`{{ admin.generateUrl('create', {parent_id: page.id}) }}`
PageAdminController does redirect with `siteId` but without my `parent_id` option.
In my case I am avoiding this by adding siteId manually 
`{{ admin.generateUrl('create', {siteId: page.site.id, parent_id: page.id}) }}`
And this is good solution, but anyway, I think we should save custom options.

<!-- Describe your Pull Request content here -->

