### PR TITLE
fix sonata_seo_context to use the right breadcrumb service

### DIFF
--- a/Block/BreadcrumbBlockService.php
+++ b/Block/BreadcrumbBlockService.php
@@ -131,7 +131,7 @@ class BreadcrumbBlockService extends BaseBreadcrumbMenuBlockService
     protected function getLocale()
     {
         $locale = $this->requestStack->getRequest()->getLocale();
-        if($locale == null) {
+        if ($locale == null) {
             $locale = $this->getContainer()->getParameter('locale');
         }
         return $locale;
@@ -147,7 +147,7 @@ class BreadcrumbBlockService extends BaseBreadcrumbMenuBlockService
         $url = $page->getUrl();
         $locale = $this->getLocale();
         if (strpos($url, '{_locale}') AND $locale != null) {
-            $url = str_replace('{_locale}',$locale, $url);
+            $url = str_replace('{_locale}', $locale, $url);
         }
         return $url;
     }

--- a/Block/BreadcrumbBlockService.php
+++ b/Block/BreadcrumbBlockService.php
@@ -18,8 +18,8 @@ use Sonata\PageBundle\CmsManager\CmsManagerSelectorInterface;
 use Sonata\PageBundle\Model\PageInterface;
 use Sonata\SeoBundle\Block\Breadcrumb\BaseBreadcrumbMenuBlockService;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * BlockService for homepage breadcrumb.
@@ -128,23 +128,24 @@ class BreadcrumbBlockService extends BaseBreadcrumbMenuBlockService
      *
      * @return string
      */
-    protected function getLocale(){
+    protected function getLocale()
+    {
         $locale = $this->requestStack->getRequest()->getLocale();
-        if($locale == null){
-            $locale = $this->getContainer()->getParameter('locale');
-        }
+            if($locale == null){
+                $locale = $this->getContainer()->getParameter('locale');
+            }
         return $locale;
-        
     }
 
     /**
-     * Return the Page Url with locale set
+     * Return the Page Url with locale set.
      *
      * @return string
      */
-    protected function getLocatedUrl(PageInterface $page){
+    protected function getLocatedUrl(PageInterface $page)
+    {
         $url = $page->getUrl();
-        $locale =  $this->getLocale();
+        $locale = $this->getLocale();
         if (strpos($url, "{_locale}") AND $locale != null) {
             $url = str_replace("{_locale}",$locale, $url);
         }
@@ -152,11 +153,12 @@ class BreadcrumbBlockService extends BaseBreadcrumbMenuBlockService
     }
 
     /**
-     * Return the Container
+     * Return the Container.
      *
      * @return ContainerInterface
      */
-    protected function getContainer(){
+    protected function getContainer()
+    {
         return $this->container;
     }
 }

--- a/Block/BreadcrumbBlockService.php
+++ b/Block/BreadcrumbBlockService.php
@@ -38,7 +38,7 @@ class BreadcrumbBlockService extends BaseBreadcrumbMenuBlockService
     protected $requestStack;
 
     /**
-     * @var ContainerInterface
+     * @var string
      */
     protected $defaultLocale;
 

--- a/Block/BreadcrumbBlockService.php
+++ b/Block/BreadcrumbBlockService.php
@@ -43,7 +43,6 @@ class BreadcrumbBlockService extends BaseBreadcrumbMenuBlockService
      */
     protected $container;
 
-
     /**
      * @param string                      $context
      * @param string                      $name
@@ -134,6 +133,7 @@ class BreadcrumbBlockService extends BaseBreadcrumbMenuBlockService
         if ($locale == null) {
             $locale = $this->getContainer()->getParameter('locale');
         }
+
         return $locale;
     }
 
@@ -149,6 +149,7 @@ class BreadcrumbBlockService extends BaseBreadcrumbMenuBlockService
         if (strpos($url, '{_locale}') and $locale != null) {
             $url = str_replace('{_locale}', $locale, $url);
         }
+        
         return $url;
     }
 

--- a/Block/BreadcrumbBlockService.php
+++ b/Block/BreadcrumbBlockService.php
@@ -131,9 +131,9 @@ class BreadcrumbBlockService extends BaseBreadcrumbMenuBlockService
     protected function getLocale()
     {
         $locale = $this->requestStack->getRequest()->getLocale();
-            if($locale == null){
-                $locale = $this->getContainer()->getParameter('locale');
-            }
+        if($locale == null) {
+            $locale = $this->getContainer()->getParameter('locale');
+        }
         return $locale;
     }
 
@@ -146,8 +146,8 @@ class BreadcrumbBlockService extends BaseBreadcrumbMenuBlockService
     {
         $url = $page->getUrl();
         $locale = $this->getLocale();
-        if (strpos($url, "{_locale}") AND $locale != null) {
-            $url = str_replace("{_locale}",$locale, $url);
+        if (strpos($url, '{_locale}') AND $locale != null) {
+            $url = str_replace('{_locale}',$locale, $url);
         }
         return $url;
     }

--- a/Block/BreadcrumbBlockService.php
+++ b/Block/BreadcrumbBlockService.php
@@ -18,7 +18,6 @@ use Sonata\PageBundle\CmsManager\CmsManagerSelectorInterface;
 use Sonata\PageBundle\Model\PageInterface;
 use Sonata\SeoBundle\Block\Breadcrumb\BaseBreadcrumbMenuBlockService;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
@@ -131,7 +130,7 @@ class BreadcrumbBlockService extends BaseBreadcrumbMenuBlockService
     {
         $locale = $this->requestStack->getRequest()->getLocale();
         if ($locale == null) {
-            $locale = $this->getContainer()->getParameter('locale');
+            $locale = $this->defaultLocale;
         }
 
         return $locale;
@@ -153,13 +152,4 @@ class BreadcrumbBlockService extends BaseBreadcrumbMenuBlockService
         return $url;
     }
 
-    /**
-     * Return the Container.
-     *
-     * @return ContainerInterface
-     */
-    protected function getContainer()
-    {
-        return $this->container;
-    }
 }

--- a/Block/BreadcrumbBlockService.php
+++ b/Block/BreadcrumbBlockService.php
@@ -41,7 +41,7 @@ class BreadcrumbBlockService extends BaseBreadcrumbMenuBlockService
     /**
      * @var ContainerInterface
      */
-    protected $container;
+    protected $defaultLocale;
 
     /**
      * @param string                      $context
@@ -51,11 +51,11 @@ class BreadcrumbBlockService extends BaseBreadcrumbMenuBlockService
      * @param FactoryInterface            $factory
      * @param CmsManagerSelectorInterface $cmsSelector
      */
-    public function __construct($context, $name, EngineInterface $templating, MenuProviderInterface $menuProvider, FactoryInterface $factory, CmsManagerSelectorInterface $cmsSelector, RequestStack $requestStack, ContainerInterface $container)
+    public function __construct($context, $name, EngineInterface $templating, MenuProviderInterface $menuProvider, FactoryInterface $factory, CmsManagerSelectorInterface $cmsSelector, RequestStack $requestStack, $defaultLocale)
     {
         $this->cmsSelector = $cmsSelector;
         $this->requestStack = $requestStack;
-        $this->container = $container;
+        $this->defaultLocale = $defaultLocale;
 
         parent::__construct($context, $name, $templating, $menuProvider, $factory);
     }
@@ -149,7 +149,7 @@ class BreadcrumbBlockService extends BaseBreadcrumbMenuBlockService
         if (strpos($url, '{_locale}') and $locale != null) {
             $url = str_replace('{_locale}', $locale, $url);
         }
-        
+
         return $url;
     }
 

--- a/Block/BreadcrumbBlockService.php
+++ b/Block/BreadcrumbBlockService.php
@@ -148,7 +148,7 @@ class BreadcrumbBlockService extends BaseBreadcrumbMenuBlockService
         if (strpos($url, "{_locale}") AND $locale != null) {
             $url = str_replace("{_locale}",$locale, $url);
         }
-        return $url
+        return $url;
     }
 
     /**

--- a/Block/BreadcrumbBlockService.php
+++ b/Block/BreadcrumbBlockService.php
@@ -146,7 +146,7 @@ class BreadcrumbBlockService extends BaseBreadcrumbMenuBlockService
     {
         $url = $page->getUrl();
         $locale = $this->getLocale();
-        if (strpos($url, '{_locale}') AND $locale != null) {
+        if (strpos($url, '{_locale}') and $locale != null) {
             $url = str_replace('{_locale}', $locale, $url);
         }
         return $url;

--- a/Resources/config/block.xml
+++ b/Resources/config/block.xml
@@ -39,6 +39,8 @@
             <argument type="service" id="knp_menu.menu_provider"/>
             <argument type="service" id="knp_menu.factory"/>
             <argument type="service" id="sonata.page.cms_manager_selector"/>
+            <argument type="service" id="request_stack"/>
+            <argument type="service" id="service_container"/>
         </service>
         <service id="sonata.page.block.shared_block" class="%sonata.page.block.shared_block.class%">
             <tag name="sonata.block"/>

--- a/Resources/config/block.xml
+++ b/Resources/config/block.xml
@@ -40,7 +40,7 @@
             <argument type="service" id="knp_menu.factory"/>
             <argument type="service" id="sonata.page.cms_manager_selector"/>
             <argument type="service" id="request_stack"/>
-            <argument type="service" id="service_container"/>
+            <argument>locale</argument>
         </service>
         <service id="sonata.page.block.shared_block" class="%sonata.page.block.shared_block.class%">
             <tag name="sonata.block"/>

--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -20,7 +20,7 @@ file that was distributed with this source code.
             {% block sonata_page_breadcrumb %}
                 <div class="row">
                     {% if sonata_seo_context is not defined %}
-                        {% set sonata_seo_context = 'homepage' %}
+                        {% set sonata_seo_context = 'page' %}
                     {% endif %}
                     {{ sonata_block_render_event('breadcrumb', { 'context': sonata_seo_context, 'current_uri': app.request.requestUri }) }}
                 </div>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because it's a minor fix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #749

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Fixed
- use page-bundle-specific breadcrumb service

```


## Subject

<!-- Describe your Pull Request content here -->
