### PR TITLE
Use new interface method to fix sf3 incompatibility

### DIFF
--- a/Admin/BaseBlockAdmin.php
+++ b/Admin/BaseBlockAdmin.php
@@ -239,7 +239,13 @@ abstract class BaseBlockAdmin extends AbstractAdmin
         $service = $this->blockManager->get($block);
 
         $resolver = new OptionsResolver();
-        $service->setDefaultSettings($resolver);
+        // use new interface method whenever possible
+        // NEXT_MAJOR: Remove this check and legacy setDefaultSettings method call
+        if (method_exists($service, 'configureSettings')) {
+            $service->configureSettings($resolver);
+        } else {
+            $service->setDefaultSettings($resolver);
+        }
 
         try {
             $block->setSettings($resolver->resolve($block->getSettings()));

--- a/Admin/BlockAdmin.php
+++ b/Admin/BlockAdmin.php
@@ -225,7 +225,13 @@ class BlockAdmin extends BaseBlockAdmin
     private function getDefaultTemplate(BlockServiceInterface $blockService)
     {
         $resolver = new OptionsResolver();
-        $blockService->setDefaultSettings($resolver);
+        // use new interface method whenever possible
+        // NEXT_MAJOR: Remove this check and legacy setDefaultSettings method call
+        if (method_exists($blockService, 'configureSettings')) {
+            $blockService->configureSettings($resolver);
+        } else {
+            $blockService->setDefaultSettings($resolver);
+        }
         $options = $resolver->resolve();
 
         if (isset($options['template'])) {


### PR DESCRIPTION
I am targeting this branch, because of a bug in v3.x and fix a sf3 incompatibility.

Fixes #857 

## Changelog

```markdown
### Fixed
- fix #857 use new configureSettings interface method when possible
```

## Subject

Use new interface method when possible, this will fix the symfony 3 incompatibility.