### PR TITLE
Fixed wrong class name

### DIFF
--- a/Form/Type/PageTypeChoiceType.php
+++ b/Form/Type/PageTypeChoiceType.php
@@ -78,7 +78,7 @@ class PageTypeChoiceType extends AbstractType
     {
         // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
         return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Symfony\Component\Form\Extension\Core\Type'
+            ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
             : 'choice';
     }
 

--- a/Form/Type/TemplateChoiceType.php
+++ b/Form/Type/TemplateChoiceType.php
@@ -75,7 +75,7 @@ class TemplateChoiceType extends AbstractType
     {
         // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
         return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Symfony\Component\Form\Extension\Core\Type'
+            ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
             : 'choice';
     }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a patch of #869.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Subject

Fixed some wrong class names.
