### PR TITLE
Fix configuration regex that shouldn't be delimited

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -84,8 +84,8 @@ EOF;
             ->arrayNode('ignore_route_patterns')
                 ->info($ignoreRoutePatternsInfo)
                 ->defaultValue(array(
-                    '/(.*)admin(.*)/',
-                    '/^_(.*)/',
+                    '(.*)admin(.*)',
+                    '^_(.*)',
                 ))
                 ->prototype('scalar')->end()
             ->end()
@@ -113,7 +113,7 @@ EOF;
             ->arrayNode('ignore_uri_patterns')
                 ->info($ignoreUriPatternsInfo)
                 ->defaultValue(array(
-                    '/admin(.*)/',
+                    'admin(.*)',
                 ))
                 ->prototype('scalar')->end()
             ->end()

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -123,8 +123,8 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
             'hide_disabled_blocks' => false,
             'use_streamed_response' => false,
             'ignore_route_patterns' => array(
-                0 => '/(.*)admin(.*)/',
-                1 => '/^_(.*)/',
+                0 => '(.*)admin(.*)',
+                1 => '^_(.*)',
             ),
             'ignore_routes' => array(
                 0 => 'sonata_page_cache_esi',
@@ -137,7 +137,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                 7 => 'sonata_cache_apc',
             ),
             'ignore_uri_patterns' => array(
-                0 => '/admin(.*)/',
+                0 => 'admin(.*)',
             ),
             'cache_invalidation' => array(
                 'service' => 'sonata.cache.invalidation.simple',
@@ -208,8 +208,8 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
             'hide_disabled_blocks' => false,
             'use_streamed_response' => false,
             'ignore_route_patterns' => array(
-                0 => '/(.*)admin(.*)/',
-                1 => '/^_(.*)/',
+                0 => '(.*)admin(.*)',
+                1 => '^_(.*)',
             ),
             'ignore_routes' => array(
                 0 => 'sonata_page_cache_esi',
@@ -222,7 +222,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                 7 => 'sonata_cache_apc',
             ),
             'ignore_uri_patterns' => array(
-                0 => '/admin(.*)/',
+                0 => 'admin(.*)',
             ),
             'cache_invalidation' => array(
                 'service' => 'sonata.cache.invalidation.simple',


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Configuration regex for `ignore_route_patterns` and `ignore_uri_patterns` nodes
```
## Subject

Default configuration for `ignore_route_patterns` and `ignore_uri_patterns` nodes is wrong: regular expressions are delimited with `/`, however in `DecoratorStrategy` those strings are **delimited again** with `#` see [L110](https://github.com/sonata-project/SonataPageBundle/blob/3.x/CmsManager/DecoratorStrategy.php#L110) and [L124](https://github.com/sonata-project/SonataPageBundle/blob/3.x/CmsManager/DecoratorStrategy.php#L124).

```php
->arrayNode('ignore_route_patterns')
    ->info($ignoreRoutePatternsInfo)
    ->defaultValue(array(
        '/(.*)admin(.*)/',
        '/^_(.*)/',
    ))
    ->prototype('scalar')->end()
->end()


->arrayNode('ignore_uri_patterns')
    ->info($ignoreUriPatternsInfo)
    ->defaultValue(array(
        '/admin(.*)/',
    ))
    ->prototype('scalar')->end()
->end()
```