### PR TITLE
Stop calling static method in a non-static way

### DIFF
--- a/Tests/Twig/Extension/PageExtensionTest.php
+++ b/Tests/Twig/Extension/PageExtensionTest.php
@@ -66,12 +66,14 @@ class PageExtensionTest extends \PHPUnit_Framework_TestCase
         ;
         $extension = new PageExtension($cmsManager, $siteSelector, $router, $blockHelper, $HttpKernelExtension);
         $extension->initRuntime($env);
-        $HttpKernelExtension->expects($this->once())->method('controller')->with(
-            'foo',
-            array('pathInfo' => '/foo/bar/'),
-            array()
-        )
-        ;
+        if (!method_exists('Symfony\Bridge\Twig\AppVariable', 'getToken')) {
+            $HttpKernelExtension->expects($this->once())->method('controller')->with(
+                'foo',
+                array('pathInfo' => '/foo/bar/'),
+                array()
+            )
+            ;
+        }
         $extension->controller('foo');
     }
 
@@ -99,7 +101,9 @@ class PageExtensionTest extends \PHPUnit_Framework_TestCase
         ;
         $extension = new PageExtension($cmsManager, $siteSelector, $router, $blockHelper, $HttpKernelExtension);
         $extension->initRuntime($env);
-        $HttpKernelExtension->expects($this->once())->method('controller')->with('bar', array(), array());
+        if (!method_exists('Symfony\Bridge\Twig\AppVariable', 'getToken')) {
+            $HttpKernelExtension->expects($this->once())->method('controller')->with('bar', array(), array());
+        }
         $extension->controller('bar');
     }
 }

--- a/Twig/Extension/PageExtension.php
+++ b/Twig/Extension/PageExtension.php
@@ -286,6 +286,11 @@ class PageExtension extends \Twig_Extension implements \Twig_Extension_InitRunti
             }
         }
 
+        // Simplify this when dropping twig-bridge < 3.2 support
+        if (method_exists('Symfony\Bridge\Twig\AppVariable', 'getToken')) {
+            return HttpKernelExtension::controller($controller, $attributes, $query);
+        }
+
         return $this->httpKernelExtension->controller($controller, $attributes, $query);
     }
 


### PR DESCRIPTION
I am targetting this branch, because this is BC.


## Subject

Fixes the broken test suite

Closes #760

Since symfony/twig-bridge#3.2, HttpKernelExtension::controller is no
longer static. This is not a problem when running the code, but it is
when trying to mock the extension and then call the method on it. This
fix calls the extension method statically and removes the mocking calls
when appropriate.

To be merged asap 🚨 