### PR TITLE
Prevent error rendering blocks when using shared blocks

### DIFF
--- a/Resources/views/Block/block_base.html.twig
+++ b/Resources/views/Block/block_base.html.twig
@@ -12,7 +12,7 @@ file that was distributed with this source code.
 {% if sonata_page.isInlineEditionOn %}
     <div id="cms-block-{{ block.id }}"
          class="cms-block{% if block.hasParent() %} cms-block-element{% endif %}{% block block_class %}{% endblock %}"
-        {% if sonata_page.isEditor and block.page is defined %}
+        {% if sonata_page.isEditor and block.page is not null %}
             data-id="{{ block.id }}"
             data-name="{{ block.name }}"
             data-role="{% block block_role %}block{% endblock %}"
@@ -20,7 +20,7 @@ file that was distributed with this source code.
         {% endif %}
         >
 {% elseif sonata_page.isEditor() %}
-    <!-- start rendering, block.id: {{ block.id }} - page.id: {% if block.page is defined %}{{ block.page.id }}{% else %}no related page{% endif %} - name: {{ block.name }} -->
+    <!-- start rendering, block.id: {{ block.id }} - page.id: {% if block.page|default(false) %}{{ block.page.id }}{% else %}no related page{% endif %} - name: {{ block.name }} -->
 {% endif %}
 
 {% block block %}EMPTY CONTENT{% endblock %}
@@ -28,5 +28,5 @@ file that was distributed with this source code.
 {% if sonata_page.isInlineEditionOn %}
     </div>
 {% elseif sonata_page.isEditor() %}
-    <!-- end rendering, block.id: {{ block.id }} - page.id: {% if block.page is defined %}{{ block.page.id }}{% else %}no related page{% endif %}  - name: {{ block.name }} -->
+    <!-- end rendering, block.id: {{ block.id }} - page.id: {% if block.page|default(false) %}{{ block.page.id }}{% else %}no related page{% endif %}  - name: {{ block.name }} -->
 {% endif %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a bugfix.

Closes #799.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- use `is not null` instead of `is defined` in `Block/block_base.html.twig`
```
## Subject

Shared blocks are not linked to pages. Thus, for a shared block, the page variable is `null` **but still defined**.

The default template `Block/block_base.html.twig` does the following check: `{% if block.page is defined %}`.This check is wrong because it returns `true` and the following `{{ block.page.id }}` throws an exception:

> Impossible to access an attribute ("id") on a null variable.
> 500 Internal Server Error - Twig_Error_Runtime

However, when SonataPageBundle is installed and enabled, the template `Block/block_base.html.twig` is used as base template also in the admin. In this case, the page variable is undefined. 

Thus the right check to do is:` {% if block.page|default(false) %}`.