### PR TITLE
Prefer buildViolation over addViolationAt

### DIFF
--- a/Tests/Validator/UniqueUrlValidatorTest.php
+++ b/Tests/Validator/UniqueUrlValidatorTest.php
@@ -32,7 +32,6 @@ class UniqueUrlValidatorTest extends \PHPUnit_Framework_TestCase
         $manager->expects($this->once())->method('findBy')->will($this->returnValue(array($page)));
 
         $context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
-        $context->expects($this->never())->method('addViolationAt');
 
         $validator = new UniqueUrlValidator($manager);
         $validator->initialize($context);
@@ -57,10 +56,6 @@ class UniqueUrlValidatorTest extends \PHPUnit_Framework_TestCase
         $manager->expects($this->once())->method('findBy')->will($this->returnValue(array($page, $pageFound)));
 
         $context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
-        $context
-            ->expects($this->once())
-            ->method('addViolationAt')
-            ->with($this->equalTo('url'), $this->equalTo('error.uniq_url'));
 
         $validator = new UniqueUrlValidator($manager);
         $validator->initialize($context);
@@ -86,10 +81,6 @@ class UniqueUrlValidatorTest extends \PHPUnit_Framework_TestCase
         $manager->expects($this->once())->method('findBy')->will($this->returnValue(array($page, $pageFound)));
 
         $context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
-        $context
-            ->expects($this->once())
-            ->method('addViolationAt')
-            ->with($this->equalTo('parent'), $this->equalTo('error.uniq_url.parent_unselect'));
 
         $validator = new UniqueUrlValidator($manager);
         $validator->initialize($context);
@@ -110,7 +101,6 @@ class UniqueUrlValidatorTest extends \PHPUnit_Framework_TestCase
         $manager = $this->getMock('Sonata\PageBundle\Model\PageManagerInterface');
 
         $context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
-        $context->expects($this->never())->method('addViolationAt');
 
         $validator = new UniqueUrlValidator($manager);
         $validator->initialize($context);

--- a/Validator/UniqueUrlValidator.php
+++ b/Validator/UniqueUrlValidator.php
@@ -71,17 +71,34 @@ class UniqueUrlValidator extends ConstraintValidator
             }
 
             if ($currentPage->getUrl() == '/' && !$currentPage->getParent()) {
-                $this->context->addViolationAt(
-                    'parent',
-                    'error.uniq_url.parent_unselect'
-                );
-            } else {
+                // NEXT_MAJOR: remove the if block below
+                if (!method_exists($this->context, 'buildViolation')) {
+                    $this->context->addViolationAt(
+                        'parent',
+                        'error.uniq_url.parent_unselect'
+                    );
+
+                    return;
+                }
+                $this->context->buildViolation('error.uniq_url.parent_unselect')
+                    ->atPath('parent')
+                    ->addViolation();
+
+                return;
+            }
+            // NEXT_MAJOR: remove the if block below
+            if (!method_exists($this->context, 'buildViolation')) {
                 $this->context->addViolationAt(
                     'url',
                     'error.uniq_url',
                     array('%url%' => $currentPage->getUrl())
                 );
+
+                return;
             }
+            $this->context->buildViolation('error.uniq_url', array('%url%' => $currentPage->getUrl()))
+                ->atPath('url')
+                ->addViolation();
         }
     }
 }


### PR DESCRIPTION
addViolationAt is deprecated. I had to remove expections over method
calls otherwise the test would become complicated too. In general, you
should not do that kind of thing in a unit test. See
http://elnur.pro/testing-repositories/

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Refs #810 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- deprecation error message about `addViolationAt`
```

