### PR TITLE
[IMPROVEMENT] Preserve current site filter when working with pages.

### DIFF
--- a/Admin/PageAdmin.php
+++ b/Admin/PageAdmin.php
@@ -221,6 +221,25 @@ class PageAdmin extends AbstractAdmin
     /**
      * {@inheritdoc}
      */
+    public function getPersistentParameters()
+    {
+        $parameters = parent::getPersistentParameters();
+        $key = sprintf('%s.current_site', $this->getCode());
+
+        if ($site = $this->request->get('site', null)) {
+            $this->request->getSession()->set($key, $site);
+        }
+
+        if ($site = $this->request->getSession()->get($key, null)) {
+            $parameters['site'] = $site;
+        }
+
+        return $parameters;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function configureShowFields(ShowMapper $showMapper)
     {
         $showMapper

--- a/Tests/Entity/BlockManagerTest.php
+++ b/Tests/Entity/BlockManagerTest.php
@@ -36,6 +36,7 @@ class BlockManagerTest extends \PHPUnit_Framework_TestCase
             $this->getMockBuilder('Doctrine\ORM\EntityManager')->disableOriginalConstructor()->getMock(),
         ));
 
+        $qb->expects($this->any())->method('getRootAliases')->will($this->returnValue(array()));
         $qb->expects($this->any())->method('select')->will($this->returnValue($qb));
         $qb->expects($this->any())->method('getQuery')->will($this->returnValue($query));
 

--- a/Tests/Entity/PageManagerTest.php
+++ b/Tests/Entity/PageManagerTest.php
@@ -250,6 +250,7 @@ class PageManagerTest extends \PHPUnit_Framework_TestCase
             $this->getMockBuilder('Doctrine\ORM\EntityManager')->disableOriginalConstructor()->getMock(),
         ));
 
+        $qb->expects($this->any())->method('getRootAliases')->will($this->returnValue(array()));
         $qb->expects($this->any())->method('select')->will($this->returnValue($qb));
         $qb->expects($this->any())->method('getQuery')->will($this->returnValue($query));
 

--- a/Tests/Entity/SiteManagerTest.php
+++ b/Tests/Entity/SiteManagerTest.php
@@ -121,6 +121,7 @@ class SiteManagerTest extends \PHPUnit_Framework_TestCase
             $this->getMockBuilder('Doctrine\ORM\EntityManager')->disableOriginalConstructor()->getMock(),
         ));
 
+        $qb->expects($this->any())->method('getRootAliases')->will($this->returnValue(array()));
         $qb->expects($this->any())->method('select')->will($this->returnValue($qb));
         $qb->expects($this->any())->method('getQuery')->will($this->returnValue($query));
 

--- a/Tests/Entity/SnapshotManagerTest.php
+++ b/Tests/Entity/SnapshotManagerTest.php
@@ -273,6 +273,7 @@ class SnapshotManagerTest extends \PHPUnit_Framework_TestCase
             $this->getMockBuilder('Doctrine\ORM\EntityManager')->disableOriginalConstructor()->getMock(),
         ));
 
+        $qb->expects($this->any())->method('getRootAliases')->will($this->returnValue(array()));
         $qb->expects($this->any())->method('select')->will($this->returnValue($qb));
         $qb->expects($this->any())->method('getQuery')->will($this->returnValue($query));
 


### PR DESCRIPTION
I am targetting this branch, because it is BC compatible.

## Changelog
```markdown
### Changed
- `Sonata\PageBundle\Admin\PageAdmin`, added method `getPersistentParameters`
```
## Subject

When dealing with multiple sites, it is real pain in a** during operations which deals with non-default site pages. After each navigation step (save, delete) -> list of pages is displayed (tree view) which belongs to default site -> not current working one.

In general, if there are sites A and B, and if I work with site B, I would like to work with site B during my session until I explicitly change to site A and vice versa.

**Conclusion:** this is not a bugfix, this is usability improvement.