### PR TITLE
Changed fallback translation domain to SonataBlockBundle in page composer

### DIFF
--- a/Resources/views/BlockAdmin/select_type.html.twig
+++ b/Resources/views/BlockAdmin/select_type.html.twig
@@ -27,7 +27,7 @@ file that was distributed with this source code.
                         class="btn btn-app btn-block sonata-block-type"
                         data-toggle="tooltip"
                         data-placement="top"
-                        title="{{ service.blockMetadata.description|trans({}, service.blockMetadata.domain|default('SonataPageBundle')) }}"
+                        title="{{ service.blockMetadata.description|trans({}, service.blockMetadata.domain|default('SonataBlockBundle')) }}"
                             >
                         {% if not service.blockMetadata.image %}
                             <i class="{{ service.blockMetadata.option('class') }}" ></i>
@@ -35,7 +35,7 @@ file that was distributed with this source code.
                             <img src="{{ asset(service.blockMetadata.image) }}" style="max-height: 20px; max-width: 100px;"/>
                             <br />
                         {% endif %}
-                        <span>{{ service.blockMetadata.title|trans({}, service.blockMetadata.domain|default('SonataPageBundle')) }}</span>
+                        <span>{{ service.blockMetadata.title|trans({}, service.blockMetadata.domain|default('SonataBlockBundle')) }}</span>
                     </a>
                 </div>
             {% else %}

--- a/Resources/views/PageAdmin/compose_container_show.html.twig
+++ b/Resources/views/PageAdmin/compose_container_show.html.twig
@@ -9,7 +9,7 @@
         <label>{{ 'composer.block.add.type'|trans({}, 'SonataPageBundle') }}</label>
         <select class="page-composer__block-type-selector__select" style="width: auto">
             {% for blockServiceId, blockService in blockServices %}
-                <option value="{{ blockServiceId }}">{{ blockService.blockMetadata.title|trans({}, blockService.blockMetadata.domain|default('SonataPageBundle')) }}</option>
+                <option value="{{ blockServiceId }}">{{ blockService.blockMetadata.title|trans({}, blockService.blockMetadata.domain|default('SonataBlockBundle')) }}</option>
             {% endfor %}
         </select>
         <a class="btn btn-action btn-small page-composer__block-type-selector__confirm"


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a only a soft BC break. It only affects the fallback behavior.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #842

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Changed fallback translation domain to `SonataBlockBundle` in page composer
```

## Subject

We should use a common fallback translation domain for all page / block composers across all bundles. Atm we have a page composer in this bundle and a dashboard composer in the [SonataDashboardBundle](https://github.com/sonata-project/SonataDashboardBundle).
