### PR TITLE
Fixes super-admin not being a page editor

### DIFF
--- a/CmsManager/CmsManagerSelector.php
+++ b/CmsManager/CmsManagerSelector.php
@@ -79,7 +79,8 @@ class CmsManagerSelector implements CmsManagerSelectorInterface, LogoutHandlerIn
      */
     public function onSecurityInteractiveLogin(InteractiveLoginEvent $event)
     {
-        if ($this->getSecurityContext()->getToken() && $this->getSecurityContext()->isGranted('ROLE_SONATA_PAGE_ADMIN_PAGE_EDIT')) {
+        if ($this->getSecurityContext()->getToken() &&
+            $this->container->get('sonata.page.admin.page')->isGranted('EDIT')) {
             $this->getSession()->set('sonata/page/isEditor', true);
         }
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because it's a small yet important fix for those using super admin rights and for a better DX experience (no need to setup roles etc.).

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #623

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- CmsManagerSelector now uses the page admin `isGranted` method to check for EDIT
```
