### PR TITLE
add target redirect type to page

### DIFF
--- a/src/Admin/PageAdmin.php
+++ b/src/Admin/PageAdmin.php
@@ -400,6 +400,13 @@ class PageAdmin extends AbstractAdmin
                             'siteId' => $this->getSubject() ? $this->getSubject()->getSite()->getId() : null,
                         ],
                     ])
+                ->add('targetRedirectType', method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                    ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType' : 'choice', [
+                        'choices' => [
+                            '301' => 'Permanent (301)',
+                            '302' => 'Temporary (302)',
+                        ],
+                    ])
                 ->end()
             ;
         }

--- a/src/Model/Page.php
+++ b/src/Model/Page.php
@@ -174,6 +174,11 @@ abstract class Page implements PageInterface
     protected static $slugifyMethod;
 
     /**
+     * @var int
+     */
+    protected $targetRedirectType = 302;
+
+    /**
      * {@inheritdoc}
      */
     public function __construct()
@@ -563,6 +568,14 @@ abstract class Page implements PageInterface
     /**
      * {@inheritdoc}
      */
+    public function getTargetRedirectType()
+    {
+        return $this->targetRedirectType;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function addSnapshot(SnapshotInterface $snapshot)
     {
         $this->snapshots[] = $snapshot;
@@ -571,13 +584,19 @@ abstract class Page implements PageInterface
     }
 
     /**
-     * Set target.
-     *
-     * @param PageInterface $target
+     * {@inheritdoc}
      */
     public function setTarget(PageInterface $target = null)
     {
         $this->target = $target;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setTargetRedirectType($statusCode = 302)
+    {
+        $this->targetRedirectType = $statusCode;
     }
 
     /**

--- a/src/Model/PageInterface.php
+++ b/src/Model/PageInterface.php
@@ -277,6 +277,20 @@ interface PageInterface
     public function getTarget();
 
     /**
+     * Set HTTP Status Code for Redirect.
+     *
+     * @param int|null $statusCode
+     */
+    public function setTargetRedirectType($statusCode = 302);
+
+    /**
+     * Get HTTP Status Code for the Redirect.
+     *
+     * @return int
+     */
+    public function getTargetRedirectType();
+
+    /**
      * Set parent.
      *
      * @param PageInterface $parent

--- a/src/Model/SnapshotPageProxy.php
+++ b/src/Model/SnapshotPageProxy.php
@@ -695,6 +695,22 @@ class SnapshotPageProxy implements SnapshotPageProxyInterface
     /**
      * {@inheritdoc}
      */
+    public function getTargetRedirectType()
+    {
+        return $this->getPage()->getTargetRedirectType();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setTargetRedirectType($statusCode = 302)
+    {
+        return $this->getPage()->setTargetRedirectType($statusCode);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     private function load()
     {
         if (!$this->page && $this->transformer) {

--- a/src/Page/PageServiceManager.php
+++ b/src/Page/PageServiceManager.php
@@ -126,11 +126,11 @@ class PageServiceManager implements PageServiceManagerInterface
     {
         if ($page->getTarget()) {
             $page->addHeader('Location', $this->router->generate($page->getTarget()));
-            $response = new Response('', 302, $page->getHeaders() ?: []);
-        } else {
-            $response = new Response('', 200, $page->getHeaders() ?: []);
+            $redirectType = $page->getTargetRedirectType() ? $page->getTargetRedirectType() : 302;
+
+            return new Response('', $redirectType, $page->getHeaders() ?: []);
         }
 
-        return $response;
+        return new Response('', 200, $page->getHeaders() ?: []);
     }
 }

--- a/src/Resources/config/doctrine/BasePage.orm.xml
+++ b/src/Resources/config/doctrine/BasePage.orm.xml
@@ -22,6 +22,7 @@
         <field name="templateCode" type="string" column="template" nullable="false"/>
         <field name="createdAt" type="datetime" column="created_at"/>
         <field name="updatedAt" type="datetime" column="updated_at"/>
+        <field name="targetRedirectType" type="integer" column="target_redirect_type" nullable="true" default="302"/>
         <lifecycle-callbacks>
             <lifecycle-callback type="prePersist" method="prePersist"/>
             <lifecycle-callback type="preUpdate" method="preUpdate"/>

--- a/src/Resources/translations/SonataPageBundle.de.xliff
+++ b/src/Resources/translations/SonataPageBundle.de.xliff
@@ -603,7 +603,8 @@
                 <target><![CDATA[
              Diese Seite ist als Weiterleitung konfiguriert. Um sie zu konfigurieren
              wurde die Weiterleitung verhindert.<br />
-             Um der Weiterleitung zu folgen klicken Sie bitte hier: <a href="%url%">%url%</a>
+             Um der Weiterleitung zu folgen klicken Sie bitte hier: <a href="%url%">%url%</a><br />
+             Status Code: %statusCode%
           ]]></target>
             </trans-unit>
             <trans-unit id="151" resname="filter.label_parent">
@@ -921,6 +922,14 @@
             <trans-unit id="form.label_icon">
                 <source>form.label_icon</source>
                 <target>Icon</target>
+            </trans-unit>
+            <trans-unit id="228" resname="filter.label_is_redirect">
+                <source>filter.label_is_redirect</source>
+                <target>Ist Weiterleitung</target>
+            </trans-unit>
+            <trans-unit id="229" resname="form.label_target_redirect_type">
+                <source>form.label_target_redirect_type</source>
+                <target>Status-Code für Weiterleitung</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Resources/translations/SonataPageBundle.en.xliff
+++ b/src/Resources/translations/SonataPageBundle.en.xliff
@@ -604,7 +604,8 @@
              This page is configured to redirect the end user to another page. In order
              to configure it, the redirect has been blocked for editor only. <br />
              <br />
-             Please click here to follow the redirection: <a href="%url%">%url%</a>.
+             Please click here to follow the redirection: <a href="%url%">%url%</a>.<br />
+             Status Code: %statusCode%
           ]]></target>
             </trans-unit>
             <trans-unit id="151" resname="filter.label_parent">
@@ -922,6 +923,14 @@
             <trans-unit id="form.label_icon">
                 <source>form.label_icon</source>
                 <target>Icon</target>
+            </trans-unit>
+            <trans-unit id="228" resname="filter.label_is_redirect">
+                <source>filter.label_is_redirect</source>
+                <target>Is Redirect</target>
+            </trans-unit>
+            <trans-unit id="229" resname="form.label_target_redirect_type">
+                <source>form.label_target_redirect_type</source>
+                <target>Redirect Type</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Resources/views/Page/redirect.html.twig
+++ b/src/Resources/views/Page/redirect.html.twig
@@ -17,7 +17,10 @@ file that was distributed with this source code.
         <h2>{{ "title_page_redirected"|trans({}, 'SonataPageBundle') }}</h2>
 
         <p>
-            {{ "message_page_redirected"|trans({'%url%': response.headers.get('Location')}, 'SonataPageBundle')|raw }}
+            {{ "message_page_redirected"|trans({
+                '%url%': response.headers.get('Location'),
+                '%statusCode%': response.statusCode
+            }, 'SonataPageBundle')|raw }}
         </p>
     </div>
 {% endblock%}

--- a/src/Resources/views/PageAdmin/tree.html.twig
+++ b/src/Resources/views/PageAdmin/tree.html.twig
@@ -21,6 +21,11 @@ file that was distributed with this source code.
                     <i class="fa page-tree__item__is-hybrid fa-{% if page.isHybrid %}gears{% else %}code{% endif %}"></i>
                     <a class="page-tree__item__edit" href="{{ admin.generateObjectUrl('edit', page) }}">{{ page.name }}</a>
                     <i class="text-muted">{{ page.url }}</i>
+                    {% if page.target is not null %}
+                        <i class="fa fa-arrow-right"></i>
+                        <i class="text-muted">{{ page.target.url }}</i>
+                        ({{ page.targetRedirectType|default('302') }})
+                    {% endif %}
                     <a class="label label-default pull-right" href="{{ admin.generateObjectUrl('compose', page) }}">{{ 'pages.compose_label'|trans({}, 'SonataPageBundle') }} <i class="fa fa-magic"></i></a>
                     {% if page.edited %}<span class="label label-warning pull-right">{{ 'pages.edited_label'|trans({}, 'SonataPageBundle') }}</span>{% endif %}
                 </div>


### PR DESCRIPTION
I am targeting this branch, because it adds functionality to the latest version.

## Changelog
```markdown

### Changed

- Allow to specify the type of the redirect (301 or 302) when a target on the page is selected.
- Displays if a page is redirected and if so to which route and its redirect type in the tree view.
- Allows to filter pages which are a redirect or not.
- Displays the status code of the redirect on the redirect page.

```
## Subject

We had to add multiple 301 redirects via the backend for some SEO stuff. This PR adds the functionality for this in configurable manner. I assume this could be useful for others.