### PR TITLE
Fixed FQCN issue reported in issue #830

### DIFF
--- a/Admin/PageAdmin.php
+++ b/Admin/PageAdmin.php
@@ -354,9 +354,10 @@ class PageAdmin extends AbstractAdmin
             $formMapper
                 ->with('form_page.group_main_label')
 //                    ->add('type', 'sonata_page_type_choice', array('required' => false))
-                    ->add('type', method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-                        'Sonata\PageBundle\Form\Type\PageTypeChoiceType' :
-                        'sonata_page_type_choice',
+                    ->add('type',
+                        method_exists('Symfony\Component\Form\AbstractType','getBlockPrefix') ?
+                            'Sonata\PageBundle\Form\Type\PageTypeChoiceType' :
+                            'sonata_page_type_choice',
                         array('required' => false))
                 ->end()
             ;
@@ -365,9 +366,10 @@ class PageAdmin extends AbstractAdmin
         $formMapper
             ->with('form_page.group_main_label')
 //                ->add('templateCode', 'sonata_page_template', array('required' => true))
-                ->add('templateCode', method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-                    'Sonata\PageBundle\Form\Type\TemplateChoiceType' :
-                    'sonata_page_template',
+                ->add('templateCode',
+                    method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
+                        'Sonata\PageBundle\Form\Type\TemplateChoiceType' :
+                        'sonata_page_template',
                     array('required' => true))
             ->end()
         ;
@@ -376,9 +378,10 @@ class PageAdmin extends AbstractAdmin
             $formMapper
                 ->with('form_page.group_main_label')
 //                    ->add('parent', 'sonata_page_selector', array(
-                    ->add('parent', method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-                        'Sonata\PageBundle\Form\Type\PageSelectorType' :
-                        'sonata_page_selector',
+                    ->add('parent',
+                        method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
+                            'Sonata\PageBundle\Form\Type\PageSelectorType' :
+                            'sonata_page_selector',
                         array(
                             'page' => $this->getSubject() ?: null,
                             'site' => $this->getSubject() ? $this->getSubject()->getSite() : null,
@@ -401,9 +404,10 @@ class PageAdmin extends AbstractAdmin
                 ->with('form_page.group_main_label')
                     ->add('pageAlias', null, array('required' => false))
 //                    ->add('target', 'sonata_page_selector', array(
-                    ->add('parent', method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-                        'Sonata\PageBundle\Form\Type\PageSelectorType' :
-                        'sonata_page_selector',
+                    ->add('parent',
+                        method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
+                            'Sonata\PageBundle\Form\Type\PageSelectorType' :
+                            'sonata_page_selector',
                         array(
                             'page' => $this->getSubject() ?: null,
                             'site' => $this->getSubject() ? $this->getSubject()->getSite() : null,

--- a/Admin/PageAdmin.php
+++ b/Admin/PageAdmin.php
@@ -355,7 +355,7 @@ class PageAdmin extends AbstractAdmin
                 ->with('form_page.group_main_label')
 //                    ->add('type', 'sonata_page_type_choice', array('required' => false))
                     ->add('type',
-                        method_exists('Symfony\Component\Form\AbstractType','getBlockPrefix') ?
+                        method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
                             'Sonata\PageBundle\Form\Type\PageTypeChoiceType' :
                             'sonata_page_type_choice',
                         array('required' => false))

--- a/Admin/PageAdmin.php
+++ b/Admin/PageAdmin.php
@@ -362,7 +362,8 @@ class PageAdmin extends AbstractAdmin
                             'Sonata\PageBundle\Form\Type\PageTypeChoiceType' :
                             'sonata_page_type_choice',
 //                        'Sonata\PageBundle\Form\Type\PageTypeChoiceType',
-                        array('required' => false))
+                        array('required' => false)
+                    )
                 ->end()
             ;
         }
@@ -378,7 +379,8 @@ class PageAdmin extends AbstractAdmin
                         'Sonata\PageBundle\Form\Type\TemplateChoiceType' :
                         'sonata_page_template',
 //                    'Sonata\PageBundle\Form\Type\TemplateChoiceType',
-                    array('required' => true))
+                    array('required' => true)
+                )
             ->end()
         ;
 
@@ -406,7 +408,8 @@ class PageAdmin extends AbstractAdmin
                             'link_parameters' => array(
                                 'siteId' => $this->getSubject() ? $this->getSubject()->getSite()->getId() : null,
                             ),
-                        ))
+                        )
+                    )
                 ->end()
             ;
         }
