### PR TITLE
Use FQCN when creating a form on sf3

### DIFF
--- a/Controller/SnapshotAdminController.php
+++ b/Controller/SnapshotAdminController.php
@@ -12,6 +12,7 @@
 namespace Sonata\PageBundle\Controller;
 
 use Sonata\AdminBundle\Controller\CRUDController as Controller;
+use Sonata\PageBundle\Form\Type\CreateSnapshotType;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
@@ -46,7 +47,7 @@ class SnapshotAdminController extends Controller
 
         $snapshot->setPage($page);
 
-        $form = $this->createForm('sonata_page_create_snapshot', $snapshot);
+        $form = $this->createForm(CreateSnapshotType::class, $snapshot);
 
         if ($request->getMethod() == 'POST') {
             $form->submit($request);


### PR DESCRIPTION
I am targeting this branch, because of a sf3 incompatibility

## Changelog

```markdown
### Fixed
- Use FQCN when creating a form on sf3
```

## Subject

Use FQCN when creating a form on sf3 as creating a form by name is deprecated in symfony 2.x. An incompatibility discovered when upgrading to sf3 and I want to create a new snapshot
