### PR TITLE
use new sf3 choices structure

### DIFF
--- a/Form/Type/PageTypeChoiceType.php
+++ b/Form/Type/PageTypeChoiceType.php
@@ -41,10 +41,17 @@ class PageTypeChoiceType extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults([
+        $defaults = [
             'choices' => $this->getPageTypes(),
             'choice_translation_domain' => false,
-        ]);
+        ];
+
+        // NEXT_MAJOR: Remove (when requirement of Symfony is >= 3.0)
+        if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+            $defaults['choices_as_values'] = true;
+        }
+
+        $resolver->setDefaults($defaults);
     }
 
     /**
@@ -63,10 +70,10 @@ class PageTypeChoiceType extends AbstractType
         $services = $this->manager->getAll();
         $types = [];
         foreach ($services as $id => $service) {
-            $types[$id] = $service->getName();
+            $types[$service->getName()] = $id;
         }
 
-        asort($types);
+        ksort($types);
 
         return $types;
     }

--- a/Form/Type/TemplateChoiceType.php
+++ b/Form/Type/TemplateChoiceType.php
@@ -41,10 +41,17 @@ class TemplateChoiceType extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults([
+        $defaults = [
             'choices' => $this->getTemplates(),
             'choice_translation_domain' => false,
-        ]);
+        ];
+
+        // NEXT_MAJOR: Remove (when requirement of Symfony is >= 3.0)
+        if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+            $defaults['choices_as_values'] = true;
+        }
+
+        $resolver->setDefaults($defaults);
     }
 
     /**
@@ -62,7 +69,7 @@ class TemplateChoiceType extends AbstractType
     {
         $templates = [];
         foreach ($this->manager->getAll() as $code => $template) {
-            $templates[$code] = $template->getName();
+            $templates[$template->getName()] = $code;
         }
 
         return $templates;

--- a/Tests/Form/Type/TemplateChoiceTypeTest.php
+++ b/Tests/Form/Type/TemplateChoiceTypeTest.php
@@ -56,7 +56,7 @@ class TemplateChoiceTypeTest extends PHPUnit_Framework_TestCase
 
         // THEN
         $this->type->getTemplates();
-        $this->assertEquals(['my_template' => 'Template 1'], $this->type->getTemplates(),
+        $this->assertEquals(['Template 1' => 'my_template'], $this->type->getTemplates(),
             'Should return an array of templates provided by the template manager');
     }
 


### PR DESCRIPTION
I am targeting this branch, because symfony 3 incompatibility.

In case of bug fix, `3.x` **MUST** be targeted.

## Changelog

```markdown
### Fixed
- use new sf3 choices structure
```

## Subject
Changed the choices structure to follow new sf3 standards. Added choices_as_values for BC.
