### PR TITLE
Get request_stack for Symfony 3

### DIFF
--- a/Controller/SiteAdminController.php
+++ b/Controller/SiteAdminController.php
@@ -32,11 +32,12 @@ class SiteAdminController extends Controller
      */
     public function snapshotsAction()
     {
+        $request = $this->getRequest();
         if (false === $this->get('sonata.page.admin.snapshot')->isGranted('CREATE')) {
             throw new AccessDeniedException();
         }
 
-        $id = $this->get('request')->get($this->admin->getIdParameter());
+        $id = $request->get($this->admin->getIdParameter());
 
         $object = $this->admin->getObject($id);
 
@@ -46,7 +47,7 @@ class SiteAdminController extends Controller
 
         $this->admin->setSubject($object);
 
-        if ($this->get('request')->getMethod() == 'POST') {
+        if ($request->getMethod() == 'POST') {
             $this->get('sonata.notification.backend')
                 ->createAndPublish('sonata.page.create_snapshots', array(
                     'siteId' => $object->getId(),


### PR DESCRIPTION
I am targeting this branch (3.x), because of a bug fix.

## Changelog

```markdown
### Fixed
- deprecation message about the "request" service from the admin controller
```
## Subject

Use the `request_stack` when available, by using `CRUDController::getRequest()`

