### PR TITLE
Added option to clean orphaned pages in UpdateCoreRoutesCommand

### DIFF
--- a/Command/UpdateCoreRoutesCommand.php
+++ b/Command/UpdateCoreRoutesCommand.php
@@ -31,6 +31,7 @@ class UpdateCoreRoutesCommand extends BaseCommand
     {
         $this->setName('sonata:page:update-core-routes');
         $this->setDescription('Update core routes, from routing files to page manager');
+        // NEXT_MAJOR: Remove the "all" option.
         $this->addOption('all', null, InputOption::VALUE_NONE, 'Create snapshots for all sites');
         $this->addOption('clean', null, InputOption::VALUE_NONE, 'Removes all unused routes');
         $this->addOption('site', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Site id', null);
@@ -42,7 +43,14 @@ class UpdateCoreRoutesCommand extends BaseCommand
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        if (!$input->getOption('site') && !$input->getOption('all')) {
+        if ($input->getOption('all')) {
+            @trigger_error(
+                'Using the "all" option is deprecated since 3.x and will be removed in 4.0.',
+                E_USER_DEPRECATED
+            );
+        }
+
+        if (!$input->getOption('site')) {
             $output->writeln('Please provide an <info>--site=SITE_ID</info> option or the <info>--site=all</info> directive');
             $output->writeln('');
 

--- a/Command/UpdateCoreRoutesCommand.php
+++ b/Command/UpdateCoreRoutesCommand.php
@@ -32,6 +32,7 @@ class UpdateCoreRoutesCommand extends BaseCommand
         $this->setName('sonata:page:update-core-routes');
         $this->setDescription('Update core routes, from routing files to page manager');
         $this->addOption('all', null, InputOption::VALUE_NONE, 'Create snapshots for all sites');
+        $this->addOption('clean', null, InputOption::VALUE_NONE, 'Removes all unused routes');
         $this->addOption('site', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Site id', null);
         $this->addOption('base-command', null, InputOption::VALUE_OPTIONAL, 'Site id', 'php app/console');
     }
@@ -56,10 +57,10 @@ class UpdateCoreRoutesCommand extends BaseCommand
 
         foreach ($this->getSites($input) as $site) {
             if ($input->getOption('site') != 'all') {
-                $this->getRoutePageGenerator()->update($site, $output);
+                $this->getRoutePageGenerator()->update($site, $output, $input->getOption('clean'));
                 $output->writeln('');
             } else {
-                $p = new Process(sprintf('%s sonata:page:update-core-routes --env=%s --site=%s %s', $input->getOption('base-command'), $input->getOption('env'), $site->getId(), $input->getOption('no-debug') ? '--no-debug' : ''));
+                $p = new Process(sprintf('%s sonata:page:update-core-routes --env=%s --site=%s %s %s', $input->getOption('base-command'), $input->getOption('env'), $site->getId(), $input->getOption('no-debug') ? '--no-debug' : '', $input->getOption('clean') ? '--clean' : ''));
 
                 $p->run(function ($type, $data) use ($output) {
                     $output->write($data);

--- a/Command/UpdateCoreRoutesCommand.php
+++ b/Command/UpdateCoreRoutesCommand.php
@@ -15,7 +15,7 @@ use Sonata\PageBundle\Route\RoutePageGenerator;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Process\Process;
+use Symfony\Component\Process\ProcessBuilder;
 
 /**
  * Update core routes by reading routing information.
@@ -60,9 +60,22 @@ class UpdateCoreRoutesCommand extends BaseCommand
                 $this->getRoutePageGenerator()->update($site, $output, $input->getOption('clean'));
                 $output->writeln('');
             } else {
-                $p = new Process(sprintf('%s sonata:page:update-core-routes --env=%s --site=%s %s %s', $input->getOption('base-command'), $input->getOption('env'), $site->getId(), $input->getOption('no-debug') ? '--no-debug' : '', $input->getOption('clean') ? '--clean' : ''));
+                $builder = ProcessBuilder::create($input->getOption('base-command'))
+                    ->add('sonata:page:update-core-routes')
+                    ->setOption('env', $input->getOption('env'))
+                    ->setOption('site', $site->getId());
 
-                $p->run(function ($type, $data) use ($output) {
+                if ($input->getOption('no-debug')) {
+                    $builder->add('--no-debug');
+                }
+
+                if ($input->getOption('clean')) {
+                    $builder->add('--clean');
+                }
+
+                $process = $builder->getProcess();
+
+                $process->run(function ($type, $data) use ($output) {
                     $output->write($data);
                 });
             }

--- a/Resources/doc/reference/command_line.rst
+++ b/Resources/doc/reference/command_line.rst
@@ -21,6 +21,10 @@ Page commands
 
     $ php app/console sonata:page:update-core-routes --site=all
 
+    You could also remove orphaned pages with the ``--clean`` option.
+
+    $ php app/console sonata:page:update-core-routes --site=all --clean
+
 - Create snapshots from defined pages::
 
     $ php app/console sonata:page:create-snapshots --site=all

--- a/Resources/doc/reference/command_line.rst
+++ b/Resources/doc/reference/command_line.rst
@@ -21,7 +21,7 @@ Page commands
 
     $ php app/console sonata:page:update-core-routes --site=all
 
-    You could also remove orphaned pages with the ``--clean`` option.
+    You could also remove orphan pages with the ``--clean`` option.
 
     $ php app/console sonata:page:update-core-routes --site=all --clean
 

--- a/Route/RoutePageGenerator.php
+++ b/Route/RoutePageGenerator.php
@@ -65,8 +65,9 @@ class RoutePageGenerator
      *
      * @param SiteInterface   $site   A page bundle site instance
      * @param OutputInterface $output A Symfony console output
+     * @param bool            $clean  clean orphaned pages
      */
-    public function update(SiteInterface $site, OutputInterface $output = null)
+    public function update(SiteInterface $site, OutputInterface $output = null, $clean = false)
     {
         $message = sprintf(
             ' > <info>Updating core routes for site</info> : <comment>%s - %s</comment>',
@@ -215,11 +216,17 @@ class RoutePageGenerator
                     $this->writeln($output, array('', 'Some hybrid pages does not exist anymore', str_repeat('-', 80)));
                 }
 
-                $this->writeln($output, sprintf('  <error>ERROR</error>   %s', $page->getRouteName()));
+                if ($clean) {
+                    $this->pageManager->delete($page);
+
+                    $this->writeln($output, sprintf('  <error>REMOVED</error>   %s', $page->getRouteName()));
+                } else {
+                    $this->writeln($output, sprintf('  <error>ERROR</error>   %s', $page->getRouteName()));
+                }
             }
         }
 
-        if ($has) {
+        if ($has && !$clean) {
             $this->writeln($output, <<<'MSG'
 <error>
   *WARNING* : Pages has been updated however some pages do not exist anymore.

--- a/Tests/Route/RoutePageGeneratorTest.php
+++ b/Tests/Route/RoutePageGeneratorTest.php
@@ -71,6 +71,38 @@ class RoutePageGeneratorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Tests site update route method with.
+     */
+    public function testUpdateRoutesClean()
+    {
+        $site = $this->getSiteMock();
+
+        $tmpFile = tmpfile();
+
+        $this->routePageGenerator->update($site, new StreamOutput($tmpFile), true);
+
+        fseek($tmpFile, 0);
+
+        $output = '';
+
+        while (!feof($tmpFile)) {
+            $output = fread($tmpFile, 4096);
+        }
+
+        $this->assertRegExp('#CREATE(.*)route1(.*)/first_custom_route#', $output);
+        $this->assertRegExp('#CREATE(.*)route1(.*)/first_custom_route#', $output);
+        $this->assertRegExp('#CREATE(.*)test_hybrid_page_with_good_host(.*)/third_custom_route#', $output);
+        $this->assertRegExp('#CREATE(.*)404#', $output);
+        $this->assertRegExp('#CREATE(.*)500#', $output);
+
+        $this->assertRegExp('#DISABLE(.*)test_hybrid_page_with_bad_host(.*)/fourth_custom_route#', $output);
+
+        $this->assertRegExp('#UPDATE(.*)test_hybrid_page_with_bad_host(.*)/fourth_custom_route#', $output);
+
+        $this->assertRegExp('#REMOVED(.*)test_hybrid_page_not_exists#', $output);
+    }
+
+    /**
      * Returns a mock of a site model.
      *
      * @return \Sonata\PageBundle\Model\SiteInterface


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this feature is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added --clean option to `sonata:page:update-core-routes` command to remove orphaned pages

### Deprecation
- Deprecated unused `--all` option in `sonata:page:update-core-routes` command
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Update the tests
- [x] Update the documentation

## Subject

Added a new option to batch delete all orphaned pages when updating the core routes.
