### PR TITLE
remove type if current action is not creation

### DIFF
--- a/Admin/BlockAdmin.php
+++ b/Admin/BlockAdmin.php
@@ -70,6 +70,14 @@ class BlockAdmin extends BaseBlockAdmin
             $parameters['composer'] = $composer;
         }
 
+        $subject = $this->getSubject();
+
+        if ($subject && $subject->getId()) {
+            if (array_key_exists('type', $parameters)) {
+                $parameters['type'] = null;
+            }
+        }
+
         return $parameters;
     }
 

--- a/Tests/Admin/BlockAdminTest.php
+++ b/Tests/Admin/BlockAdminTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\PageBundle\Tests\Admin;
+
+use Sonata\PageBundle\Admin\BlockAdmin;
+use Sonata\PageBundle\Tests\Model\Block;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @author Artur Vesker <arturvesker@gmail.com>
+ */
+class BlockAdminTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetPersistentParametersWithPersistedSubject()
+    {
+        $admin = new BlockAdmin('sonata.page.admin.page', Block::class, 'SonataPageBundle:BlockAdmin');
+        $subject = new Block();
+        $subject->setId(1);
+        $admin->setSubject($subject);
+        $admin->setRequest(Request::create('/?type=foobar'));
+        $this->assertSame(array('type' => null), $admin->getPersistentParameters());
+    }
+
+    public function testGetPersistentParametersWithNewSubject()
+    {
+        $admin = new BlockAdmin('sonata.page.admin.page', Block::class, 'SonataPageBundle:BlockAdmin');
+        $subject = new Block();
+        $admin->setSubject($subject);
+        $admin->setRequest(Request::create('/?type=foobar'));
+        $this->assertSame(array('type' => 'foobar'), $admin->getPersistentParameters());
+    }
+}

--- a/Tests/Model/Block.php
+++ b/Tests/Model/Block.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\PageBundle\Tests\Model;
+
+/**
+ * @author Artur Vesker <arturvesker@gmail.com>
+ */
+class Block extends \Sonata\PageBundle\Model\Block
+{
+    protected $id;
+
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

I am targetting this branch, becaus this is non-BC fix

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->

``` markdown
### Fixed
- New block type is taken from previous one
```
## Subject

When we are adding a block and clicking Actions > Add new - type of current block will be saved in url and user won't be asked for it.
If we save changes using "Update and close" button, we will be redirected to list page with type parameter, and it also will be saved in url if we will try to create new block (and we won't be asked for type).

<!-- Describe your Pull Request content here -->