@@ -436,7 +439,8 @@ class PageAdmin extends AbstractAdmin
                             'link_parameters' => array(
                                 'siteId' => $this->getSubject() ? $this->getSubject()->getSite()->getId() : null,
                             ),
-                        ))
+                        )
+                    )
                 ->end()
             ;
         }

--- a/Admin/PageAdmin.php
+++ b/Admin/PageAdmin.php
@@ -290,6 +290,7 @@ class PageAdmin extends AbstractAdmin
                     'Sonata\PageBundle\Form\Type\PageTypeChoiceType' :
                     'sonata_page_type_choice',
             ))
+//            ->add('type', null, array('field_type' => 'Sonata\PageBundle\Form\Type\PageTypeChoiceType'))
             ->add('pageAlias')
             ->add('parent')
             ->add('edited')

--- a/Admin/PageAdmin.php
+++ b/Admin/PageAdmin.php
@@ -280,16 +280,15 @@ class PageAdmin extends AbstractAdmin
      */
     protected function configureDatagridFilters(DatagridMapper $datagridMapper)
     {
-        /*
-         * NEXT_MAJOR: remove type and uncomment the second type when dropping sf < 2.8
-         */
         $datagridMapper
             ->add('site')
             ->add('name')
+            // NEXT_MAJOR: remove these five lines and uncomment the one following.
             ->add('type', null, array('field_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
                     'Sonata\PageBundle\Form\Type\PageTypeChoiceType' :
                     'sonata_page_type_choice',
-            ))
+                )
+            )
 //            ->add('type', null, array('field_type' => 'Sonata\PageBundle\Form\Type\PageTypeChoiceType'))
             ->add('pageAlias')
             ->add('parent')
