### PR TITLE
Carry #735

### DIFF
--- a/Admin/PageAdmin.php
+++ b/Admin/PageAdmin.php
@@ -465,11 +465,19 @@ class PageAdmin extends AbstractAdmin
             $admin->generateMenuUrl('sonata.page.admin.snapshot.list', array('id' => $id))
         );
 
-        if (!$this->getSubject()->isHybrid() && !$this->getSubject()->isInternal()) {
+        $page = $this->getSubject();
+        if (!$page->isHybrid() && !$page->isInternal()) {
             try {
-                $menu->addChild('view_page',
-                    array('uri' => $this->getRouteGenerator()->generate('page_slug', array('path' => $this->getSubject()->getUrl())))
-                );
+                $path = $page->getUrl();
+                $siteRelativePath = $page->getSite()->getRelativePath();
+                if (!empty($siteRelativePath)) {
+                    $path = $siteRelativePath.$path;
+                }
+                $menu->addChild('view_page', array(
+                    'uri' => $this->getRouteGenerator()->generate('page_slug', array(
+                        'path' => $path,
+                    )),
+                ));
             } catch (\Exception $e) {
                 // avoid crashing the admin if the route is not setup correctly
                 // throw $e;

--- a/Tests/Admin/PageAdminTest.php
+++ b/Tests/Admin/PageAdminTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\PageBundle\Tests\Admin;
+
+use Knp\Menu\MenuFactory;
+use Prophecy\Argument;
+use Sonata\PageBundle\Admin\PageAdmin;
+use Sonata\PageBundle\Tests\Model\Page;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+class PageAdminTest extends \PHPUnit_Framework_TestCase
+{
+    public function testTabMenuHasLinksWithSubSite()
+    {
+        $request = new Request(array('id' => 42));
+        $admin = new PageAdmin(
+            'admin.page',
+            'Sonata\PageBundle\Model\Page',
+            'Sonata\PageBundle\Controller\PageController'
+        );
+        $admin->setMenuFactory(new MenuFactory());
+        $admin->setRequest($request);
+
+        $site = $this->prophesize('Sonata\PageBundle\Model\Site');
+        $site->getRelativePath()->willReturn('/my-subsite');
+
+        $page = $this->prophesize('Sonata\PageBundle\Model\Page');
+        $page->getRouteName()->willReturn(Page::PAGE_ROUTE_CMS_NAME);
+        $page->getUrl()->willReturn('/my-page');
+        $page->isHybrid()->willReturn(false);
+        $page->isInternal()->willReturn(false);
+        $page->getSite()->willReturn($site->reveal());
+        $admin->setSubject($page->reveal());
+
+        $routeGenerator = $this->prophesize('Sonata\AdminBundle\Route\RouteGeneratorInterface');
+        $routeGenerator->generateMenuUrl(
+            $admin,
+            Argument::any(),
+            array('id' => 42),
+            UrlGeneratorInterface::ABSOLUTE_PATH
+        )->willReturn(array(
+            'route' => 'page_edit',
+            'routeParameters' => array('id' => 42),
+            'routeAbsolute' => true,
+        ));
+
+        $routeGenerator->generate(
+            'page_slug',
+            array('path' => '/my-subsite/my-page')
+        )->shouldBeCalled();
+
+        $admin->setRouteGenerator($routeGenerator->reveal());
+        $admin->setSubject($page->reveal());
+
+        $admin->buildTabMenu('edit');
+    }
+}


### PR DESCRIPTION
I am targetting this branch to fix the bug with the "view page" link that doesn't take into account the relative path of the site.

Closes #735

## Changelog

```markdown
### Fixed
- Add relative path to the "view page" link in the Class PageAdmin
```

## Subject

On the admin interface of a page, the link "view page" doesn't use the relative path of the site.
