### PR TITLE
Workaround for missing getRequest method on sf3

### DIFF
--- a/Controller/PageController.php
+++ b/Controller/PageController.php
@@ -18,6 +18,7 @@ use Sonata\PageBundle\Exception\PageNotFoundException;
 use Sonata\PageBundle\Listener\ExceptionListener;
 use Sonata\PageBundle\Page\PageServiceManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
@@ -67,6 +68,7 @@ class PageController extends Controller
 
         $cms->setCurrentPage($page);
 
+        // NEXT_MAJOR: remove the usage of $this->getRequest() by injecting the request action method (sf 2.4+)
         return $this->getPageServiceManager()->execute($page, $this->getRequest());
     }
 
@@ -100,5 +102,17 @@ class PageController extends Controller
     protected function getCmsManagerSelector()
     {
         return $this->get('sonata.page.cms_manager_selector');
+    }
+
+    /**
+     * @return Request
+     */
+    private function getRequest()
+    {
+        if ($this->container->has('request_stack')) {
+            return $this->container->get('request_stack')->getCurrentRequest();
+        }
+
+        return $this->container->get('request');
     }
 }


### PR DESCRIPTION
I am targeting this branch, because bugfix for an incompatibility with sf3.

## Changelog

```markdown
### Fixed
- The `getRequest` method is incompatible with sf3 in the page controller
```

## Subject

An incompatibility discovered when upgrading to sf3 and checking the error pages. The `getRequest` method on the controller class is deprecated since sf2.4 and removed in sf3. In the next major this workaround should be replaced with just injecting the service in the action method (possible if we don't support sf2.3 anymore). 