@@ -351,13 +350,11 @@ class PageAdmin extends AbstractAdmin
         ;
 
         if ($this->hasSubject() && !$this->getSubject()->isInternal()) {
-            /*
-             * NEXT_MAJOR: remove method_exists and uncomment the second type when dropping sf < 2.8
-             */
             $formMapper
                 ->with('form_page.group_main_label')
                     ->add(
                         'type',
+                        // NEXT_MAJOR: remove these three lines and uncomment the one following
                         method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
                             'Sonata\PageBundle\Form\Type\PageTypeChoiceType' :
                             'sonata_page_type_choice',
@@ -368,13 +365,11 @@ class PageAdmin extends AbstractAdmin
             ;
         }
 
-        /*
-         * NEXT_MAJOR: remove method_exists and uncomment the second type when dropping sf < 2.8
-         */
         $formMapper
             ->with('form_page.group_main_label')
                 ->add(
                     'templateCode',
+                    // NEXT_MAJOR: remove these three lines and uncomment the one following
                     method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
                         'Sonata\PageBundle\Form\Type\TemplateChoiceType' :
                         'sonata_page_template',
@@ -385,13 +380,11 @@ class PageAdmin extends AbstractAdmin
         ;
 
         if (!$this->getSubject() || ($this->getSubject() && $this->getSubject()->getParent()) || ($this->getSubject() && !$this->getSubject()->getId())) {
-            /*
-             * NEXT_MAJOR: remove method_exists and uncomment the second type when dropping sf < 2.8
-             */
             $formMapper
                 ->with('form_page.group_main_label')
                     ->add(
                         'parent',
+                        // NEXT_MAJOR: remove these three lines and uncomment the one following
                         method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
                             'Sonata\PageBundle\Form\Type\PageSelectorType' :
                             'sonata_page_selector',
@@ -415,14 +408,12 @@ class PageAdmin extends AbstractAdmin
         }
 
         if (!$this->getSubject() || !$this->getSubject()->isDynamic()) {
-            /*
-             * NEXT_MAJOR: remove method_exists and uncomment the second type when dropping sf < 2.8
-             */
             $formMapper
                 ->with('form_page.group_main_label')
                     ->add('pageAlias', null, array('required' => false))
                     ->add(
                         'parent',
+                        // NEXT_MAJOR: remove these three lines and uncomment the one following
                         method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
                             'Sonata\PageBundle\Form\Type\PageSelectorType' :
                             'sonata_page_selector',

--- a/Admin/PageAdmin.php
+++ b/Admin/PageAdmin.php
@@ -290,7 +290,10 @@ class PageAdmin extends AbstractAdmin
                     'Sonata\PageBundle\Form\Type\PageTypeChoiceType' :
                     'sonata_page_type_choice',
             ))
-//            ->add('type', null, array('field_type' => 'Sonata\PageBundle\Form\Type\PageTypeChoiceType'))
+/**
+ * NEXT_MAJOR
+ *          ->add('type', null, array('field_type' => 'Sonata\PageBundle\Form\Type\PageTypeChoiceType'))
+ */
             ->add('pageAlias')
             ->add('parent')
             ->add('edited')
@@ -358,6 +361,10 @@ class PageAdmin extends AbstractAdmin
                         method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
                             'Sonata\PageBundle\Form\Type\PageTypeChoiceType' :
                             'sonata_page_type_choice',
+/**
+ * NEXT_MAJOR
+ *                      'Sonata\PageBundle\Form\Type\PageTypeChoiceType',
+ */
                         array('required' => false))
                 ->end()
             ;
@@ -370,6 +377,10 @@ class PageAdmin extends AbstractAdmin
                     method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
                         'Sonata\PageBundle\Form\Type\TemplateChoiceType' :
                         'sonata_page_template',
+/**
+ * NEXT_MAJOR
+ *                  'Sonata\PageBundle\Form\Type\TemplateChoiceType',
+ */
                     array('required' => true))
             ->end()
         ;
@@ -382,6 +393,10 @@ class PageAdmin extends AbstractAdmin
                         method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
                             'Sonata\PageBundle\Form\Type\PageSelectorType' :
                             'sonata_page_selector',
+/**
+ * NEXT_MAJOR
+ *                      'Sonata\PageBundle\Form\Type\PageSelectorType',
+ */
                         array(
                             'page' => $this->getSubject() ?: null,
                             'site' => $this->getSubject() ? $this->getSubject()->getSite() : null,
@@ -408,6 +423,10 @@ class PageAdmin extends AbstractAdmin
                         method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
                             'Sonata\PageBundle\Form\Type\PageSelectorType' :
                             'sonata_page_selector',
+/**
+ * NEXT_MAJOR
+ *                      'Sonata\PageBundle\Form\Type\PageSelectorType',
+ */
                         array(
                             'page' => $this->getSubject() ?: null,
                             'site' => $this->getSubject() ? $this->getSubject()->getSite() : null,

--- a/Admin/PageAdmin.php
+++ b/Admin/PageAdmin.php
@@ -353,33 +353,45 @@ class PageAdmin extends AbstractAdmin
         if ($this->hasSubject() && !$this->getSubject()->isInternal()) {
             $formMapper
                 ->with('form_page.group_main_label')
-                    ->add('type', 'sonata_page_type_choice', array('required' => false))
+//                    ->add('type', 'sonata_page_type_choice', array('required' => false))
+                    ->add('type', method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
+                        'Sonata\PageBundle\Form\Type\PageTypeChoiceType' :
+                        'sonata_page_type_choice',
+                        array('required' => false))
                 ->end()
             ;
         }
 
         $formMapper
             ->with('form_page.group_main_label')
-                ->add('templateCode', 'sonata_page_template', array('required' => true))
+//                ->add('templateCode', 'sonata_page_template', array('required' => true))
+                ->add('templateCode', method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
+                    'Sonata\PageBundle\Form\Type\TemplateChoiceType' :
+                    'sonata_page_template',
+                    array('required' => true))
             ->end()
         ;
 
         if (!$this->getSubject() || ($this->getSubject() && $this->getSubject()->getParent()) || ($this->getSubject() && !$this->getSubject()->getId())) {
             $formMapper
                 ->with('form_page.group_main_label')
-                    ->add('parent', 'sonata_page_selector', array(
-                        'page' => $this->getSubject() ?: null,
-                        'site' => $this->getSubject() ? $this->getSubject()->getSite() : null,
-                        'model_manager' => $this->getModelManager(),
-                        'class' => $this->getClass(),
-                        'required' => false,
-                        'filter_choice' => array('hierarchy' => 'root'),
-                    ), array(
-                        'admin_code' => $this->getCode(),
-                        'link_parameters' => array(
-                            'siteId' => $this->getSubject() ? $this->getSubject()->getSite()->getId() : null,
-                        ),
-                    ))
+//                    ->add('parent', 'sonata_page_selector', array(
+                    ->add('parent', method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
+                        'Sonata\PageBundle\Form\Type\PageSelectorType' :
+                        'sonata_page_selector',
+                        array(
+                            'page' => $this->getSubject() ?: null,
+                            'site' => $this->getSubject() ? $this->getSubject()->getSite() : null,
+                            'model_manager' => $this->getModelManager(),
+                            'class' => $this->getClass(),
+                            'required' => false,
+                            'filter_choice' => array('hierarchy' => 'root'),
+                        ), array(
+                            'admin_code' => $this->getCode(),
+                            'link_parameters' => array(
+                                'siteId' => $this->getSubject() ? $this->getSubject()->getSite()->getId() : null,
+                            ),
+                        ))
                 ->end()
             ;
         }
@@ -388,19 +400,23 @@ class PageAdmin extends AbstractAdmin
             $formMapper
                 ->with('form_page.group_main_label')
                     ->add('pageAlias', null, array('required' => false))
-                    ->add('target', 'sonata_page_selector', array(
-                        'page' => $this->getSubject() ?: null,
-                        'site' => $this->getSubject() ? $this->getSubject()->getSite() : null,
-                        'model_manager' => $this->getModelManager(),
-                        'class' => $this->getClass(),
-                        'filter_choice' => array('request_method' => 'all'),
-                        'required' => false,
-                    ), array(
-                        'admin_code' => $this->getCode(),
-                        'link_parameters' => array(
-                            'siteId' => $this->getSubject() ? $this->getSubject()->getSite()->getId() : null,
-                        ),
-                    ))
+//                    ->add('target', 'sonata_page_selector', array(
+                    ->add('parent', method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
+                        'Sonata\PageBundle\Form\Type\PageSelectorType' :
+                        'sonata_page_selector',
+                        array(
+                            'page' => $this->getSubject() ?: null,
+                            'site' => $this->getSubject() ? $this->getSubject()->getSite() : null,
+                            'model_manager' => $this->getModelManager(),
+                            'class' => $this->getClass(),
+                            'filter_choice' => array('request_method' => 'all'),
+                            'required' => false,
+                        ), array(
+                            'admin_code' => $this->getCode(),
+                            'link_parameters' => array(
+                                'siteId' => $this->getSubject() ? $this->getSubject()->getSite()->getId() : null,
+                            ),
+                        ))
                 ->end()
             ;
         }

--- a/Admin/PageAdmin.php
+++ b/Admin/PageAdmin.php
@@ -290,7 +290,7 @@ class PageAdmin extends AbstractAdmin
                     'Sonata\PageBundle\Form\Type\PageTypeChoiceType' :
                     'sonata_page_type_choice',
             ))
