### PR TITLE
Don't call Extension::addClassesToCompile() on php versions greater than 7

### DIFF
--- a/DependencyInjection/SonataPageExtension.php
+++ b/DependencyInjection/SonataPageExtension.php
@@ -83,7 +83,10 @@ class SonataPageExtension extends Extension
         $this->configureExceptions($container, $config);
         $this->configurePageDefaults($container, $config);
         $this->configurePageServices($container, $config);
-        $this->configureClassesToCompile();
+
+        if (PHP_VERSION_ID < 70000) {
+            $this->configureClassesToCompile();
+        }
 
         $container->setParameter('sonata.page.assets', $config['assets']);
         $container->setParameter('sonata.page.slugify_service', $config['slugify_service']);

--- a/Tests/DependencyInjection/SonataPageExtensionTest.php
+++ b/Tests/DependencyInjection/SonataPageExtensionTest.php
@@ -26,6 +26,10 @@ class SonataPageExtensionTest extends AbstractExtensionTestCase
      */
     public function testConfigureClassesToCompile()
     {
+        if (PHP_VERSION_ID >= 70000) {
+            $this->markTestSkipped('ClassesToCompile is deprecated in symfony 3.3 and php >= 7.0');
+        }
+
         $extension = new SonataPageExtension();
         $extension->configureClassesToCompile();
 


### PR DESCRIPTION
I am targeting this branch, because of a deprecation fix for symfony 3.3.

```markdown
### Fixed
- Don't call Extension::addClassesToCompile() on php versions greater than 7
```

## Subject

This method is deprecated in 3.3. See symfony/symfony#20735
