### PR TITLE
Improved extensibility of controller actions

### DIFF
--- a/Controller/Api/BlockController.php
+++ b/Controller/Api/BlockController.php
@@ -67,11 +67,12 @@ class BlockController
      *
      * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
      *
-     * @param $id
+     * @param Request $request
+     * @param int     $id
      *
      * @return BlockInterface
      */
-    public function getBlockAction($id)
+    public function getBlockAction(Request $request, $id)
     {
         return $this->getBlock($id);
     }
@@ -92,14 +93,14 @@ class BlockController
      *  }
      * )
      *
-     * @param int     $id      A Block identifier
      * @param Request $request A Symfony request
+     * @param int     $id      A Block identifier
      *
      * @return BlockInterface
      *
      * @throws NotFoundHttpException
      */
-    public function putBlockAction($id, Request $request)
+    public function putBlockAction(Request $request, $id)
     {
         $block = $id ? $this->getBlock($id) : null;
 
@@ -140,13 +141,12 @@ class BlockController
      *  }
      * )
      *
-     * @param int $id A Block identifier
+     * @param Request $request
+     * @param int     $id A Block identifier
      *
-     * @return \FOS\RestBundle\View\View
-     *
-     * @throws NotFoundHttpException
+     * @return FOSRestView
      */
-    public function deleteBlockAction($id)
+    public function deleteBlockAction(Request $request, $id)
     {
         $block = $this->getBlock($id);
 

--- a/Controller/Api/PageController.php
+++ b/Controller/Api/PageController.php
@@ -100,11 +100,12 @@ class PageController
      *
      * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
      *
+     * @param Request               $request
      * @param ParamFetcherInterface $paramFetcher
      *
      * @return PagerInterface
      */
-    public function getPagesAction(ParamFetcherInterface $paramFetcher)
+    public function getPagesAction(Request $request, ParamFetcherInterface $paramFetcher)
     {
         $supportedCriteria = array(
             'enabled' => '',
@@ -153,11 +154,12 @@ class PageController
      *
      * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
      *
-     * @param $id
+     * @param Request $request
+     * @param int     $id
      *
      * @return PageInterface
      */
-    public function getPageAction($id)
+    public function getPageAction(Request $request, $id)
     {
         return $this->getPage($id);
     }
@@ -178,11 +180,12 @@ class PageController
      *
      * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
      *
-     * @param $id
+     * @param Request $request
+     * @param int     $id
      *
      * @return BlockInterface[]
      */
-    public function getPageBlocksAction($id)
+    public function getPageBlocksAction(Request $request, $id)
     {
         return $this->getPage($id)->getBlocks();
     }
@@ -203,11 +206,12 @@ class PageController
      *
      * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
      *
-     * @param $id
+     * @param Request $request
+     * @param int     $id
      *
      * @return PageInterface[]
      */
-    public function getPagePagesAction($id)
+    public function getPagePagesAction(Request $request, $id)
     {
         $page = $this->getPage($id);
 
@@ -230,14 +234,14 @@ class PageController
      *  }
      * )
      *
-     * @param int     $id      A Page identifier
      * @param Request $request A Symfony request
+     * @param int     $id      A Page identifier
      *
      * @return BlockInterface
      *
      * @throws NotFoundHttpException
      */
-    public function postPageBlockAction($id, Request $request)
+    public function postPageBlockAction(Request $request, $id)
     {
         $page = $id ? $this->getPage($id) : null;
 
@@ -305,14 +309,14 @@ class PageController
      *  }
      * )
      *
-     * @param int     $id      A Page identifier
      * @param Request $request A Symfony request
+     * @param int     $id      A Page identifier
      *
      * @return PageInterface
      *
      * @throws NotFoundHttpException
      */
-    public function putPageAction($id, Request $request)
+    public function putPageAction(Request $request, $id)
     {
         return $this->handleWritePage($request, $id);
     }
@@ -331,13 +335,12 @@ class PageController
      *  }
      * )
      *
-     * @param int $id A Page identifier
+     * @param Request $request
+     * @param int     $id A Page identifier
      *
-     * @return \FOS\RestBundle\View\View
-     *
-     * @throws NotFoundHttpException
+     * @return FOSRestView
      */
-    public function deletePageAction($id)
+    public function deletePageAction(Request $request, $id)
     {
         $page = $this->getPage($id);
 
@@ -360,13 +363,12 @@ class PageController
      *  }
      * )
      *
-     * @param int $id A Page identifier
+     * @param Request $request
+     * @param int     $id A Page identifier
      *
-     * @return \FOS\RestBundle\View\View
-     *
-     * @throws NotFoundHttpException
+     * @return FOSRestView
      */
-    public function postPageSnapshotAction($id)
+    public function postPageSnapshotAction(Request $request, $id)
     {
         $page = $this->getPage($id);
 
@@ -387,11 +389,11 @@ class PageController
      *  }
      * )
      *
-     * @return \FOS\RestBundle\View\View
+     * @param Request $request
      *