-/**
+/*
  * NEXT_MAJOR
  *          ->add('type', null, array('field_type' => 'Sonata\PageBundle\Form\Type\PageTypeChoiceType'))
  */
@@ -361,7 +361,7 @@ class PageAdmin extends AbstractAdmin
                         method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
                             'Sonata\PageBundle\Form\Type\PageTypeChoiceType' :
                             'sonata_page_type_choice',
-/**
+/*
  * NEXT_MAJOR
  *                      'Sonata\PageBundle\Form\Type\PageTypeChoiceType',
  */
@@ -377,7 +377,7 @@ class PageAdmin extends AbstractAdmin
                     method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
                         'Sonata\PageBundle\Form\Type\TemplateChoiceType' :
                         'sonata_page_template',
-/**
+/*
  * NEXT_MAJOR
  *                  'Sonata\PageBundle\Form\Type\TemplateChoiceType',
  */
@@ -393,7 +393,7 @@ class PageAdmin extends AbstractAdmin
                         method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
                             'Sonata\PageBundle\Form\Type\PageSelectorType' :
                             'sonata_page_selector',
-/**
+/*
  * NEXT_MAJOR
  *                      'Sonata\PageBundle\Form\Type\PageSelectorType',
  */
@@ -423,7 +423,7 @@ class PageAdmin extends AbstractAdmin
                         method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
                             'Sonata\PageBundle\Form\Type\PageSelectorType' :
                             'sonata_page_selector',
