### PR TITLE
Added missing upgrade notes in #697

### DIFF
--- a/CmsManager/CmsSnapshotManager.php
+++ b/CmsManager/CmsSnapshotManager.php
@@ -152,7 +152,7 @@ class CmsSnapshotManager extends BaseCmsPageManager
                 throw new PageNotFoundException();
             }
 
-            // NEXT_MJAOR: Remove this check
+            // NEXT_MAJOR: Remove this check
             if (method_exists($this->snapshotManager, 'createSnapshotPageProxy')) {
                 $page = $this->snapshotManager->createSnapshotPageProxy($this->transformer, $snapshot);
             } else {

--- a/Entity/SnapshotManager.php
+++ b/Entity/SnapshotManager.php
@@ -173,6 +173,11 @@ class SnapshotManager extends BaseEntityManager implements SnapshotManagerInterf
      */
     public function getPageByName($routeName)
     {
+        @trigger_error(
+            'The '.__METHOD__.' method is deprecated since version 3.x and will be removed in 4.0.',
+            E_USER_DEPRECATED
+        );
+
         $snapshots = $this->getEntityManager()->createQueryBuilder()
             ->select('s')
             ->from($this->class, 's')

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -6,3 +6,7 @@ UPGRADE 3.x
 All files under the ``Tests`` directory are now correctly handled as internal test classes. 
 You can't extend them anymore, because they are only loaded when running internal tests. 
 More information can be found in the [composer docs](https://getcomposer.org/doc/04-schema.md#autoload-dev).
+
+### Deprecations
+
+The ``SnapshotManager::getPageByName`` method is deprecated and will be removed with the next major release.


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this adds only upgrade informations.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Fixes #697

## Subject

Adds missing informations for #697.
