### PR TITLE
Drop old versions of php/sf

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^5.3 || ^7.0",
+        "php": "^7.1",
         "cocur/slugify": "^1.0 || ^2.0",
         "sonata-project/admin-bundle": "^3.4",
         "sonata-project/block-bundle": "^3.3.1",
@@ -30,19 +30,19 @@
         "sonata-project/notification-bundle": "^3.0",
         "sonata-project/seo-bundle": "^2.0",
         "symfony-cmf/routing-bundle": "^1.1 || ^2.0",
-        "symfony/config": "^2.3.9 || ^3.0",
-        "symfony/console": "^2.3 || ^3.0",
-        "symfony/debug": "^2.3 || ^3.0",
-        "symfony/dependency-injection": "^2.3.3 || ^3.0",
-        "symfony/form": "^2.3.5 || ^3.0",
-        "symfony/http-foundation": "^2.3 || ^3.0",
-        "symfony/http-kernel": "^2.3 || ^3.0",
-        "symfony/options-resolver": "^2.3 || ^3.0",
-        "symfony/process": "^2.3.5 || ^3.0",
-        "symfony/routing": "^2.3 || ^3.0",
-        "symfony/security": "^2.3 || ^3.0",
-        "symfony/templating": "^2.3 || ^3.0",
-        "symfony/validator": "^2.3 || ^3.0"
+        "symfony/config": "^2.8 || ^3.0",
+        "symfony/console": "^2.8 || ^3.0",
+        "symfony/debug": "^2.8 || ^3.0",
+        "symfony/dependency-injection": "^2.8 || ^3.0",
+        "symfony/form": "^2.8 || ^3.0",
+        "symfony/http-foundation": "^2.8 || ^3.0",
+        "symfony/http-kernel": "^2.8 || ^3.0",
+        "symfony/options-resolver": "^2.8 || ^3.0",
+        "symfony/process": "^2.8 || ^3.0",
+        "symfony/routing": "^2.8 || ^3.0",
+        "symfony/security": "^2.8 || ^3.0",
+        "symfony/templating": "^2.8 || ^3.0",
+        "symfony/validator": "^2.8 || ^3.0"
     },
     "require-dev": {
         "friendsofsymfony/rest-bundle": "^1.1",
@@ -51,7 +51,7 @@
         "nelmio/api-doc-bundle": "^2.4",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
         "sonata-project/doctrine-orm-admin-bundle": "^3.0",
-        "symfony/phpunit-bridge": "^2.7 || ^3.0"
+        "symfony/phpunit-bridge": "^3.3"
     },
     "conflict": {
         "jms/serializer": "<0.13",


### PR DESCRIPTION
I am targeting this branch, because this is BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- support for old versions of php and Symfony
```