-/**
+/*
  * NEXT_MAJOR
  *                      'Sonata\PageBundle\Form\Type\PageSelectorType',
  */

--- a/Admin/PageAdmin.php
+++ b/Admin/PageAdmin.php
@@ -290,10 +290,7 @@ class PageAdmin extends AbstractAdmin
                     'Sonata\PageBundle\Form\Type\PageTypeChoiceType' :
                     'sonata_page_type_choice',
             ))
-/*
- * NEXT_MAJOR
- *          ->add('type', null, array('field_type' => 'Sonata\PageBundle\Form\Type\PageTypeChoiceType'))
- */
+//            ->add('type', null, array('field_type' => 'Sonata\PageBundle\Form\Type\PageTypeChoiceType'))
             ->add('pageAlias')
             ->add('parent')
             ->add('edited')
@@ -354,6 +351,9 @@ class PageAdmin extends AbstractAdmin
         ;
 
         if ($this->hasSubject() && !$this->getSubject()->isInternal()) {
+            /*
+             * NEXT_MAJOR: remove method_exists and uncomment the second type when dropping sf < 2.8
+             */
             $formMapper
                 ->with('form_page.group_main_label')
                     ->add(
@@ -361,15 +361,15 @@ class PageAdmin extends AbstractAdmin
                         method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
                             'Sonata\PageBundle\Form\Type\PageTypeChoiceType' :
                             'sonata_page_type_choice',
-/*
- * NEXT_MAJOR
- *                      'Sonata\PageBundle\Form\Type\PageTypeChoiceType',
- */
+//                        'Sonata\PageBundle\Form\Type\PageTypeChoiceType',
                         array('required' => false))
                 ->end()
             ;
         }
 
