### PR TITLE
Twig 2 bc fixes 

### DIFF
--- a/Controller/PageAdminController.php
+++ b/Controller/PageAdminController.php
@@ -94,7 +94,15 @@ class PageAdminController extends Controller
         $datagrid = $this->admin->getDatagrid();
         $formView = $datagrid->getForm()->createView();
 
-        $this->get('twig')->getExtension('form')->renderer->setTheme($formView, $this->admin->getFilterTheme());
+        // NEXT_MAJOR: remove bc check
+        // BC for Symfony < 3.2 where this runtime does not exist
+        $twig = $this->get('twig');
+        $theme = $this->admin->getFilterTheme();
+        if (!method_exists('Symfony\Bridge\Twig\AppVariable', 'getToken')) {
+            $twig->getExtension('Symfony\Bridge\Twig\Extension\FormExtension')->renderer->setTheme($formView, $theme);
+        } else {
+            $twig->getRuntime('Symfony\Bridge\Twig\Form\TwigRenderer')->setTheme($formView, $theme);
+        }
 
         return $this->render($this->admin->getTemplate('tree'), array(
             'action' => 'tree',

--- a/Resources/views/PageAdmin/tree.html.twig
+++ b/Resources/views/PageAdmin/tree.html.twig
@@ -24,8 +24,9 @@ file that was distributed with this source code.
                     <a class="label label-default pull-right" href="{{ admin.generateObjectUrl('compose', page) }}">{{ 'pages.compose_label'|trans({}, 'SonataPageBundle') }} <i class="fa fa-magic"></i></a>
                     {% if page.edited %}<span class="label label-warning pull-right">{{ 'pages.edited_label'|trans({}, 'SonataPageBundle') }}</span>{% endif %}
                 </div>
+                {% import _self as macro %}
                 {% if page.children|length %}
-                    {{ _self.pages(page.children, admin, false) }}
+                    {{ macro.pages(page.children, admin, false) }}
                 {% endif %}
             </li>
         {% endfor %}


### PR DESCRIPTION
I am targeting the 3.x branch, because of BC fixes for twig 2.0

## Changelog

```markdown
### Fixed
- ``_self`` returns the template path instead of the template object
- Twig runtime error on Symfony < 3.2 and Twig 2.x
```

## Subject

I've came across these issues while starting a new project with sf 3.3 and twig 2.4.
Fixed Twig_Error_Runtime: The "form" extension is not enabled. Solution borrowed from sonata-project/SonataClassificationBundle#294.