### PR TITLE
Fixed paths related to SonataEasyExtendsBundle

### DIFF
--- a/Resources/config/doctrine/Block.orm.xml.skeleton
+++ b/Resources/config/doctrine/Block.orm.xml.skeleton
@@ -9,7 +9,7 @@
             association mapping  : http://www.doctrine-project.org/projects/orm/2.0/docs/reference/association-mapping/en
     -->
     <entity
-        name="Application\Sonata\PageBundle\Entity\Block"
+        name="{{ namespace }}\Entity\Block"
         table="page__block"
         repository-class="Doctrine\ORM\EntityRepository">
 

--- a/Resources/config/doctrine/Page.orm.xml.skeleton
+++ b/Resources/config/doctrine/Page.orm.xml.skeleton
@@ -9,7 +9,7 @@
             association mapping  : http://www.doctrine-project.org/projects/orm/2.0/docs/reference/association-mapping/en
     -->
     <entity
-        name="Application\Sonata\PageBundle\Entity\Page"
+        name="{{ namespace }}\Entity\Page"
         table="page__page"
         >
 

--- a/Resources/config/doctrine/Site.orm.xml.skeleton
+++ b/Resources/config/doctrine/Site.orm.xml.skeleton
@@ -9,7 +9,7 @@
             association mapping  : http://www.doctrine-project.org/projects/orm/2.0/docs/reference/association-mapping/en
     -->
     <entity
-        name="Application\Sonata\PageBundle\Entity\Site"
+        name="{{ namespace }}\Entity\Site"
         table="page__site"
         >
 

--- a/Resources/config/doctrine/Snapshot.orm.xml.skeleton
+++ b/Resources/config/doctrine/Snapshot.orm.xml.skeleton
@@ -9,7 +9,7 @@
             association mapping  : http://www.doctrine-project.org/projects/orm/2.0/docs/reference/association-mapping/en
     -->
     <entity
-        name="Application\Sonata\PageBundle\Entity\Snapshot"
+        name="{{ namespace }}\Entity\Snapshot"
         table="page__snapshot"
         >
 

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
         "sonata-project/cache-bundle": "^2.1.7",
         "sonata-project/cache": "^1.0.2",
         "sonata-project/core-bundle": "^3.0",
+        "sonata-project/easy-extends-bundle": "^2.2",
         "symfony-cmf/routing-bundle": "^1.1",
         "sonata-project/notification-bundle": "^3.0",
         "sonata-project/datagrid-bundle": "^2.2",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because my patch is fixing the bug, arisen due to the hardcoded class-path.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed hardcoded paths to classes in `.xml.skeleton` files of config
```

## Subject

<!-- Describe your Pull Request content here -->
Fixed some hardcoded paths, which become invalid after enabling
the '--namespace' option in SonataEasyExtendsBundle's last release
(https://github.com/sonata-project/SonataEasyExtendsBundle/releases/tag/2.2.0)

See also: https://github.com/sonata-project/SonataMediaBundle/pull/1250