### PR TITLE
Ignoring routes that duplicates an existing path

### DIFF
--- a/Route/RoutePageGenerator.php
+++ b/Route/RoutePageGenerator.php
@@ -104,8 +104,12 @@ class RoutePageGenerator
         foreach ($this->router->getRouteCollection()->all() as $name => $route) {
             $routePath = $route->getPath();
             if (array_key_exists($routePath, $routesDedupInfos)) {
-                $this->writeln($output, sprintf('  <info>IGNORE</info> route %s is ignored because it uses the same path as %s (path=%s)',
-                    $name, $routesDedupInfos[$routePath][0], $routePath));
+                $this->writeln($output, sprintf(
+                    '  <info>IGNORE</info> route %s is ignored because it uses the same path as %s (path=%s)',
+                    $name,
+                    $routesDedupInfos[$routePath][0],
+                    $routePath
+                ));
             } else {
                 $routesDedupInfos[$routePath] = array(trim($name), $route);
             }

--- a/Route/RoutePageGenerator.php
+++ b/Route/RoutePageGenerator.php
@@ -99,9 +99,18 @@ class RoutePageGenerator
         }
 
         // Iterate over declared routes from the routing mechanism
+        $routesDedupInfos = array();
+        // We first de-duplicate routes by path; the first declaration win !
         foreach ($this->router->getRouteCollection()->all() as $name => $route) {
-            $name = trim($name);
-
+            $routePath = $route->getPath();
+            if (!array_key_exists($routePath, $routesDedupInfos)) {
+                $routesDedupInfos[$routePath] = array(trim($name), $route);
+            } else {
+                $this->writeln($output, sprintf('  <info>IGNORE</info> route %s is ignored because it uses the same path as %s (path=%s)', $name, $routesDedupInfos[$routePath][0], $routePath));
+            }
+        }
+        foreach ($routesDedupInfos as $routeInfo) {
+        	list($name, $route) = $routeInfo;
             $knowRoutes[] = $name;
 
             $page = $this->pageManager->findOneBy(array(

--- a/Route/RoutePageGenerator.php
+++ b/Route/RoutePageGenerator.php
@@ -103,14 +103,15 @@ class RoutePageGenerator
         // We first de-duplicate routes by path; the first declaration win !
         foreach ($this->router->getRouteCollection()->all() as $name => $route) {
             $routePath = $route->getPath();
-            if (!array_key_exists($routePath, $routesDedupInfos)) {
-                $routesDedupInfos[$routePath] = array(trim($name), $route);
-            } else {
+            if (array_key_exists($routePath, $routesDedupInfos)) {
                 $this->writeln($output, sprintf('  <info>IGNORE</info> route %s is ignored because it uses the same path as %s (path=%s)', $name, $routesDedupInfos[$routePath][0], $routePath));
+            } else {
+                $routesDedupInfos[$routePath] = array(trim($name), $route);
             }
         }
+
         foreach ($routesDedupInfos as $routeInfo) {
-        	list($name, $route) = $routeInfo;
+            list($name, $route) = $routeInfo;
             $knowRoutes[] = $name;
 
             $page = $this->pageManager->findOneBy(array(

--- a/Route/RoutePageGenerator.php
+++ b/Route/RoutePageGenerator.php
@@ -104,7 +104,8 @@ class RoutePageGenerator
         foreach ($this->router->getRouteCollection()->all() as $name => $route) {
             $routePath = $route->getPath();
             if (array_key_exists($routePath, $routesDedupInfos)) {
-                $this->writeln($output, sprintf('  <info>IGNORE</info> route %s is ignored because it uses the same path as %s (path=%s)', $name, $routesDedupInfos[$routePath][0], $routePath));
+                $this->writeln($output, sprintf('  <info>IGNORE</info> route %s is ignored because it uses the same path as %s (path=%s)',
+                    $name, $routesDedupInfos[$routePath][0], $routePath));
             } else {
                 $routesDedupInfos[$routePath] = array(trim($name), $route);
             }


### PR DESCRIPTION
Ignoring routes that duplicates an existing path because it breaks the page edition (`BasePage.routeName` must be unique).
An example is the SonataUserBundle routes that overrides the FosUserBundle routes.
Cf. https://github.com/sonata-project/SonataUserBundle/blob/3.x/Resources/doc/reference/installation.rst#use-custom-sonatauser-controllers-and-templates-instead-of-fosuser-ones

N.B.: there should be similar bugs like sonata-project/SonataPageBundle#590 but I only care about the SonataUserBundle case

This fixes sonata-project/SonataPageBundle#757

I am targetting this branch, because the commit fixes the bug that should not exist and, to my opinion, without any breaking changes.

On my project, executing `./bin/console sonata:page:update-core-routes` now outputs (in addition of the actual ouput) :

```bash
  IGNORE route sonata_user_security_login is ignored because it uses the same path as fos_user_security_login (path=/login)
  IGNORE route sonata_user_security_check is ignored because it uses the same path as fos_user_security_check (path=/login_check)
  IGNORE route sonata_user_security_logout is ignored because it uses the same path as fos_user_security_logout (path=/logout)
  IGNORE route sonata_user_resetting_request is ignored because it uses the same path as fos_user_resetting_request (path=/resetting/request)
  IGNORE route sonata_user_resetting_send_email is ignored because it uses the same path as fos_user_resetting_send_email (path=/resetting/send-email)
  IGNORE route sonata_user_resetting_check_email is ignored because it uses the same path as fos_user_resetting_check_email (path=/resetting/check-email)
  IGNORE route sonata_user_resetting_reset is ignored because it uses the same path as fos_user_resetting_reset (path=/resetting/reset/{token})
  IGNORE route sonata_user_profile_show is ignored because it uses the same path as fos_user_profile_show (path=/profile/)
  IGNORE route sonata_user_profile_edit_authentication is ignored because it uses the same path as fos_user_profile_edit_authentication (path=/profile/edit-authentication)
  IGNORE route sonata_user_profile_edit is ignored because it uses the same path as fos_user_profile_edit (path=/profile/edit-profile)
  IGNORE route sonata_user_registration_register is ignored because it uses the same path as fos_user_registration_register (path=/register/)
  IGNORE route sonata_user_registration_check_email is ignored because it uses the same path as fos_user_registration_check_email (path=/register/check-email)
  IGNORE route sonata_user_registration_confirm is ignored because it uses the same path as fos_user_registration_confirm (path=/register/confirm/{token})
  IGNORE route sonata_user_registration_confirmed is ignored because it uses the same path as fos_user_registration_confirmed (path=/register/confirmed)
  IGNORE route sonata_user_change_password is ignored because it uses the same path as fos_user_change_password (path=/profile/change-password)
```

Closes #757

## Changelog

```markdown
### Fixed
- fix sonata-project/SonataPageBundle#757 ignoring page duplicates during `sonata:page:update-core-routes` : simply only retain the first routes for a given path
```

## Subject

Ignore routes that duplicates an existing path to achieve to be able to edit the pages.