+        /*
+         * NEXT_MAJOR: remove method_exists and uncomment the second type when dropping sf < 2.8
+         */
         $formMapper
             ->with('form_page.group_main_label')
                 ->add(
@@ -377,15 +377,15 @@ class PageAdmin extends AbstractAdmin
                     method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
                         'Sonata\PageBundle\Form\Type\TemplateChoiceType' :
                         'sonata_page_template',
-/*
- * NEXT_MAJOR
- *                  'Sonata\PageBundle\Form\Type\TemplateChoiceType',
- */
+//                    'Sonata\PageBundle\Form\Type\TemplateChoiceType',
                     array('required' => true))
             ->end()
         ;
 
         if (!$this->getSubject() || ($this->getSubject() && $this->getSubject()->getParent()) || ($this->getSubject() && !$this->getSubject()->getId())) {
+            /*
+             * NEXT_MAJOR: remove method_exists and uncomment the second type when dropping sf < 2.8
+             */
             $formMapper
                 ->with('form_page.group_main_label')
                     ->add(
@@ -393,10 +393,7 @@ class PageAdmin extends AbstractAdmin
                         method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
                             'Sonata\PageBundle\Form\Type\PageSelectorType' :
                             'sonata_page_selector',
-/*
- * NEXT_MAJOR
- *                      'Sonata\PageBundle\Form\Type\PageSelectorType',
- */
+//                        'Sonata\PageBundle\Form\Type\PageSelectorType',
                         array(
                             'page' => $this->getSubject() ?: null,
                             'site' => $this->getSubject() ? $this->getSubject()->getSite() : null,
@@ -415,6 +412,9 @@ class PageAdmin extends AbstractAdmin
         }
 
         if (!$this->getSubject() || !$this->getSubject()->isDynamic()) {
+            /*
+             * NEXT_MAJOR: remove method_exists and uncomment the second type when dropping sf < 2.8
+             */
             $formMapper
                 ->with('form_page.group_main_label')
                     ->add('pageAlias', null, array('required' => false))
@@ -423,10 +423,7 @@ class PageAdmin extends AbstractAdmin
                         method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
                             'Sonata\PageBundle\Form\Type\PageSelectorType' :
                             'sonata_page_selector',
-/*
- * NEXT_MAJOR
- *                      'Sonata\PageBundle\Form\Type\PageSelectorType',
- */
+//                        'Sonata\PageBundle\Form\Type\PageSelectorType',
                         array(
                             'page' => $this->getSubject() ?: null,
                             'site' => $this->getSubject() ? $this->getSubject()->getSite() : null,

--- a/Admin/PageAdmin.php
+++ b/Admin/PageAdmin.php
@@ -290,7 +290,6 @@ class PageAdmin extends AbstractAdmin
                     'Sonata\PageBundle\Form\Type\PageTypeChoiceType' :
                     'sonata_page_type_choice',
             ))
-//            ->add('type', null, array('field_type' => 'Sonata\PageBundle\Form\Type\PageTypeChoiceType'))
             ->add('pageAlias')
             ->add('parent')
             ->add('edited')
@@ -353,7 +352,6 @@ class PageAdmin extends AbstractAdmin
         if ($this->hasSubject() && !$this->getSubject()->isInternal()) {
             $formMapper
                 ->with('form_page.group_main_label')
-//                    ->add('type', 'sonata_page_type_choice', array('required' => false))
                     ->add(
                         'type',
                         method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
@@ -366,7 +364,6 @@ class PageAdmin extends AbstractAdmin
 
         $formMapper
             ->with('form_page.group_main_label')
-//                ->add('templateCode', 'sonata_page_template', array('required' => true))
                 ->add(
                     'templateCode',
                     method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
@@ -379,7 +376,6 @@ class PageAdmin extends AbstractAdmin
         if (!$this->getSubject() || ($this->getSubject() && $this->getSubject()->getParent()) || ($this->getSubject() && !$this->getSubject()->getId())) {
             $formMapper
                 ->with('form_page.group_main_label')
-//                    ->add('parent', 'sonata_page_selector', array(
                     ->add(
                         'parent',
                         method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
@@ -406,7 +402,6 @@ class PageAdmin extends AbstractAdmin
             $formMapper
                 ->with('form_page.group_main_label')
                     ->add('pageAlias', null, array('required' => false))
-//                    ->add('target', 'sonata_page_selector', array(
                     ->add(
                         'parent',
                         method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?

--- a/Admin/PageAdmin.php
+++ b/Admin/PageAdmin.php
@@ -354,7 +354,8 @@ class PageAdmin extends AbstractAdmin
             $formMapper
                 ->with('form_page.group_main_label')
 //                    ->add('type', 'sonata_page_type_choice', array('required' => false))
-                    ->add('type',
+                    ->add(
+                        'type',
                         method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
                             'Sonata\PageBundle\Form\Type\PageTypeChoiceType' :
                             'sonata_page_type_choice',
@@ -366,7 +367,8 @@ class PageAdmin extends AbstractAdmin
         $formMapper
             ->with('form_page.group_main_label')
 //                ->add('templateCode', 'sonata_page_template', array('required' => true))
-                ->add('templateCode',
+                ->add(
+                    'templateCode',
                     method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
                         'Sonata\PageBundle\Form\Type\TemplateChoiceType' :
                         'sonata_page_template',
@@ -378,7 +380,8 @@ class PageAdmin extends AbstractAdmin
             $formMapper
                 ->with('form_page.group_main_label')
 //                    ->add('parent', 'sonata_page_selector', array(
-                    ->add('parent',
+                    ->add(
+                        'parent',
                         method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
                             'Sonata\PageBundle\Form\Type\PageSelectorType' :
                             'sonata_page_selector',
@@ -404,7 +407,8 @@ class PageAdmin extends AbstractAdmin
                 ->with('form_page.group_main_label')
                     ->add('pageAlias', null, array('required' => false))
 //                    ->add('target', 'sonata_page_selector', array(
-                    ->add('parent',
+                    ->add(
+                        'parent',
                         method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
                             'Sonata\PageBundle\Form\Type\PageSelectorType' :
                             'sonata_page_selector',


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because of the bug noted in issue #830.

In case of bug fix, `3.x` **MUST** be targeted.

Closes #830

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- form typess are referenced by FQCN and not by name, which is no longer supported
```


## Subject

This pull request corrects the issues noted in issue #830 following the pattern used in issue #820. This will need testing to ensure backward compatibility.
