### PR TITLE
Update PageAdmin.php legacy code bug fix 

### DIFF
--- a/Admin/PageAdmin.php
+++ b/Admin/PageAdmin.php
@@ -336,7 +336,7 @@ class PageAdmin extends AbstractAdmin
         if ($this->hasSubject() && !$this->getSubject()->getId()) {
             $formMapper
                 ->with('form_page.group_main_label')
-                    ->add('site', null, array('required' => true, 'read_only' => true))
+                    ->add('site', null, array('required' => true, 'attr' => array('readonly' => 'readonly'))
                 ->end()
             ;
         }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because Calling this function caused a bug because it interferes 
with calls to getSchmeckles().
Fixes #989.
