### PR TITLE
Removed block bundle deprecations

### DIFF
--- a/Block/ChildrenPagesBlockService.php
+++ b/Block/ChildrenPagesBlockService.php
@@ -12,8 +12,8 @@
 namespace Sonata\PageBundle\Block;
 
 use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\BlockBundle\Block\BaseBlockService;
 use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Block\Service\AbstractAdminBlockService;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\PageBundle\CmsManager\CmsManagerSelectorInterface;
 use Sonata\PageBundle\Exception\PageNotFoundException;
@@ -27,7 +27,7 @@ use Symfony\Component\Templating\EngineInterface;
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class ChildrenPagesBlockService extends BaseBlockService
+class ChildrenPagesBlockService extends AbstractAdminBlockService
 {
     /**
      * @var SiteSelectorInterface

--- a/Block/PageListBlockService.php
+++ b/Block/PageListBlockService.php
@@ -12,8 +12,8 @@
 namespace Sonata\PageBundle\Block;
 
 use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\BlockBundle\Block\BaseBlockService;
 use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Block\Service\AbstractAdminBlockService;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\CoreBundle\Model\Metadata;
 use Sonata\PageBundle\Model\Page;
@@ -22,7 +22,7 @@ use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class PageListBlockService extends BaseBlockService
+class PageListBlockService extends AbstractAdminBlockService
 {
     /**
      * @var PageManagerInterface

--- a/Block/SharedBlockBlockService.php
+++ b/Block/SharedBlockBlockService.php
@@ -12,13 +12,12 @@
 namespace Sonata\PageBundle\Block;
 
 use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\BlockBundle\Block\BaseBlockService;
 use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Block\Service\AbstractAdminBlockService;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\BlockBundle\Model\BlockManagerInterface;
 use Sonata\CoreBundle\Validator\ErrorElement;
 use Sonata\PageBundle\Admin\SharedBlockAdmin;
-use Sonata\PageBundle\Entity\BlockManager;
 use Sonata\PageBundle\Model\Block;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Form\FormBuilder;
@@ -32,7 +31,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
  *
  * @author Romain Mouillard <romain.mouillard@gmail.com>
  */
-class SharedBlockBlockService extends BaseBlockService
+class SharedBlockBlockService extends AbstractAdminBlockService
 {
     /**
      * @var SharedBlockAdmin

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "symfony/templating": "^2.3",
         "symfony/validator": "^2.3",
         "sonata-project/admin-bundle": "^3.4",
-        "sonata-project/block-bundle": "^3.1.1",
+        "sonata-project/block-bundle": "^3.2",
         "sonata-project/seo-bundle": "^2.0",
         "sonata-project/doctrine-extensions" : "^1.0",
         "sonata-project/cache-bundle": "^2.1.7",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataTimelineBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
 - Removed block service deprecation
```

## Subject

Removed sonata block bundle deprecation.
