### PR TITLE
fix Twig check for block existence

### DIFF
--- a/Resources/views/base_error.html.twig
+++ b/Resources/views/base_error.html.twig
@@ -8,7 +8,7 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 
 #}
-{% set title = block('title') ? block('title') : 'Sonata Project - Internal Error' %}
+{% set title = block('title') is defined ? block('title') : 'Sonata Project - Internal Error' %}
 <!DOCTYPE html>
 <html>
     <head>


### PR DESCRIPTION
Silently using an undefined block breaks in Twig 2.x. This behaviour was deprecated in Twig 1.29.

# Changelog

```markdown
## Fixed
- compatibility with Twig 2.0 was improved
```