### PR TITLE
add ‘blockId’ to shared block service. solves #741

### DIFF
--- a/Block/SharedBlockBlockService.php
+++ b/Block/SharedBlockBlockService.php
@@ -126,6 +126,7 @@ class SharedBlockBlockService extends BaseBlockService
     {
         $resolver->setDefaults(array(
             'template' => 'SonataPageBundle:Block:block_shared_block.html.twig',
+            'blockId' => null,
         ));
     }
 


### PR DESCRIPTION
I am targetting this branch, because it's a minor fix.

Closes #741 

## Changelog

```markdown
### Fixed
- missing `blockId` setting SharedBlockBlockService
```
