### PR TITLE
Add support FOSRestBundle 2.0

### DIFF
--- a/Controller/Api/BlockController.php
+++ b/Controller/Api/BlockController.php
@@ -12,8 +12,6 @@
 namespace Sonata\PageBundle\Controller\Api;
 
 use FOS\RestBundle\Controller\Annotations\View;
-use FOS\RestBundle\View\View as FOSRestView;
-use JMS\Serializer\SerializationContext;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\BlockBundle\Model\BlockManagerInterface;
@@ -24,7 +22,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 /**
  * @author Vincent Composieux <vincent.composieux@gmail.com>
  */
-class BlockController
+class BlockController extends FOSRestController
 {
     /**
      * @var BlockManagerInterface
@@ -61,7 +59,7 @@ class BlockController
      *  }
      * )
      *
-     * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
+     * @View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
      * @param $id
      *
@@ -110,13 +108,7 @@ class BlockController
 
             $this->blockManager->save($block);
 
-            $view = FOSRestView::create($block);
-            $serializationContext = SerializationContext::create();
-            $serializationContext->setGroups(array('sonata_api_read'));
-            $serializationContext->enableMaxDepthChecks();
-            $view->setSerializationContext($serializationContext);
-
-            return $view;
+            return $this->serializeContext($block, array('sonata_api_read'));
         }
 
         return $form;

--- a/Controller/Api/FOSRestController.php
+++ b/Controller/Api/FOSRestController.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\PageBundle\Controller\Api;
+
+use FOS\RestBundle\Context\Context;
+use FOS\RestBundle\Controller\Annotations\QueryParam;
+use FOS\RestBundle\Request\ParamFetcherInterface;
+use FOS\RestBundle\View\View as FOSRestView;
+use JMS\Serializer\SerializationContext;
+
+/**
+ * @author Duchkina Anastasiya <duchkina.nast@gmail.com>
+ */
+class FOSRestController
+{
+    /**
+     * @param ParamFetcherInterface $paramFetcher
+     *
+     * @return ParamFetcherInterface
+     */
+    final protected function setMapForOrderByParam(ParamFetcherInterface $paramFetcher)
+    {
+        $orderByQueryParam = new QueryParam();
+        if (property_exists($orderByQueryParam, 'map')) {
+            // support FOSRestApi 2.0
+            $orderByQueryParam->map = true;
+        } else {
+            $orderByQueryParam->array = true;
+        }
+        $paramFetcher->addParam($orderByQueryParam);
+
+        return $paramFetcher;
+    }
+
+    /**
+     * @param $entity
+     * @param array $groups
+     *
+     * @return FOSRestView
+     */
+    final protected function serializeContext($entity, array $groups)
+    {
+        $view = FOSRestView::create($entity);
+        if (method_exists($view, 'setSerializationContext')) {
+            // support FOSRestApi <= v1.7.9
+            $serializationContext = SerializationContext::create();
+            $serializationContext->setGroups($groups);
+            $serializationContext->enableMaxDepthChecks();
+            $view->setSerializationContext($serializationContext);
+        } else {
+            // since FOSRestApi >= v1.8
+            $context = new Context();
+            $context->setGroups($groups);
+            $view->setContext($context);
+        }
+
+        return $view;
+    }
+}

--- a/Controller/Api/FOSRestController.php
+++ b/Controller/Api/FOSRestController.php
@@ -20,7 +20,7 @@ use JMS\Serializer\SerializationContext;
 /**
  * @author Duchkina Anastasiya <duchkina.nast@gmail.com>
  */
-class FOSRestController
+abstract class FOSRestController
 {
     /**
      * @param ParamFetcherInterface $paramFetcher

--- a/Controller/Api/PageController.php
+++ b/Controller/Api/PageController.php
@@ -14,8 +14,6 @@ namespace Sonata\PageBundle\Controller\Api;
 use FOS\RestBundle\Controller\Annotations\QueryParam;
 use FOS\RestBundle\Controller\Annotations\View;
 use FOS\RestBundle\Request\ParamFetcherInterface;
-use FOS\RestBundle\View\View as FOSRestView;
-use JMS\Serializer\SerializationContext;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\BlockBundle\Model\BlockManagerInterface;
@@ -32,7 +30,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 /**
  * @author Hugo Briand <briand@ekino.com>
  */
-class PageController
+class PageController extends FOSRestController
 {
     /**
      * @var SiteManagerInterface
@@ -91,9 +89,9 @@ class PageController
      * @QueryParam(name="root", requirements="0|1", nullable=true, strict=true, description="Filter pages having no parent id")
      * @QueryParam(name="site", requirements="\d+", nullable=true, strict=true, description="Filter pages for a specific site's id")
      * @QueryParam(name="parent", requirements="\d+", nullable=true, strict=true, description="Get pages being child of given page id")
-     * @QueryParam(name="orderBy", requirements="ASC|DESC", array=true, nullable=true, strict=true, description="Order by array (key is field, value is direction)")
+     * @QueryParam(name="orderBy", requirements="ASC|DESC", nullable=true, strict=true, description="Order by array (key is field, value is direction)")
      *
-     * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
+     * @View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
      * @param ParamFetcherInterface $paramFetcher
      *
@@ -101,6 +99,8 @@ class PageController
      */
     public function getPagesAction(ParamFetcherInterface $paramFetcher)
     {
+        $this->setMapForOrderByParam($paramFetcher);
+
         $supportedCriteria = array(
             'enabled' => '',
             'edited' => '',
@@ -146,7 +146,7 @@ class PageController
      *  }
      * )
      *
-     * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
+     * @View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
      * @param $id
      *
@@ -171,7 +171,7 @@ class PageController
      *  }
      * )
      *
-     * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
+     * @View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
      * @param $id
      *
@@ -196,7 +196,7 @@ class PageController
      *  }
      * )
      *
