### PR TITLE
Updating minimum PHP version to 5.6

### DIFF
--- a/CmsManager/CmsSnapshotManager.php
+++ b/CmsManager/CmsSnapshotManager.php
@@ -152,12 +152,7 @@ class CmsSnapshotManager extends BaseCmsPageManager
                 throw new PageNotFoundException();
             }
 
-            // NEXT_MAJOR: Remove this check
-            if (method_exists($this->snapshotManager, 'createSnapshotPageProxy')) {
-                $page = $this->snapshotManager->createSnapshotPageProxy($this->transformer, $snapshot);
-            } else {
-                $page = new SnapshotPageProxy($this->snapshotManager, $this->transformer, $snapshot);
-            }
+            $page = $this->snapshotManager->createSnapshotPageProxy($this->transformer, $snapshot);
 
             $this->pages[$id] = false;
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -90,11 +90,7 @@ EOF;
                 ->prototype('scalar')->end()
             ->end()
             ->scalarNode('slugify_service')
-                // NEXT_MAJOR: reword this info message
-                ->info('You should use: sonata.core.slugify.cocur, but for BC we keep \'sonata.core.slugify.native\' as default')
-
-                // NEXT_MAJOR: use "sonata.core.slugify.cocur" instead of "sonata.core.slugify.native" as default value
-                ->defaultValue('sonata.core.slugify.native')
+                ->defaultValue('sonata.core.slugify.cocur')
             ->end()
             ->arrayNode('ignore_routes')
                 ->defaultValue(array(

--- a/Entity/SnapshotManager.php
+++ b/Entity/SnapshotManager.php
@@ -54,19 +54,10 @@ class SnapshotManager extends BaseEntityManager implements SnapshotManagerInterf
      * @param array                             $templates                An array of templates
      * @param SnapshotPageProxyFactoryInterface $snapshotPageProxyFactory
      */
-    public function __construct($class, ManagerRegistry $registry, $templates = array(), SnapshotPageProxyFactoryInterface $snapshotPageProxyFactory = null)
+    public function __construct($class, ManagerRegistry $registry, $templates = array(), SnapshotPageProxyFactoryInterface $snapshotPageProxyFactory)
     {
         parent::__construct($class, $registry);
-
-        // NEXT_MAJOR: make $snapshotPageProxyFactory parameter required
-        if (null === $snapshotPageProxyFactory) {
-            @trigger_error(
-                'The $snapshotPageProxyFactory parameter is required with the next major release.',
-                E_USER_DEPRECATED
-            );
-            $snapshotPageProxyFactory = new SnapshotPageProxyFactory('Sonata\PageBundle\Model\SnapshotPageProxy');
-        }
-
+        
         $this->templates = $templates;
         $this->snapshotPageProxyFactory = $snapshotPageProxyFactory;
     }

--- a/Model/SnapshotManagerInterface.php
+++ b/Model/SnapshotManagerInterface.php
@@ -44,7 +44,6 @@ interface SnapshotManagerInterface extends ManagerInterface, PageableManagerInte
      */
     public function cleanup(PageInterface $page, $keep);
 
-    // NEXT_MAJOR: Uncomment this method
     /*
      * Create snapShotPageProxy instance.
      *
@@ -53,5 +52,5 @@ interface SnapshotManagerInterface extends ManagerInterface, PageableManagerInte
      *
      * @return SnapshotPageProxyInterface
      */
-    // public function createSnapshotPageProxy(TransformerInterface $transformer, SnapshotInterface $snapshot);
+     public function createSnapshotPageProxy(TransformerInterface $transformer, SnapshotInterface $snapshot);
 }

--- a/README.md
+++ b/README.md
@@ -39,3 +39,4 @@ This package is available under the [MIT license](LICENSE).
 [coveralls_stable_link]: https://coveralls.io/github/sonata-project/SonataPageBundle?branch=3.x
 [coveralls_unstable_badge]: https://coveralls.io/repos/github/sonata-project/SonataPageBundle/badge.svg?branch=master
 [coveralls_unstable_link]: https://coveralls.io/github/sonata-project/SonataPageBundle?branch=master
+

--- a/SonataPageBundle.php
+++ b/SonataPageBundle.php
@@ -59,19 +59,7 @@ class SonataPageBundle extends Bundle
         }
 
         call_user_func(array($class, 'setSlugifyMethod'), function ($text) use ($container) {
-            // NEXT_MAJOR: remove this check
-            if ($container->hasParameter('sonata.page.slugify_service')) {
-                $id = $container->getParameter('sonata.page.slugify_service');
-            } else {
-                @trigger_error(
-                    'The "sonata.core.slugify.native" service is deprecated since 2.3.9, to be removed in 4.0. '.
-                    'Use "sonata.core.slugify.cocur" service through config instead.',
-                    E_USER_DEPRECATED
-                );
-
-                // default BC value, you should use sonata.core.slugify.cocur
-                $id = 'sonata.core.slugify.native';
-            }
+            $id = $container->getParameter('sonata.page.slugify_service');
 
             $service = $container->get($id);
 

--- a/Tests/Model/PageTest.php
+++ b/Tests/Model/PageTest.php
@@ -13,11 +13,6 @@ namespace Sonata\PageBundle\Tests\Model;
 
 class PageTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * NEXT_MAJOR: remove the legacy group from this test.
-     *
-     * @group legacy
-     */
     public function testSlugify()
     {
         setlocale(LC_ALL, 'en_US.utf8');

--- a/Tests/Model/PageTest.php
+++ b/Tests/Model/PageTest.php
@@ -13,19 +13,6 @@ namespace Sonata\PageBundle\Tests\Model;
 
 class PageTest extends \PHPUnit_Framework_TestCase
 {
-    public function testSlugify()
-    {
-        setlocale(LC_ALL, 'en_US.utf8');
-        setlocale(LC_CTYPE, 'en_US.utf8');
-
-        $this->assertEquals(Page::slugify('test'), 'test');
-        $this->assertEquals(Page::slugify('S§!@@#$#$alut'), 's-alut');
-        $this->assertEquals(Page::slugify('Symfony2'), 'symfony2');
-        $this->assertEquals(Page::slugify('test'), 'test');
-        $this->assertEquals(Page::slugify('c\'est bientôt l\'été'), 'c-est-bientot-l-ete');
-        $this->assertEquals(Page::slugify(urldecode('%2Fc\'est+bientôt+l\'été')), 'c-est-bientot-l-ete');
-    }
-
     public function testHeader()
     {
         $expectedHeaders = array(

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^5.3 || ^7.0",
+        "php": "^5.6 || ^7.0",
         "symfony/config": "^2.3.9",
         "symfony/console": "^2.3",
         "symfony/debug": "^2.3",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

I am targetting this branch, because it's a PHP version change / potential BC break

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Refs # https://github.com/sonata-project/dev-kit/issues/208
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->

``` markdown
### Deprecated
- PHP versions 5.3 - 5.5
```

## Subject

<!-- Describe your Pull Request content here -->

Updating minimum PHP version to 5.6, as per https://github.com/sonata-project/dev-kit/issues/208