-     * @throws NotFoundHttpException
+     * @return FOSRestView
      */
-    public function postPagesSnapshotsAction()
+    public function postPagesSnapshotsAction(Request $request)
     {
         $sites = $this->siteManager->findAll();
 

--- a/Controller/Api/SiteController.php
+++ b/Controller/Api/SiteController.php
@@ -69,11 +69,12 @@ class SiteController
      *
      * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
      *
+     * @param Request               $request
      * @param ParamFetcherInterface $paramFetcher
      *
      * @return PagerInterface
      */
-    public function getSitesAction(ParamFetcherInterface $paramFetcher)
+    public function getSitesAction(Request $request, ParamFetcherInterface $paramFetcher)
     {
         $supportedCriteria = array(
             'enabled' => '',
@@ -119,11 +120,12 @@ class SiteController
      *
      * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
      *
-     * @param $id
+     * @param Request $request
+     * @param         $id
      *
      * @return SiteInterface
      */
-    public function getSiteAction($id)
+    public function getSiteAction(Request $request, $id)
     {
         return $this->getSite($id);
     }
@@ -167,14 +169,14 @@ class SiteController
      *  }
      * )
      *
-     * @param int     $id      A Site identifier
      * @param Request $request A Symfony request
+     * @param int     $id      A Site identifier
      *
      * @return SiteInterface
      *
      * @throws NotFoundHttpException
      */
-    public function putSiteAction($id, Request $request)
+    public function putSiteAction(Request $request, $id)
     {
         return $this->handleWriteSite($request, $id);
     }
@@ -193,13 +195,12 @@ class SiteController
      *  }
      * )
      *
-     * @param int $id A Site identifier
+     * @param Request $request
+     * @param int     $id A Site identifier
      *
-     * @return \FOS\RestBundle\View\View
-     *
-     * @throws NotFoundHttpException
+     * @return FOSRestView
      */
