### PR TITLE
Fix/issue 745

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -213,15 +213,29 @@ EOF;
                                 continue;
                             }
 
+                            if (isset($template['inherits_containers'])) {
+                                $inherits = $template['inherits_containers'];
+                                if (!isset($templates[$inherits])) {
+                                    throw new InvalidConfigurationException(
+                                        sprintf('Template "%s" cannot inherit containers from undefined template "%s"', $id, $inherits)
+                                    );
+                                }
+                                $template['containers'] = array_merge($templates[$inherits]['containers'], $template['containers']);
+                            }
+
                             foreach ($template['containers'] as $containerKey => $container) {
                                 if (!isset($template['matrix'][$containerKey])) {
-                                    throw new InvalidConfigurationException(sprintf('No area defined in matrix for template container "%s"', $containerKey));
+                                    throw new InvalidConfigurationException(
+                                        sprintf('No area defined in matrix for template container "%s"', $containerKey)
+                                    );
                                 }
                             }
 
                             foreach ($template['matrix'] as $containerKey => $config) {
                                 if (!isset($template['containers'][$containerKey])) {
-                                    throw new InvalidConfigurationException(sprintf('No container defined for matrix area "%s"', $containerKey));
+                                    throw new InvalidConfigurationException(
+                                        sprintf('No container defined for matrix area "%s"', $containerKey)
+                                    );
                                 }
                                 $template['containers'][$containerKey]['placement'] = $config;
                             }

--- a/Resources/doc/reference/page_composer.rst
+++ b/Resources/doc/reference/page_composer.rst
@@ -52,6 +52,10 @@ Configure
                        - sonata.media.block.media
                        - sonata.media.block.gallery
                        - sonata.media.block.feature_media
+               content:
+                   name: Main content
+                   blocks:
+                       - sonata.media.block.media
                right_col:
                    name: Right column
                    blocks:
@@ -78,6 +82,61 @@ Configure
                   C: content
                   B: content_bottom
                   F: footer
+
+       3columns:
+           path: 'ApplicationSonataPageBundle::demo_3columns_layout.html.twig'
+           name: '3 columns layout'
+           containers:
+               left_col:
+                   name: Left column
+                   blocks:
+                       - sonata.media.block.media
+                       - sonata.media.block.gallery
+                       - sonata.media.block.feature_media
+               mid_col:
+                   name: Left column
+                   blocks:
+                       - sonata.media.block.media
+                       - sonata.media.block.gallery
+                       - sonata.media.block.feature_media
+               right_col:
+                   name: Right column
+                   blocks:
+                       - sonata.news.block.recent_posts
+                       - sonata.order.block.recent_orders
+                       - sonata.product.block.recent_products
+           matrix:
+               layout: |
+                   LLLMMMMRRR
+                   LLLMMMMRRR
+                   LLLMMMMRRR
+                   LLLMMMMRRR
+                   LLLMMMMRRR
+
+               mapping:
+                  L: left_col
+                  R: right_col
+                  M: mid_col
+
+
+Template inheritance
+^^^^^^^^^^^^^^^^^^^^
+
+If you want your template to extend from another template so you don't
+have to redeclare all your containers you can use the ``inherits_containers`` option.
+This is also shown in the example above.
+
+.. code-block:: yaml
+
+   templates:
+       2columns:
+           inherits_containers: default
+           containers:
+               content:
+                   name: Main content
+                   blocks:
+                       - sonata.media.block.media
+
 
 Template chooser
 ^^^^^^^^^^^^^^^^

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -30,6 +30,15 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                     'containers' => array('header' => array('name' => 'My Header')),
                     'matrix' => array('layout' => 'HHHH', 'mapping' => array('H' => 'header')),
                 ),
+                '2columns' => array(
+                    'path' => 'ApplicationSonataPageBundle::demo_2columns_layout.html.twig',
+                    'name' => '2 columns layout',
+                    'inherits_containers' => 'default',
+                    'containers' => array(
+                        'left_col' => array('name' => 'Left column'),
+                    ),
+                    'matrix' => array('layout' => 'HHHHLLLL', 'mapping' => array('H' => 'header', 'L' => 'left_col')),
+                ),
             ),
         )));
 
@@ -52,6 +61,40 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                                 'width' => 100,
                                 'height' => 100,
                                 'right' => 0,
+                                'bottom' => 0,
+                            ),
+                        ),
+                    ),
+                ),
+                '2columns' => array(
+                    'path' => 'ApplicationSonataPageBundle::demo_2columns_layout.html.twig',
+                    'name' => '2 columns layout',
+                    'containers' => array(
+                        'left_col' => array(
+                            'name' => 'Left column',
+                            'blocks' => array(),
+                            'shared' => false,
+                            'type' => 1,
+                            'placement' => array(
+                                'x' => 50.0,
+                                'y' => 0,
+                                'width' => 50.0,
+                                'height' => 100,
+                                'right' => 0,
+                                'bottom' => 0,
+                            ),
+                        ),
+                        'header' => array(
+                            'name' => 'My Header',
+                            'type' => 1,
+                            'shared' => false,
+                            'blocks' => array(),
+                            'placement' => array(
+                                'x' => 0,
+                                'y' => 0,
+                                'width' => 50.0,
+                                'height' => 100,
+                                'right' => 50.0,
                                 'bottom' => 0,
                             ),
                         ),

--- a/Tests/Twig/Extension/PageExtensionTest.php
+++ b/Tests/Twig/Extension/PageExtensionTest.php
@@ -41,6 +41,7 @@ class PageExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testController()
     {
+        $this->skipInPHP55();
         $cmsManager = $this->getMock('Sonata\PageBundle\CmsManager\CmsManagerSelectorInterface');
         $site = $this->getMock('Sonata\PageBundle\Model\SiteInterface');
         $site->method('getRelativePath')->willReturn('/foo/bar');
@@ -77,6 +78,7 @@ class PageExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testControllerWithoutSite()
     {
+        $this->skipInPHP55();
         $cmsManager = $this->getMock('Sonata\PageBundle\CmsManager\CmsManagerSelectorInterface');
         $siteSelector = $this->getMock('Sonata\PageBundle\Site\SiteSelectorInterface');
         $router = $this->getMock('Symfony\Component\Routing\RouterInterface');
@@ -101,5 +103,14 @@ class PageExtensionTest extends \PHPUnit_Framework_TestCase
         $extension->initRuntime($env);
         $HttpKernelExtension->expects($this->once())->method('controller')->with('bar', array(), array());
         $extension->controller('bar');
+    }
+
+    private function skipInPHP55()
+    {
+        if (version_compare(PHP_VERSION, '5.5.0', '>=') && version_compare(PHP_VERSION, '5.6.0', '<=')) {
+            $this->markTestSkipped(
+                'This test should be skipped in php 5.5 due to an issue with phpunit.'
+            );
+        }
     }
 }


### PR DESCRIPTION
See ticket #745

https://sonata-project.org/bundles/page/3-x/doc/reference/advanced_configuration.html

Changelog

```markdown
### Fixed
- Fixed `inherits_containers` feature Subject
```

inherits_containers feature was malfunctioning due to the core code being delete in an earlier commit

https://github.com/sonata-project/SonataPageBundle/pull/746 from a new branch