-     * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
+     * @View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
      * @param $id
      *
@@ -248,13 +248,7 @@ class PageController
 
             $this->blockManager->save($block);
 
-            $view = FOSRestView::create($block);
-            $serializationContext = SerializationContext::create();
-            $serializationContext->setGroups(array('sonata_api_read'));
-            $serializationContext->enableMaxDepthChecks();
-            $view->setSerializationContext($serializationContext);
-
-            return $view;
+            return $this->serializeContext($block, array('sonata_api_read'));
         }
 
         return $form;
@@ -461,13 +455,7 @@ class PageController
             $page = $form->getData();
             $this->pageManager->save($page);
 
-            $view = FOSRestView::create($page);
-            $serializationContext = SerializationContext::create();
-            $serializationContext->setGroups(array('sonata_api_read'));
-            $serializationContext->enableMaxDepthChecks();
-            $view->setSerializationContext($serializationContext);
-
-            return $view;
+            return $this->serializeContext($page, array('sonata_api_read'));
         }
 
         return $form;

--- a/Controller/Api/SiteController.php
+++ b/Controller/Api/SiteController.php
@@ -15,7 +15,6 @@ use FOS\RestBundle\Controller\Annotations\QueryParam;
 use FOS\RestBundle\Controller\Annotations\View;
 use FOS\RestBundle\Request\ParamFetcherInterface;
 use FOS\RestBundle\View\View as FOSRestView;
-use JMS\Serializer\SerializationContext;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use Sonata\PageBundle\Model\SiteInterface;
 use Sonata\PageBundle\Model\SiteManagerInterface;
@@ -27,7 +26,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 /**
  * @author Raphaël Benitte <benitteraphael@gmail.com>
  */
-class SiteController
+class SiteController extends FOSRestController
 {
     /**
      * @var SiteManagerInterface
@@ -61,9 +60,9 @@ class SiteController
      * @QueryParam(name="count", requirements="\d+", default="10", description="Maximum number of sites per page")
      * @QueryParam(name="enabled", requirements="0|1", nullable=true, strict=true, description="Enabled/Disabled sites filter")
      * @QueryParam(name="is_default", requirements="0|1", nullable=true, strict=true, description="Default sites filter")
-     * @QueryParam(name="orderBy", requirements="ASC|DESC", array=true, nullable=true, strict=true, description="Order by array (key is field, value is direction)")
+     * @QueryParam(name="orderBy", requirements="ASC|DESC", nullable=true, strict=true, description="Order by array (key is field, value is direction)")
      *
-     * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
+     * @View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
      * @param ParamFetcherInterface $paramFetcher
      *
@@ -71,6 +70,8 @@ class SiteController
      */
     public function getSitesAction(ParamFetcherInterface $paramFetcher)
     {
+        $this->setMapForOrderByParam($paramFetcher);
+
         $supportedCriteria = array(
             'enabled' => '',
             'is_default' => '',
@@ -113,7 +114,7 @@ class SiteController
      *  }
      * )
      *
-     * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
+     * @View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
      * @param $id
      *
@@ -247,13 +248,7 @@ class SiteController
 
             $this->siteManager->save($site);
 
-            $view = FOSRestView::create($site);
-            $serializationContext = SerializationContext::create();
-            $serializationContext->setGroups(array('sonata_api_read'));
-            $serializationContext->enableMaxDepthChecks();
-            $view->setSerializationContext($serializationContext);
-
-            return $view;
+            return $this->serializeContext($site, array('sonata_api_read'));
         }
 
         return $form;

--- a/Controller/Api/SnapshotController.php
+++ b/Controller/Api/SnapshotController.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 /**
  * @author Benoit de Jacobet <benoit.de-jacobet@ekino.com>
  */
