### PR TITLE
symfony 3 admin bundle integration issue #820 fix

### DIFF
--- a/Admin/PageAdmin.php
+++ b/Admin/PageAdmin.php
@@ -280,10 +280,17 @@ class PageAdmin extends AbstractAdmin
      */
     protected function configureDatagridFilters(DatagridMapper $datagridMapper)
     {
+        /*
+         * NEXT_MAJOR: remove type and uncomment the second type when dropping sf < 2.8
+         */
         $datagridMapper
             ->add('site')
             ->add('name')
-            ->add('type', null, array('field_type' => 'sonata_page_type_choice'))
+            ->add('type', null, array('field_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
+                    'Sonata\PageBundle\Form\Type\PageTypeChoiceType' :
+                    'sonata_page_type_choice',
+            ))
+//            ->add('type', null, array('field_type' => 'Sonata\PageBundle\Form\Type\PageTypeChoiceType'))
             ->add('pageAlias')
             ->add('parent')
             ->add('edited')


### PR DESCRIPTION
I am targeting this branch, because BC

Closes #820 

## Changelog

```markdown
### Fixed
- use FQCN for Symfony 3 for `type` in `PageAdmin`

```

### Todo
- [ ] test in symfony < 2.8

### Subject

the solution was derived from the following with @greg0ire 's recommendation:
https://github.com/sonata-project/SonataAdminBundle/blob/240ecbd02d453f9acaf81e00112ff5d8dae4459b/Form/Type/CollectionType.php#L29 

so it should work but i haven't gotten a full installed sonata stack installed on symfony 2.x
