### PR TITLE
Fixing length of "locale" field for doctrine, it should be 7 instead of 6.

### DIFF
--- a/Resources/config/doctrine/BaseSite.orm.xml
+++ b/Resources/config/doctrine/BaseSite.orm.xml
@@ -11,7 +11,7 @@
         <field name="isDefault"         type="boolean"      column="is_default"         default="false"/>
         <field name="createdAt"         type="datetime"     column="created_at"/>
         <field name="updatedAt"         type="datetime"     column="updated_at"/>
-        <field name="locale"            type="string"       column="locale"             nullable="true"   length="6"/>
+        <field name="locale"            type="string"       column="locale"             nullable="true"   length="7"/>
 
         <field name="title"             type="string"       column="title"              nullable="true"   length="64"/>
         <field name="metaKeywords"      type="string"       column="meta_keywords"      nullable="true"   length="255"/>


### PR DESCRIPTION
"Locale" field of entity "Site" has length set as 6, instead of 7, which is not according to current valid ISO standards.

Example, sr_Latn (which is valid locale code) can not be accommodated into field, see: https://en.wikipedia.org/wiki/Template:ISO_639_name_sr-Latn

There is no BC break for this PR.