### PR TITLE
Remove scope attribute

### DIFF
--- a/Resources/config/page.xml
+++ b/Resources/config/page.xml
@@ -46,14 +46,14 @@
             <argument type="service" id="sonata.page.decorator_strategy"/>
             <argument type="service" id="sonata.seo.page"/>
         </service>
-        <service id="sonata.page.response_listener" class="%sonata.page.response_listener.class%" scope="request">
+        <service id="sonata.page.response_listener" class="%sonata.page.response_listener.class%">
             <tag name="kernel.event_listener" event="kernel.response" method="onCoreResponse" priority="-1"/>
             <argument type="service" id="sonata.page.cms_manager_selector"/>
             <argument type="service" id="sonata.page.page_service_manager"/>
             <argument type="service" id="sonata.page.decorator_strategy"/>
             <argument type="service" id="templating"/>
         </service>
-        <service id="sonata.page.request_listener" class="%sonata.page.request_listener.class%" scope="request">
+        <service id="sonata.page.request_listener" class="%sonata.page.request_listener.class%">
             <tag name="kernel.event_listener" event="kernel.request" method="onCoreRequest" priority="30"/>
             <argument type="service" id="sonata.page.cms_manager_selector"/>
             <argument type="service" id="sonata.page.site.selector"/>


### PR DESCRIPTION

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- deprecation warning about scope attributes
```

## Subject

Request and response listener always have access to the current request
object, by definition, which means there is no point in giving them the
request scope.

I'm really unsure about this. @skoubin @aimeric @Id4v @jmontoyaa @robbert-vdh @pbrzoski @bruno-ds can any of you test this and report back?
