### PR TITLE
Add RelativePath in View page link

### DIFF
--- a/Admin/PageAdmin.php
+++ b/Admin/PageAdmin.php
@@ -449,15 +449,15 @@ class PageAdmin extends AbstractAdmin
 
         if (!$this->getSubject()->isHybrid() && !$this->getSubject()->isInternal()) {
             try {
-                $url = $this->getSubject()->getUrl();
-                $relativePath = $page->getSite()->getRelativePath();
-                if (!empty($relativePath)) {
-                    $url = $relativePath.$url;
+                $path = $this->getSubject()->getUrl();
+                $siteRelativePath = $page->getSite()->getRelativePath();
+                if (!empty($siteRelativePath)) {
+                    $path = $siteRelativePath.$path;
                 }
                 
                 $menu->addChild(
                     'view_page',
-                    array('uri' => $this->getRouteGenerator()->generate('page_slug', array('path' => $url)))
+                    array('uri' => $this->getRouteGenerator()->generate('page_slug', array('path' => $path)))
                 );
             } catch (\Exception $e) {
                 // avoid crashing the admin if the route is not setup correctly

--- a/Admin/PageAdmin.php
+++ b/Admin/PageAdmin.php
@@ -449,8 +449,15 @@ class PageAdmin extends AbstractAdmin
 
         if (!$this->getSubject()->isHybrid() && !$this->getSubject()->isInternal()) {
             try {
-                $menu->addChild('view_page',
-                    array('uri' => $this->getRouteGenerator()->generate('page_slug', array('path' => $this->getSubject()->getUrl())))
+                $url = $this->getSubject()->getUrl();
+                $relativePath = $page->getSite()->getRelativePath();
+                if (!empty($relativePath)) {
+                    $url = $relativePath.$url;
+                }
+                
+                $menu->addChild(
+                    'view_page',
+                    array('uri' => $this->getRouteGenerator()->generate('page_slug', array('path' => $url)))
                 );
             } catch (\Exception $e) {
                 // avoid crashing the admin if the route is not setup correctly

--- a/Admin/PageAdmin.php
+++ b/Admin/PageAdmin.php
@@ -454,7 +454,7 @@ class PageAdmin extends AbstractAdmin
                 if (!empty($siteRelativePath)) {
                     $path = $siteRelativePath.$path;
                 }
-                
+
                 $menu->addChild(
                     'view_page',
                     array('uri' => $this->getRouteGenerator()->generate('page_slug', array('path' => $path)))


### PR DESCRIPTION
I am targetting this branch, because there's a bug in "View page" link that doesnt take into account the relative path of the sub site.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->

``` markdown
### Added
- Add relative path in "View page link"
```
## Subject

When creating a subsite, the relative path is not taking into account.
