### PR TITLE
Use new factory definition API when available

### DIFF
--- a/DependencyInjection/SonataPageExtension.php
+++ b/DependencyInjection/SonataPageExtension.php
@@ -39,6 +39,18 @@ class SonataPageExtension extends Extension
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('page.xml');
 
+        // NEXT_MAJOR: remove this code block
+        $definition = $container->getDefinition('sonata.page.router.request_context');
+        if (method_exists($definition, 'setFactory')) {
+            $definition->setFactory(array(
+                new Reference('sonata.page.site.selector'),
+                'getRequestContext',
+            ));
+        } else {
+            $definition->setFactoryService('sonata.page.site.selector');
+            $definition->setFactoryMethod('getRequestContext');
+        }
+
         if (isset($bundles['FOSRestBundle']) && isset($bundles['NelmioApiDocBundle'])) {
             $loader->load('serializer.xml');
 

--- a/Resources/config/page.xml
+++ b/Resources/config/page.xml
@@ -78,7 +78,13 @@
             <argument/>
             <argument/>
         </service>
-        <service id="sonata.page.router.request_context" factory-method="getRequestContext" factory-service="sonata.page.site.selector" class="Symfony\Component\Routing\RequestContext" public="false"/>
+        <service id="sonata.page.router.request_context" class="Symfony\Component\Routing\RequestContext" public="false">
+            <!-- NEXT_MAJOR: uncomment factory tag
+            <factory service="sonata.page.site.selector"
+                method="getRequestContext"
+            />
+            -->
+        </service>
         <service id="sonata.page.router" class="%sonata.page.router.class%">
             <argument type="service" id="sonata.page.cms_manager_selector"/>
             <argument type="service" id="sonata.page.site.selector"/>


### PR DESCRIPTION

I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- A deprecation warning regarding the usage of factories in the DIC was fixed
```

## To do

- [x] Rebase on 3.x once #811 is merged

## Subject

<!-- Describe your Pull Request content here -->
This will fix a deprecation warning and improve compatibility with
Symfony 3.