-class SnapshotController
+class SnapshotController extends FOSRestController
 {
     /**
      * @var SnapshotManagerInterface
@@ -53,9 +53,9 @@ class SnapshotController
      * @QueryParam(name="root", requirements="0|1", nullable=true, strict=true, description="Filter snapshots having no parent id")
      * @QueryParam(name="parent", requirements="\d+", nullable=true, strict=true, description="Get snapshots being child of given snapshots id")
      * @QueryParam(name="enabled", requirements="0|1", nullable=true, strict=true, description="Enabled/Disabled snapshots filter")
-     * @QueryParam(name="orderBy", requirements="ASC|DESC", array=true, nullable=true, strict=true, description="Order by array (key is field, value is direction)")
+     * @QueryParam(name="orderBy", requirements="ASC|DESC", nullable=true, strict=true, description="Order by array (key is field, value is direction)")
      *
-     * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
+     * @View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
      * @param ParamFetcherInterface $paramFetcher
      *
@@ -63,6 +63,8 @@ class SnapshotController
      */
     public function getSnapshotsAction(ParamFetcherInterface $paramFetcher)
     {
+        $this->setMapForOrderByParam($paramFetcher);
+
         $supportedCriteria = array(
             'enabled' => '',
             'site' => '',
@@ -108,7 +110,7 @@ class SnapshotController
      *  }
      * )
      *
-     * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
+     * @View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
      * @param $id
      *

--- a/Tests/Controller/Api/PageControllerTest.php
+++ b/Tests/Controller/Api/PageControllerTest.php
@@ -23,12 +23,16 @@ class PageControllerTest extends \PHPUnit_Framework_TestCase
     {
         $pager = $this->getMockBuilder('Sonata\AdminBundle\Datagrid\Pager')->disableOriginalConstructor()->getMock();
 
-        $pageManager = $this->getMock('Sonata\PageBundle\Model\PageManagerInterface');
-        $pageManager->expects($this->once())->method('getPager')->will($this->returnValue($pager));
+        $paramFetcher = $this->getMockBuilder('FOS\RestBundle\Request\ParamFetcherInterface')
+            ->setMethods(array('addParam', 'setController', 'get', 'all'))
+            ->getMock();
 
-        $paramFetcher = $this->getMock('FOS\RestBundle\Request\ParamFetcherInterface');
+        $paramFetcher->expects($this->once())->method('addParam');
         $paramFetcher->expects($this->exactly(3))->method('get');
         $paramFetcher->expects($this->once())->method('all')->will($this->returnValue(array()));
+
+        $pageManager = $this->getMockBuilder('Sonata\PageBundle\Model\PageManagerInterface')->getMock();
+        $pageManager->expects($this->once())->method('getPager')->will($this->returnValue($pager));
 
         $this->assertSame($pager, $this->createPageController(null, null, $pageManager)->getPagesAction($paramFetcher));
     }

--- a/Tests/Controller/Api/SiteControllerTest.php
+++ b/Tests/Controller/Api/SiteControllerTest.php
@@ -21,10 +21,14 @@ class SiteControllerTest extends \PHPUnit_Framework_TestCase
 {
     public function testGetSitesAction()
     {
-        $siteManager = $this->getMock('Sonata\PageBundle\Model\SiteManagerInterface');
+        $siteManager = $this->getMockBuilder('Sonata\PageBundle\Model\SiteManagerInterface')->getMock();
         $siteManager->expects($this->once())->method('getPager')->will($this->returnValue(array()));
 
-        $paramFetcher = $this->getMock('FOS\RestBundle\Request\ParamFetcherInterface');
+        $paramFetcher = $this->getMockBuilder('FOS\RestBundle\Request\ParamFetcherInterface')
+            ->setMethods(array('addParam', 'setController', 'get', 'all'))
+            ->getMock();
+
+        $paramFetcher->expects($this->once())->method('addParam');
         $paramFetcher->expects($this->exactly(3))->method('get');
         $paramFetcher->expects($this->once())->method('all')->will($this->returnValue(array()));
 

--- a/Tests/Controller/Api/SnapshotControllerTest.php
+++ b/Tests/Controller/Api/SnapshotControllerTest.php
@@ -20,10 +20,14 @@ class SnapshotControllerTest extends \PHPUnit_Framework_TestCase
 {
     public function testGetSnapshotsAction()
     {
-        $snapshotManager = $this->getMock('Sonata\PageBundle\Model\SnapshotManagerInterface');
+        $snapshotManager = $this->getMockBuilder('Sonata\PageBundle\Model\SnapshotManagerInterface')->getMock();
         $snapshotManager->expects($this->once())->method('getPager')->will($this->returnValue(array()));
 
-        $paramFetcher = $this->getMock('FOS\RestBundle\Request\ParamFetcherInterface');
+        $paramFetcher = $this->getMockBuilder('FOS\RestBundle\Request\ParamFetcherInterface')
+            ->setMethods(array('addParam', 'setController', 'get', 'all'))
+            ->getMock();
+
+        $paramFetcher->expects($this->once())->method('addParam');
         $paramFetcher->expects($this->exactly(3))->method('get');
         $paramFetcher->expects($this->once())->method('all')->will($this->returnValue(array()));
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because i want to add support FOSRestBundle v2.0.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
 - added support for `FOSRestBundle:2.0`
