### PR TITLE
Fix: Mixed Content in case of: No content was found #725

### DIFF
--- a/Model/Site.php
+++ b/Model/Site.php
@@ -151,11 +151,30 @@ abstract class Site implements SiteInterface
      */
     public function getUrl()
     {
+        if ($this->isSecureRequest()) {
+            $protcol = 'https';
+        } else {
+            $protcol = 'http';
+        }
+
         if ($this->isLocalhost()) {
             return $this->getRelativePath();
         }
 
-        return sprintf('http://%s%s', $this->getHost(), $this->getRelativePath());
+        return sprintf($protcol. '://%s%s', $this->getHost(), $this->getRelativePath());
+    }
+
+    /**
+     * Is secure site request?
+     *
+     * @access  private
+     * @return  bool
+     */
+    private function isSecureRequest()
+    {
+        return
+            (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off')
+            || $_SERVER['SERVER_PORT'] == 443;
     }
 
     /**

--- a/Model/Site.php
+++ b/Model/Site.php
@@ -151,26 +151,12 @@ abstract class Site implements SiteInterface
      */
     public function getUrl()
     {
-        if ($this->isSecureRequest()) {
-            $protcol = 'https';
-        } else {
-            $protcol = 'http';
-        }
-
         if ($this->isLocalhost()) {
             return $this->getRelativePath();
         }
 
-        return sprintf($protcol.'://%s%s', $this->getHost(), $this->getRelativePath());
+        return sprintf('//%s%s', $this->getHost(), $this->getRelativePath());
     }
-
-    /**
-     * {@inheritdoc}
-     */
-     private function isSecureRequest()
-     {
-         return !empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off';
-     }
 
     /**
      * @return bool

--- a/Model/Site.php
+++ b/Model/Site.php
@@ -169,7 +169,7 @@ abstract class Site implements SiteInterface
      */
      private function isSecureRequest()
      {
-         return (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off');
+         return !empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off';
      }
 
     /**

--- a/Model/Site.php
+++ b/Model/Site.php
@@ -167,12 +167,10 @@ abstract class Site implements SiteInterface
     /**
      * {@inheritdoc}
      */
-    private function isSecureRequest()
-    {
-        return
-            (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off')
-            || $_SERVER['SERVER_PORT'] == 443;
-    }
+     private function isSecureRequest()
+     {
+         return (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off');
+     }
 
     /**
      * @return bool

--- a/Model/Site.php
+++ b/Model/Site.php
@@ -161,14 +161,11 @@ abstract class Site implements SiteInterface
             return $this->getRelativePath();
         }
 
-        return sprintf($protcol. '://%s%s', $this->getHost(), $this->getRelativePath());
+        return sprintf($protcol.'://%s%s', $this->getHost(), $this->getRelativePath());
     }
 
     /**
-     * Is secure site request?
-     *
-     * @access  private
-     * @return  bool
+     * {@inheritdoc}
      */
     private function isSecureRequest()
     {


### PR DESCRIPTION
Fix for Issue #725 
## Changelog

``` markdown
### Fixed
- Mixed Content in case of: No content was found #725
```
## Subject

In case of an https connection, the user will now always be redirected to the https site and not to the http site.

Please see my issue #725 

Old Code:
![screenshot 2016-09-25 17 47 04](https://cloud.githubusercontent.com/assets/2656987/18816448/8ee29eee-834a-11e6-9437-d3676638cfe9.png)

Fixed Code:
![screenshot 2016-09-25 18 05 22](https://cloud.githubusercontent.com/assets/2656987/18816457/acc14e24-834a-11e6-9e3e-8b4382c8841f.png)
