### PR TITLE
Feature: CmsPageRouter can now render pages from other sites by chang…

### DIFF
--- a/Request/SiteRequestContext.php
+++ b/Request/SiteRequestContext.php
@@ -19,7 +19,7 @@ use Symfony\Component\Routing\RequestContext;
  * SiteRequestContext.
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
- * @TODO: This should implement SiteRequestContextInterface on the next release
+ * NEXT_MAJOR: This should implement SiteRequestContextInterface on the next release
  */
 class SiteRequestContext extends RequestContext
 {
@@ -31,7 +31,7 @@ class SiteRequestContext extends RequestContext
     /**
      * @var SiteInterface
      */
-    protected $site;
+    private $site;
 
     /**
      * @param SiteSelectorInterface $selector

--- a/Request/SiteRequestContext.php
+++ b/Request/SiteRequestContext.php
@@ -19,7 +19,6 @@ use Symfony\Component\Routing\RequestContext;
  * SiteRequestContext.
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
- * NEXT_MAJOR: This should implement SiteRequestContextInterface on the next release
  */
 class SiteRequestContext extends RequestContext implements SiteRequestContextInterface
 {
@@ -77,12 +76,12 @@ class SiteRequestContext extends RequestContext implements SiteRequestContextInt
         return parent::getBaseUrl();
     }
 
-    public function setSite(SiteInterface $site)
+    final public function setSite(SiteInterface $site)
     {
         $this->site = $site;
     }
 
-    public function getSite()
+    final public function getSite()
     {
         if (!$this->site instanceof SiteInterface) {
             $this->site = $this->selector->retrieve();

--- a/Request/SiteRequestContext.php
+++ b/Request/SiteRequestContext.php
@@ -19,8 +19,9 @@ use Symfony\Component\Routing\RequestContext;
  * SiteRequestContext.
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @TODO: This should implement SiteRequestContextInterface on the next release
  */
-class SiteRequestContext extends RequestContext implements SiteRequestContextInterface
+class SiteRequestContext extends RequestContext
 {
     /**
      * @var SiteSelectorInterface

--- a/Request/SiteRequestContext.php
+++ b/Request/SiteRequestContext.php
@@ -21,7 +21,7 @@ use Symfony\Component\Routing\RequestContext;
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  * NEXT_MAJOR: This should implement SiteRequestContextInterface on the next release
  */
-class SiteRequestContext extends RequestContext
+class SiteRequestContext extends RequestContext implements SiteRequestContextInterface
 {
     /**
      * @var SiteSelectorInterface

--- a/Request/SiteRequestContext.php
+++ b/Request/SiteRequestContext.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\PageBundle\Request;
 
+use Sonata\PageBundle\Model\SiteInterface;
 use Sonata\PageBundle\Site\SiteSelectorInterface;
 use Symfony\Component\Routing\RequestContext;
 
@@ -19,12 +20,17 @@ use Symfony\Component\Routing\RequestContext;
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class SiteRequestContext extends RequestContext
+class SiteRequestContext extends RequestContext implements SiteRequestContextInterface
 {
     /**
      * @var SiteSelectorInterface
      */
     protected $selector;
+
+    /**
+     * @var SiteInterface
+     */
+    protected $site;
 
     /**
      * @param SiteSelectorInterface $selector
@@ -47,7 +53,7 @@ class SiteRequestContext extends RequestContext
      */
     public function getHost()
     {
-        $site = $this->selector->retrieve();
+        $site = $this->getSite();
 
         if ($site && !$site->isLocalhost()) {
             return $site->getHost();
@@ -61,12 +67,26 @@ class SiteRequestContext extends RequestContext
      */
     public function getBaseUrl()
     {
-        $site = $this->selector->retrieve();
+        $site = $this->getSite();
 
         if ($site) {
             return parent::getBaseUrl().$site->getRelativePath();
         }
 
         return parent::getBaseUrl();
+    }
+
+    public function setSite(SiteInterface $site)
+    {
+        $this->site = $site;
+    }
+
+    public function getSite()
+    {
+        if (!$this->site instanceof SiteInterface) {
+            $this->site = $this->selector->retrieve();
+        }
+
+        return $this->site;
     }
 }

--- a/Request/SiteRequestContextInterface.php
+++ b/Request/SiteRequestContextInterface.php
@@ -21,16 +21,12 @@ use Sonata\PageBundle\Model\SiteInterface;
 interface SiteRequestContextInterface
 {
     /**
-     * {@inheritdoc}
+     * @param SiteInterface $site
      */
-    public function getHost();
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getBaseUrl();
-
     public function setSite(SiteInterface $site);
 
+    /**
+     * @return SiteInterface|null
+     */
     public function getSite();
 }

--- a/Request/SiteRequestContextInterface.php
+++ b/Request/SiteRequestContextInterface.php
@@ -1,7 +1,17 @@
 <?php
-namespace Sonata\PageBundle\Request;
-use Sonata\PageBundle\Model\SiteInterface;
 
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\PageBundle\Request;
+
+use Sonata\PageBundle\Model\SiteInterface;
 
 /**
  * SiteRequestContext.

--- a/Request/SiteRequestContextInterface.php
+++ b/Request/SiteRequestContextInterface.php
@@ -16,7 +16,7 @@ use Sonata\PageBundle\Model\SiteInterface;
 /**
  * SiteRequestContext.
  *
- * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Joeri Timmermans <info@pix-art.be>
  */
 interface SiteRequestContextInterface
 {

--- a/Request/SiteRequestContextInterface.php
+++ b/Request/SiteRequestContextInterface.php
@@ -1,0 +1,26 @@
+<?php
+namespace Sonata\PageBundle\Request;
+use Sonata\PageBundle\Model\SiteInterface;
+
+
+/**
+ * SiteRequestContext.
+ *
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ */
+interface SiteRequestContextInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getHost();
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBaseUrl();
+
+    public function setSite(SiteInterface $site);
+
+    public function getSite();
+}

--- a/Route/CmsPageRouter.php
+++ b/Route/CmsPageRouter.php
@@ -16,6 +16,7 @@ use Sonata\PageBundle\CmsManager\CmsManagerSelectorInterface;
 use Sonata\PageBundle\Exception\PageNotFoundException;
 use Sonata\PageBundle\Model\PageInterface;
 use Sonata\PageBundle\Model\SiteInterface;
+use Sonata\PageBundle\Request\SiteRequestContext;
 use Sonata\PageBundle\Request\SiteRequestContextInterface;
 use Sonata\PageBundle\Site\SiteSelectorInterface;
 use Symfony\Cmf\Component\Routing\ChainedRouterInterface;
@@ -209,7 +210,12 @@ class CmsPageRouter implements ChainedRouterInterface
             throw new \RuntimeException(sprintf('Page "%d" has no url or customUrl.', $page->getId()));
         }
 
-        if (!$this->context instanceof SiteRequestContextInterface) {
+        @trigger_error(
+            'The context should implement SiteRequestContextInterface on the next release',
+            E_USER_DEPRECATED
+        );
+
+        if (!$this->context instanceof SiteRequestContext) {
             return $this->decorateUrl($url, $parameters, $referenceType);
         }
 

--- a/Route/CmsPageRouter.php
+++ b/Route/CmsPageRouter.php
@@ -16,6 +16,7 @@ use Sonata\PageBundle\CmsManager\CmsManagerSelectorInterface;
 use Sonata\PageBundle\Exception\PageNotFoundException;
 use Sonata\PageBundle\Model\PageInterface;
 use Sonata\PageBundle\Model\SiteInterface;
+use Sonata\PageBundle\Request\SiteRequestContextInterface;
 use Sonata\PageBundle\Site\SiteSelectorInterface;
 use Symfony\Cmf\Component\Routing\ChainedRouterInterface;
 use Symfony\Cmf\Component\Routing\VersatileGeneratorInterface;
@@ -185,6 +186,7 @@ class CmsPageRouter implements ChainedRouterInterface
 
     /**
      * Generates an URL from a Page object.
+     * We swap site context to make sure the right context is used when generating the url.
      *
      * @param PageInterface $page          Page object
      * @param array         $parameters    An array of parameters
@@ -207,7 +209,20 @@ class CmsPageRouter implements ChainedRouterInterface
             throw new \RuntimeException(sprintf('Page "%d" has no url or customUrl.', $page->getId()));
         }
 
-        return $this->decorateUrl($url, $parameters, $referenceType);
+        if (!$this->context instanceof SiteRequestContextInterface) {
+            return $this->decorateUrl($url, $parameters, $referenceType);
+        }
+
+        // Get current site
+        $currentSite = $this->context->getSite();
+        // Change to new site
+        $this->context->setSite($page->getSite());
+        // Fetch Url
+        $decoratedUrl = $this->decorateUrl($url, $parameters, $referenceType);
+        // Swap back to original site
+        $this->context->setSite($currentSite);
+
+        return $decoratedUrl;
     }
 
     /**

--- a/Route/CmsPageRouter.php
+++ b/Route/CmsPageRouter.php
@@ -210,9 +210,10 @@ class CmsPageRouter implements ChainedRouterInterface
             throw new \RuntimeException(sprintf('Page "%d" has no url or customUrl.', $page->getId()));
         }
 
+        // NEXT_MAJOR: remove this if block
         if (!$this->context instanceof SiteRequestContext) {
             @trigger_error(
-                'The context should implement SiteRequestContextInterface on the next release',
+                sprintf('Since, 3.x, when calling %s, %s::$context should implement SiteRequestContextInterface. This will become mandatory in 4.x', __METHOD__, __CLASS__),
                 E_USER_DEPRECATED
             );
 

--- a/Route/CmsPageRouter.php
+++ b/Route/CmsPageRouter.php
@@ -16,7 +16,6 @@ use Sonata\PageBundle\CmsManager\CmsManagerSelectorInterface;
 use Sonata\PageBundle\Exception\PageNotFoundException;
 use Sonata\PageBundle\Model\PageInterface;
 use Sonata\PageBundle\Model\SiteInterface;
-use Sonata\PageBundle\Request\SiteRequestContext;
 use Sonata\PageBundle\Request\SiteRequestContextInterface;
 use Sonata\PageBundle\Site\SiteSelectorInterface;
 use Symfony\Cmf\Component\Routing\ChainedRouterInterface;
@@ -211,9 +210,9 @@ class CmsPageRouter implements ChainedRouterInterface
         }
 
         // NEXT_MAJOR: remove this if block
-        if (!$this->context instanceof SiteRequestContext) {
+        if (!$this->context instanceof SiteRequestContextInterface) {
             @trigger_error(
-                sprintf('Since, 3.x, when calling %s, %s::$context should implement SiteRequestContextInterface. This will become mandatory in 4.x', __METHOD__, __CLASS__),
+                sprintf('Since, 3.x when calling %s, %s::$context should implement SiteRequestContextInterface. This will become mandatory in 4.0.', __METHOD__, __CLASS__),
                 E_USER_DEPRECATED
             );
 

--- a/Route/CmsPageRouter.php
+++ b/Route/CmsPageRouter.php
@@ -210,12 +210,12 @@ class CmsPageRouter implements ChainedRouterInterface
             throw new \RuntimeException(sprintf('Page "%d" has no url or customUrl.', $page->getId()));
         }
 
-        @trigger_error(
-            'The context should implement SiteRequestContextInterface on the next release',
-            E_USER_DEPRECATED
-        );
-
         if (!$this->context instanceof SiteRequestContext) {
+            @trigger_error(
+                'The context should implement SiteRequestContextInterface on the next release',
+                E_USER_DEPRECATED
+            );
+
             return $this->decorateUrl($url, $parameters, $referenceType);
         }
 

--- a/Tests/Route/CmsPageRouterTest.php
+++ b/Tests/Route/CmsPageRouterTest.php
@@ -343,7 +343,6 @@ class CmsPageRouterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('//localhost/test/key/value', $url);
     }
 
-
     public function testGenerateWithPageAndNewSiteContext()
     {
         $site1 = $this->getMock('Sonata\PageBundle\Model\SiteInterface');
@@ -371,5 +370,4 @@ class CmsPageRouterTest extends \PHPUnit_Framework_TestCase
         $url = $this->router->generate($page2, array('key' => 'value'));
         $this->assertEquals('/site2/test/path?key=value', $url);
     }
-
 }


### PR DESCRIPTION
In the documentation there is a part talking about twig helpers:

`{{ path(page) }} => /absolute/path/to/url`

This is actually nice, but when you want to generate a url for a page outside of the current sitecontext than this will generate an invalid url.

**Example:**

2 Websites with 2 pages:

- Page1: localhost/site1/hello
- Page2: localhost/site2/hello2

When you try render {{ path(page2) }} while you're on the Page1, this will generate `localhost/site1/hello2` while you expect `localhost/site2/hello2`

By changing the site context ONLY when rendering from a PageInterface, we can allow our path() function to generate the right url with the right context.

## Changelog

Implemented posibility to change site context if the url being generated starts from a PageInterface object.

```markdown
### Added
- Added `SiteRequestContextInterface` to check the current context type in get SiteRequestContext
- Added `SiteRequestContext::setSite()` to change the site context
- Added `SiteRequestContext::getSite()` to get the site context

### Changed
- Changed `CmsPageRouter::generateFromPage` to change the site context when generating the url for the given page
```

