### PR TITLE
use font-awesome icon instead of a famfamfam icon

### DIFF
--- a/Resources/views/PageAdmin/select_site.html.twig
+++ b/Resources/views/PageAdmin/select_site.html.twig
@@ -30,7 +30,7 @@ file that was distributed with this source code.
             {% for site in sites %}
                 <li>
                     {% if current and site.id == current.id %}
-                        <img src="{{ asset('bundles/sonataadmin/famfamfam/accept.png') }}">
+                        <i class="fa fa-check"></i>
                     {% endif %}
 
                     <a href="{{ admin.generateUrl('create', {'siteId': site.id, 'uniqid': admin.uniqid}) }}">


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Refs https://github.com/sonata-project/SonataAdminBundle/pull/4315

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- use font awesome icon instead of famfamfam icon in `select_site.html.twig`
```
