### PR TITLE
[Bugfix] Property "locale" of entity "Site" should be length of 7

### DIFF
--- a/Resources/config/doctrine/BaseSite.orm.xml
+++ b/Resources/config/doctrine/BaseSite.orm.xml
@@ -10,7 +10,7 @@
         <field name="isDefault" type="boolean" column="is_default" default="false"/>
         <field name="createdAt" type="datetime" column="created_at"/>
         <field name="updatedAt" type="datetime" column="updated_at"/>
-        <field name="locale" type="string" column="locale" nullable="true" length="6"/>
+        <field name="locale" type="string" column="locale" nullable="true" length="7"/>
         <field name="title" type="string" column="title" nullable="true" length="64"/>
         <field name="metaKeywords" type="string" column="meta_keywords" nullable="true" length="255"/>
         <field name="metaDescription" type="string" column="meta_description" nullable="true" length="255"/>


### PR DESCRIPTION
I am targetting this branch, because this is BC compatible.

## Changelog
```markdown
### Fixed
- ISO 639 compatibility  Entity Site, property locale, now has length set as 7 instead of 6.
```

## Subject

This fixes compatibility with ISO standards in regards to locale length, see: https://en.wikipedia.org/wiki/Template:ISO_639_name_sr-Latn 

In general, locale can have length of 7 chars.
