### PR TITLE
Revert: Use the page name if the page has no SEO title (#646)

### DIFF
--- a/Page/Service/DefaultPageService.php
+++ b/Page/Service/DefaultPageService.php
@@ -73,7 +73,9 @@ class DefaultPageService extends BasePageService
             return;
         }
 
-        $this->seoPage->setTitle($page->getTitle() ?: $page->getName());
+        if ($page->getTitle()) {
+            $this->seoPage->setTitle($page->getTitle() ?: $page->getName());
+        }
 
         if ($page->getMetaDescription()) {
             $this->seoPage->addMeta('name', 'description', $page->getMetaDescription());

--- a/Page/Service/DefaultPageService.php
+++ b/Page/Service/DefaultPageService.php
@@ -73,7 +73,7 @@ class DefaultPageService extends BasePageService
             return;
         }
 
-        if ($page->getTitle()) {
+        if (!$this->seoPage->getTitle()) {
             $this->seoPage->setTitle($page->getTitle() ?: $page->getName());
         }
 

--- a/Tests/Page/Service/DefaultPageServiceTest.php
+++ b/Tests/Page/Service/DefaultPageServiceTest.php
@@ -60,7 +60,8 @@ class DefaultPageServiceTest extends \PHPUnit_Framework_TestCase
 
         // mock a page instance
         $page = $this->getMock('Sonata\PageBundle\Model\PageInterface');
-        $page->expects($this->exactly(2))->method('getTitle')->will($this->returnValue('page title'));
+        $this->seoPage->expects($this->once())->method('getTitle')->will($this->returnValue(null));
+        $page->expects($this->once())->method('getTitle')->will($this->returnValue('page title'));
         $page->expects($this->atLeastOnce())->method('getMetaDescription')->will($this->returnValue('page meta description'));
         $page->expects($this->atLeastOnce())->method('getMetaKeyword')->will($this->returnValue('page meta keywords'));
         $page->expects($this->once())->method('getTemplateCode')->will($this->returnValue('template code'));

--- a/Tests/Page/Service/DefaultPageServiceTest.php
+++ b/Tests/Page/Service/DefaultPageServiceTest.php
@@ -60,7 +60,7 @@ class DefaultPageServiceTest extends \PHPUnit_Framework_TestCase
 
         // mock a page instance
         $page = $this->getMock('Sonata\PageBundle\Model\PageInterface');
-        $page->expects($this->any())->method('getTitle')->will($this->returnValue('page title'));
+        $page->expects($this->exactly(2))->method('getTitle')->will($this->returnValue('page title'));
         $page->expects($this->atLeastOnce())->method('getMetaDescription')->will($this->returnValue('page meta description'));
         $page->expects($this->atLeastOnce())->method('getMetaKeyword')->will($this->returnValue('page meta keywords'));
         $page->expects($this->once())->method('getTemplateCode')->will($this->returnValue('template code'));


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Reverts #646 partially

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
 - the page title won't get overwritten anymore
```

## Subject

Reverts my PR from last year, because any existing title was overwritten. This PR fixes this behavior, so the title will be set if there isn't any.