### PR TITLE
use choices instead of choices_list in PageSelectorType. Fixes #823

### DIFF
--- a/Form/Type/PageSelectorType.php
+++ b/Form/Type/PageSelectorType.php
@@ -15,8 +15,6 @@ use Sonata\PageBundle\Model\PageInterface;
 use Sonata\PageBundle\Model\PageManagerInterface;
 use Sonata\PageBundle\Model\SiteInterface;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
-use Symfony\Component\Form\Extension\Core\ChoiceList\SimpleChoiceList;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
@@ -51,10 +49,8 @@ class PageSelectorType extends AbstractType
         $resolver->setDefaults(array(
             'page' => null,
             'site' => null,
-            'choice_list' => function (Options $opts, $previousValue) use ($that) {
-                return class_exists('Symfony\Component\Form\ChoiceList\ArrayChoiceList') ?
-                    new ArrayChoiceList($that->getChoices($opts)) :
-                    new SimpleChoiceList($that->getChoices($opts)); // NEXT_MAJOR: remove condition
+            'choices' => function (Options $opts, $previousValue) use ($that) {
+                return $that->getChoices($opts);
             },
             'choice_translation_domain' => false,
             'filter_choice' => array(

--- a/Tests/Form/Type/PageSelectorTypeTest.php
+++ b/Tests/Form/Type/PageSelectorTypeTest.php
@@ -94,13 +94,7 @@ class PageSelectorTypeTest extends PHPUnit_Framework_TestCase
             'request_method' => 'all',
         )));
 
-        $this->assertInstanceOf(
-            class_exists('Symfony\Component\Form\ChoiceList\ArrayChoiceList') ? // NEXT_MAJOR: remove condition
-                'Symfony\Component\Form\ChoiceList\ArrayChoiceList' :
-                'Symfony\Component\Form\Extension\Core\ChoiceList\SimpleChoiceList',
-            $options['choice_list']
-        );
-        $this->assertEquals(array(), $options['choice_list']->getValues());
+        $this->assertEquals(array(), $options['choices']);
     }
 
     /**
@@ -116,13 +110,7 @@ class PageSelectorTypeTest extends PHPUnit_Framework_TestCase
             'request_method' => 'all',
         )));
 
-        $this->assertInstanceOf(
-            class_exists('Symfony\Component\Form\ChoiceList\ArrayChoiceList') ? // NEXT_MAJOR: remove condition
-                'Symfony\Component\Form\ChoiceList\ArrayChoiceList' :
-                'Symfony\Component\Form\Extension\Core\ChoiceList\SimpleChoiceList',
-            $options['choice_list']
-        );
-        $this->assertCount(4, $options['choice_list']->getChoices());
+        $this->assertCount(4, $options['choices']);
     }
 
     public function testGetRequestMethodChoices()
@@ -133,25 +121,12 @@ class PageSelectorTypeTest extends PHPUnit_Framework_TestCase
 
         $options = $options->resolve(array('site' => $this->site));
 
-        // NEXT_MAJOR: remove else clause
-        if (class_exists('Symfony\Component\Form\ChoiceList\ArrayChoiceList')) {
-            $this->assertInstanceOf(
-                'Symfony\Component\Form\ChoiceList\ArrayChoiceList',
-                $options['choice_list']
-            );
-            $views = $options['choice_list']->getChoices();
-        } else {
-            $this->assertInstanceOf(
-                'Symfony\Component\Form\Extension\Core\ChoiceList\SimpleChoiceList',
-                $options['choice_list']
-            );
-            $views = $options['choice_list']->getRemainingViews();
-        }
+        $views = $options['choices'];
 
         $this->assertCount(3, $views);
-        $this->assertRouteNameEquals('all', $views[0]);
-        $this->assertRouteNameEquals('get', $views[1]);
-        $this->assertRouteNameEquals('get-post', $views[2]);
+        $this->assertRouteNameEquals('all', $views[1]);
+        $this->assertRouteNameEquals('get', $views[3]);
+        $this->assertRouteNameEquals('get-post', $views[4]);
     }
 
     public function testPostRequestMethodChoices()
@@ -164,25 +139,12 @@ class PageSelectorTypeTest extends PHPUnit_Framework_TestCase
             'request_method' => 'post',
         )));
 
-        // NEXT_MAJOR: remove else clause
-        if (class_exists('Symfony\Component\Form\ChoiceList\ArrayChoiceList')) {
-            $this->assertInstanceOf(
-                'Symfony\Component\Form\ChoiceList\ArrayChoiceList',
-                $options['choice_list']
-            );
-            $views = $options['choice_list']->getChoices();
-        } else {
-            $this->assertInstanceOf(
-                'Symfony\Component\Form\Extension\Core\ChoiceList\SimpleChoiceList',
-                $options['choice_list']
-            );
-            $views = $options['choice_list']->getRemainingViews();
-        }
+        $views = $options['choices'];
 
         $this->assertCount(3, $views);
-        $this->assertRouteNameEquals('all', $views[0]);
-        $this->assertRouteNameEquals('post', $views[1]);
-        $this->assertRouteNameEquals('get-post', $views[2]);
+        $this->assertRouteNameEquals('all', $views[1]);
+        $this->assertRouteNameEquals('post', $views[2]);
+        $this->assertRouteNameEquals('get-post', $views[4]);
     }
 
     public function testRootHierarchyChoices()
@@ -196,23 +158,10 @@ class PageSelectorTypeTest extends PHPUnit_Framework_TestCase
             'request_method' => 'all',
         )));
 
-        // NEXT_MAJOR: remove else clause
-        if (class_exists('Symfony\Component\Form\ChoiceList\ArrayChoiceList')) {
-            $this->assertInstanceOf(
-                'Symfony\Component\Form\ChoiceList\ArrayChoiceList',
-                $options['choice_list']
-            );
-            $views = $options['choice_list']->getChoices();
-        } else {
-            $this->assertInstanceOf(
-                'Symfony\Component\Form\Extension\Core\ChoiceList\SimpleChoiceList',
-                $options['choice_list']
-            );
-            $views = $options['choice_list']->getRemainingViews();
-        }
+        $views = $options['choices'];
 
         $this->assertCount(1, $views);
-        $this->assertRouteNameEquals('all', $views[0]);
+        $this->assertRouteNameEquals('all', $views[1]);
     }
 
     public function testChildrenHierarchyChoices()
@@ -226,25 +175,12 @@ class PageSelectorTypeTest extends PHPUnit_Framework_TestCase
             'request_method' => 'all',
         )));
 
-        // NEXT_MAJOR: remove else clause
-        if (class_exists('Symfony\Component\Form\ChoiceList\ArrayChoiceList')) {
-            $this->assertInstanceOf(
-                'Symfony\Component\Form\ChoiceList\ArrayChoiceList',
-                $options['choice_list']
-            );
-            $views = $options['choice_list']->getChoices();
-        } else {
-            $this->assertInstanceOf(
-                'Symfony\Component\Form\Extension\Core\ChoiceList\SimpleChoiceList',
-                $options['choice_list']
-            );
-            $views = $options['choice_list']->getRemainingViews();
-        }
+        $views = $options['choices'];
 
         $this->assertCount(3, $views);
-        $this->assertRouteNameEquals('post', $views[0]);
-        $this->assertRouteNameEquals('get', $views[1]);
-        $this->assertRouteNameEquals('get-post', $views[2]);
+        $this->assertRouteNameEquals('post', $views[2]);
+        $this->assertRouteNameEquals('get', $views[3]);
+        $this->assertRouteNameEquals('get-post', $views[4]);
     }
 
     public function testComplexHierarchyChoices()
@@ -258,24 +194,11 @@ class PageSelectorTypeTest extends PHPUnit_Framework_TestCase
             'request_method' => 'POST',
         )));
 
-        // NEXT_MAJOR: remove else clause
-        if (class_exists('Symfony\Component\Form\ChoiceList\ArrayChoiceList')) {
-            $this->assertInstanceOf(
-                'Symfony\Component\Form\ChoiceList\ArrayChoiceList',
-                $options['choice_list']
-            );
-            $views = $options['choice_list']->getChoices();
-        } else {
-            $this->assertInstanceOf(
-                'Symfony\Component\Form\Extension\Core\ChoiceList\SimpleChoiceList',
-                $options['choice_list']
-            );
-            $views = $options['choice_list']->getRemainingViews();
-        }
+        $views = $options['choices'];
 
         $this->assertCount(2, $views);
-        $this->assertRouteNameEquals('post', $views[0]);
-        $this->assertRouteNameEquals('get-post', $views[1]);
+        $this->assertRouteNameEquals('post', $views[2]);
+        $this->assertRouteNameEquals('get-post', $views[4]);
     }
 
     private function assertRouteNameEquals($expected, $choiceView)


### PR DESCRIPTION
I am targeting this branch, because 3.5 introduced the problem.

Fixes #823 

Closes #823 

## Changelog

use choices instead of choices_list in PageSelectorType

```markdown
### Fixed
- parent page select input no longer has flipped choices

```

## To do

- [x] Run tests to assure backwards compatibility