-    public function deleteSiteAction($id)
+    public function deleteSiteAction(Request $request, $id)
     {
         $site = $this->getSite($id);
 
@@ -210,8 +211,6 @@ class SiteController
 
     /**
      * Retrieves Site with id $id or throws an exception if it doesn't exist.
-     *
-     * @param $id
      *
      * @return SiteInterface
      *

--- a/Controller/Api/SnapshotController.php
+++ b/Controller/Api/SnapshotController.php
@@ -18,6 +18,7 @@ use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use Sonata\DatagridBundle\Pager\PagerInterface;
 use Sonata\PageBundle\Model\SnapshotInterface;
 use Sonata\PageBundle\Model\SnapshotManagerInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
@@ -61,11 +62,12 @@ class SnapshotController
      *
      * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
      *
+     * @param Request               $request
      * @param ParamFetcherInterface $paramFetcher
      *
      * @return PagerInterface
      */
-    public function getSnapshotsAction(ParamFetcherInterface $paramFetcher)
+    public function getSnapshotsAction(Request $request, ParamFetcherInterface $paramFetcher)
     {
         $supportedCriteria = array(
             'enabled' => '',
@@ -114,11 +116,12 @@ class SnapshotController
      *
      * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
      *
-     * @param $id
+     * @param Request $request
+     * @param         $id
      *
      * @return SnapshotInterface
      */
-    public function getSnapshotAction($id)
+    public function getSnapshotAction(Request $request, $id)
     {
         return $this->getSnapshot($id);
     }
@@ -137,13 +140,12 @@ class SnapshotController
      *  }
      * )
      *
-     * @param int $id A Snapshot identifier
+     * @param Request $request
+     * @param int     $id A Snapshot identifier
      *
      * @return \FOS\RestBundle\View\View
-     *
-     * @throws NotFoundHttpException
      */
-    public function deleteSnapshotAction($id)
+    public function deleteSnapshotAction(Request $request, $id)
     {
         $snapshots = $this->getSnapshot($id);
 

--- a/Controller/BlockAdminController.php
+++ b/Controller/BlockAdminController.php
@@ -27,13 +27,13 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 class BlockAdminController extends Controller
 {
     /**
-     * @param Request|null $request
+     * @param Request $request
      *
      * @return Response
      *
      * @throws AccessDeniedException
      */
-    public function savePositionAction(Request $request = null)
+    public function savePositionAction(Request $request)
     {
         $this->admin->checkAccess('savePosition');
 
@@ -75,7 +75,7 @@ class BlockAdminController extends Controller
     /**
      * {@inheritdoc}
      */
-    public function createAction(Request $request = null)
+    public function createAction(Request $request)
     {
         $this->admin->checkAccess('create');
 
@@ -99,11 +99,11 @@ class BlockAdminController extends Controller
     }
 
     /**
-     * @param Request|null $request
+     * @param Request $request
      *
      * @return Response
      */
-    public function switchParentAction(Request $request = null)
+    public function switchParentAction(Request $request)
     {
         $this->admin->checkAccess('switchParent');
 
@@ -130,14 +130,14 @@ class BlockAdminController extends Controller
     }
 
     /**
-     * @param Request|null $request
+     * @param Request $request
      *
      * @return Response
      *
      * @throws AccessDeniedException
      * @throws PageNotFoundException
      */
-    public function composePreviewAction(Request $request = null)
+    public function composePreviewAction(Request $request)
     {
         $this->admin->checkAccess('composePreview');
 

--- a/Controller/BlockController.php
+++ b/Controller/BlockController.php
@@ -12,6 +12,7 @@
 namespace Sonata\PageBundle\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -22,9 +23,11 @@ use Symfony\Component\HttpFoundation\Response;
 class BlockController extends Controller
 {
     /**
+     * @param Request $request
+     *
      * @return Response
      */
-    public function emptyAction()
+    public function emptyAction(Request $request)
     {
         return new Response('Empty response');
     }

--- a/Controller/PageAdminController.php
+++ b/Controller/PageAdminController.php
@@ -51,7 +51,7 @@ class PageAdminController extends Controller
     /**
      * {@inheritdoc}
      */
-    public function listAction(Request $request = null)
+    public function listAction(Request $request)
     {
         if (!$request->get('filter')) {
             return new RedirectResponse($this->admin->generateUrl('tree'));
@@ -65,7 +65,7 @@ class PageAdminController extends Controller
      *
      * @return Response
      */
-    public function treeAction(Request $request = null)
+    public function treeAction(Request $request)
     {
         $this->admin->checkAccess('tree');
 
@@ -109,7 +109,7 @@ class PageAdminController extends Controller
     /**
      * {@inheritdoc}
      */
-    public function createAction(Request $request = null)
+    public function createAction(Request $request)
     {
         $this->admin->checkAccess('create');
 
@@ -146,7 +146,7 @@ class PageAdminController extends Controller
      * @throws AccessDeniedException
      * @throws NotFoundHttpException
      */
-    public function composeAction(Request $request = null)
+    public function composeAction(Request $request)
     {
         $this->admin->checkAccess('compose');
         if (false === $this->get('sonata.page.admin.block')->isGranted('LIST')) {
@@ -226,7 +226,7 @@ class PageAdminController extends Controller
      * @throws AccessDeniedException
      * @throws NotFoundHttpException
      */
-    public function composeContainerShowAction(Request $request = null)
+    public function composeContainerShowAction(Request $request)
     {
         if (false === $this->get('sonata.page.admin.block')->isGranted('LIST')) {
             throw new AccessDeniedException();

--- a/Controller/PageController.php
+++ b/Controller/PageController.php
@@ -18,6 +18,7 @@ use Sonata\PageBundle\Exception\PageNotFoundException;
 use Sonata\PageBundle\Listener\ExceptionListener;
 use Sonata\PageBundle\Page\PageServiceManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
@@ -29,11 +30,11 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 class PageController extends Controller
 {
     /**
-     * @throws AccessDeniedException
+     * @param Request $request
      *
      * @return Response
      */
-    public function exceptionsListAction()
+    public function exceptionsListAction(Request $request)
     {
         if (!$this->getCmsManagerSelector()->isEditor()) {
             throw new AccessDeniedException();
@@ -45,13 +46,12 @@ class PageController extends Controller
     }
 
     /**
-     * @throws InternalErrorException|AccessDeniedException
-     *
-     * @param string $code
+     * @param Request $request
+     * @param string  $code
      *
      * @return Response
      */
-    public function exceptionEditAction($code)
+    public function exceptionEditAction(Request $request, $code)
     {
         $cms = $this->getCmsManager();
 

--- a/Controller/SiteAdminController.php
+++ b/Controller/SiteAdminController.php
@@ -13,6 +13,7 @@ namespace Sonata\PageBundle\Controller;
 
 use Sonata\AdminBundle\Controller\CRUDController as Controller;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
@@ -25,12 +26,11 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 class SiteAdminController extends Controller
 {
     /**
-     * @return RedirectResponse|Response
+     * @param Request $request
      *
-     * @throws NotFoundHttpException
-     * @throws AccessDeniedException
+     * @return Response
      */
-    public function snapshotsAction()
+    public function snapshotsAction(Request $request)
     {
         if (false === $this->get('sonata.page.admin.snapshot')->isGranted('CREATE')) {
             throw new AccessDeniedException();

--- a/Controller/SnapshotAdminController.php
+++ b/Controller/SnapshotAdminController.php
@@ -26,7 +26,7 @@ class SnapshotAdminController extends Controller
     /**
      * {@inheritdoc}
      */
-    public function createAction(Request $request = null)
+    public function createAction(Request $request)
     {
         $this->admin->checkAccess('create');
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

I am targetting this branch, because this is a BC break.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->

``` markdown
### Added
- Added `$request` parameter to all controller actions
```
## Subject

Improved extensibility of controller actions by injection the `$request` parameter by default.
