### PR TITLE
Remove pre-sf2.8 form type checks

### DIFF
--- a/Admin/BlockAdmin.php
+++ b/Admin/BlockAdmin.php
@@ -15,7 +15,11 @@ use Doctrine\ORM\EntityRepository;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Route\RouteCollection;
 use Sonata\BlockBundle\Block\BlockServiceInterface;
+use Sonata\BlockBundle\Form\Type\ServiceListType;
 use Sonata\PageBundle\Model\PageInterface;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -131,12 +135,7 @@ class BlockAdmin extends BaseBlockAdmin
         if (!$isComposer) {
             $formMapper->add('name');
         } else {
-            $formMapper->add('name',
-                // NEXT_MAJOR: remove these three lines and uncomment the one following
-                method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-                    'Symfony\Component\Form\Extension\Core\Type\HiddenType' :
-                    'hidden'
-            );
+            $formMapper->add('name', HiddenType::class);
         }
 
         $formMapper->end();
@@ -153,43 +152,29 @@ class BlockAdmin extends BaseBlockAdmin
 
             // need to investigate on this case where $page == null ... this should not be possible
             if ($isStandardBlock && $page && !empty($containerBlockTypes)) {
-                $formMapper->add('parent',
-                    // NEXT_MAJOR: remove these three lines and uncomment the one following
-                    method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-                        'Symfony\Bridge\Doctrine\Form\Type\EntityType' :
-                        'entity',
-                    [
-                        'class' => $this->getClass(),
-                        'query_builder' => function (EntityRepository $repository) use ($page, $containerBlockTypes) {
-                            return $repository->createQueryBuilder('a')
-                                ->andWhere('a.page = :page AND a.type IN (:types)')
-                                ->setParameters([
-                                        'page' => $page,
-                                        'types' => $containerBlockTypes,
-                                    ]);
-                        },
-                    ], [
-                        'admin_code' => $this->getCode(),
-                    ]);
+                $formMapper->add('parent', EntityType::class, [
+                    'class' => $this->getClass(),
+                    'query_builder' => function (EntityRepository $repository) use ($page, $containerBlockTypes) {
+                        return $repository->createQueryBuilder('a')
+                            ->andWhere('a.page = :page AND a.type IN (:types)')
+                            ->setParameters([
+                                    'page' => $page,
+                                    'types' => $containerBlockTypes,
+                                ]);
+                    },
+                ], [
+                    'admin_code' => $this->getCode(),
+                ]);
             }
 
             if ($isComposer) {
-                $formMapper->add('enabled',
-                    // NEXT_MAJOR: remove these three lines and uncomment the one following
-                    method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-                        'Symfony\Component\Form\Extension\Core\Type\HiddenType' :
-                        'hidden',
-                    ['data' => true]);
+                $formMapper->add('enabled', HiddenType::class, ['data' => true]);
             } else {
                 $formMapper->add('enabled');
             }
 
             if ($isStandardBlock) {
-                $formMapper->add('position',
-                    // NEXT_MAJOR: remove these three lines and uncomment the one following
-                    method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-                    'Symfony\Component\Form\Extension\Core\Type\IntegerType' :
-                    'integer');
+                $formMapper->add('position', IntegerType::class);
             }
 
             $formMapper->end();
@@ -226,21 +211,9 @@ class BlockAdmin extends BaseBlockAdmin
         } else {
             $formMapper
                 ->with('form.field_group_options', $optionsGroupOptions)
-                ->add('type',
-                    // NEXT_MAJOR: remove these three lines and uncomment the one following
-                    method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-                        'Sonata\BlockBundle\Form\Type\ServiceListType' :
-                        'sonata_block_service_choice',
-                    [
-                        'context' => 'sonata_page_bundle',
-                    ])
+                ->add('type', ServiceListType::class, ['context' => 'sonata_page_bundle'])
                 ->add('enabled')
-                ->add('position',
-                    // NEXT_MAJOR: remove these three lines and uncomment the one following
-                    method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-                        'Symfony\Component\Form\Extension\Core\Type\IntegerType' :
-                        'integer'
-                )
+                ->add('position', IntegerType::class)
                 ->end()
             ;
         }

--- a/Admin/PageAdmin.php
+++ b/Admin/PageAdmin.php
@@ -22,10 +22,15 @@ use Sonata\AdminBundle\Show\ShowMapper;
 use Sonata\Cache\CacheManagerInterface;
 use Sonata\PageBundle\Exception\InternalErrorException;
 use Sonata\PageBundle\Exception\PageNotFoundException;
+use Sonata\PageBundle\Form\Type\PageSelectorType;
+use Sonata\PageBundle\Form\Type\PageTypeChoiceType;
+use Sonata\PageBundle\Form\Type\TemplateChoiceType;
 use Sonata\PageBundle\Model\PageInterface;
 use Sonata\PageBundle\Model\PageManagerInterface;
 use Sonata\PageBundle\Model\SiteInterface;
 use Sonata\PageBundle\Model\SiteManagerInterface;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 /**
  * Admin definition for the Page class.
@@ -283,13 +288,7 @@ class PageAdmin extends AbstractAdmin
         $datagridMapper
             ->add('site')
             ->add('name')
-            // NEXT_MAJOR: remove these five lines and uncomment the one following.
-            ->add('type', null, ['field_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-                    'Sonata\PageBundle\Form\Type\PageTypeChoiceType' :
-                    'sonata_page_type_choice',
-                ]
-            )
-//            ->add('type', null, array('field_type' => 'Sonata\PageBundle\Form\Type\PageTypeChoiceType'))
+            ->add('type', null, ['field_type' => PageTypeChoiceType::class])
             ->add('pageAlias')
             ->add('parent')
             ->add('edited')
@@ -328,12 +327,7 @@ class PageAdmin extends AbstractAdmin
         if (!$this->getSubject() || (!$this->getSubject()->isInternal() && !$this->getSubject()->isError())) {
             $formMapper
                 ->with('form_page.group_main_label')
-                    ->add('url',
-                        // NEXT_MAJOR: remove these three lines and uncomment the one following
-                        method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-                            'Symfony\Component\Form\Extension\Core\Type\TextType' :
-                            'text',
-                        ['attr' => ['readonly' => 'readonly']])
+                    ->add('url', TextType::class, ['attr' => ['readonly' => 'readonly']])
                 ->end()
             ;
         }
@@ -357,57 +351,33 @@ class PageAdmin extends AbstractAdmin
         if ($this->hasSubject() && !$this->getSubject()->isInternal()) {
             $formMapper
                 ->with('form_page.group_main_label')
-                    ->add(
-                        'type',
-                        // NEXT_MAJOR: remove these three lines and uncomment the one following
-                        method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-                            'Sonata\PageBundle\Form\Type\PageTypeChoiceType' :
-                            'sonata_page_type_choice',
-//                        'Sonata\PageBundle\Form\Type\PageTypeChoiceType',
-                        ['required' => false]
-                    )
+                    ->add('type', PageTypeChoiceType::class, ['required' => false])
                 ->end()
             ;
         }
 
         $formMapper
             ->with('form_page.group_main_label')
-                ->add(
-                    'templateCode',
-                    // NEXT_MAJOR: remove these three lines and uncomment the one following
-                    method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-                        'Sonata\PageBundle\Form\Type\TemplateChoiceType' :
-                        'sonata_page_template',
-//                    'Sonata\PageBundle\Form\Type\TemplateChoiceType',
-                    ['required' => true]
-                )
+                ->add('templateCode', TemplateChoiceType::class, ['required' => true])
             ->end()
         ;
 
         if (!$this->getSubject() || ($this->getSubject() && $this->getSubject()->getParent()) || ($this->getSubject() && !$this->getSubject()->getId())) {
             $formMapper
                 ->with('form_page.group_main_label')
-                    ->add(
-                        'parent',
-                        // NEXT_MAJOR: remove these three lines and uncomment the one following
-                        method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-                            'Sonata\PageBundle\Form\Type\PageSelectorType' :
-                            'sonata_page_selector',
-//                        'Sonata\PageBundle\Form\Type\PageSelectorType',
-                        [
-                            'page' => $this->getSubject() ?: null,
-                            'site' => $this->getSubject() ? $this->getSubject()->getSite() : null,
-                            'model_manager' => $this->getModelManager(),
-                            'class' => $this->getClass(),
-                            'required' => false,
-                            'filter_choice' => ['hierarchy' => 'root'],
-                        ], [
-                            'admin_code' => $this->getCode(),
-                            'link_parameters' => [
-                                'siteId' => $this->getSubject() ? $this->getSubject()->getSite()->getId() : null,
-                            ],
-                        ]
-                    )
+                    ->add('parent', PageSelectorType::class, [
+                        'page' => $this->getSubject() ?: null,
+                        'site' => $this->getSubject() ? $this->getSubject()->getSite() : null,
+                        'model_manager' => $this->getModelManager(),
+                        'class' => $this->getClass(),
+                        'required' => false,
+                        'filter_choice' => ['hierarchy' => 'root'],
+                    ], [
+                        'admin_code' => $this->getCode(),
+                        'link_parameters' => [
+                            'siteId' => $this->getSubject() ? $this->getSubject()->getSite()->getId() : null,
+                        ],
+                    ])
                 ->end()
             ;
         }
@@ -416,27 +386,19 @@ class PageAdmin extends AbstractAdmin
             $formMapper
                 ->with('form_page.group_main_label')
                     ->add('pageAlias', null, ['required' => false])
-                    ->add(
-                        'parent',
-                        // NEXT_MAJOR: remove these three lines and uncomment the one following
-                        method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-                            'Sonata\PageBundle\Form\Type\PageSelectorType' :
-                            'sonata_page_selector',
-//                        'Sonata\PageBundle\Form\Type\PageSelectorType',
-                        [
-                            'page' => $this->getSubject() ?: null,
-                            'site' => $this->getSubject() ? $this->getSubject()->getSite() : null,
-                            'model_manager' => $this->getModelManager(),
-                            'class' => $this->getClass(),
-                            'filter_choice' => ['request_method' => 'all'],
-                            'required' => false,
-                        ], [
-                            'admin_code' => $this->getCode(),
-                            'link_parameters' => [
-                                'siteId' => $this->getSubject() ? $this->getSubject()->getSite()->getId() : null,
-                            ],
-                        ]
-                    )
+                    ->add('parent', PageSelectorType::class, [
+                        'page' => $this->getSubject() ?: null,
+                        'site' => $this->getSubject() ? $this->getSubject()->getSite() : null,
+                        'model_manager' => $this->getModelManager(),
+                        'class' => $this->getClass(),
+                        'filter_choice' => ['request_method' => 'all'],
+                        'required' => false,
+                    ], [
+                        'admin_code' => $this->getCode(),
+                        'link_parameters' => [
+                            'siteId' => $this->getSubject() ? $this->getSubject()->getSite()->getId() : null,
+                        ],
+                    ])
                 ->end()
             ;
         }
@@ -444,18 +406,8 @@ class PageAdmin extends AbstractAdmin
         if (!$this->getSubject() || !$this->getSubject()->isHybrid()) {
             $formMapper
                 ->with('form_page.group_seo_label')
-                    ->add('slug',
-                        // NEXT_MAJOR: remove these three lines and uncomment the one following
-                        method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-                            'Symfony\Component\Form\Extension\Core\Type\TextType' :
-                            'text',
-                        ['required' => false])
-                    ->add('customUrl',
-                        // NEXT_MAJOR: remove these three lines and uncomment the one following
-                        method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-                            'Symfony\Component\Form\Extension\Core\Type\TextType' :
-                            'text',
-                        ['required' => false])
+                    ->add('slug', TextType::class, ['required' => false])
+                    ->add('customUrl', TextType::class, ['required' => false])
                 ->end()
             ;
         }
@@ -463,18 +415,8 @@ class PageAdmin extends AbstractAdmin
         $formMapper
             ->with('form_page.group_seo_label', ['collapsed' => true])
                 ->add('title', null, ['required' => false])
-                ->add('metaKeyword',
-                    // NEXT_MAJOR: remove these three lines and uncomment the one following
-                    method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-                        'Symfony\Component\Form\Extension\Core\Type\TextareaType' :
-                        'textarea',
-                    ['required' => false])
-                ->add('metaDescription',
-                    // NEXT_MAJOR: remove these three lines and uncomment the one following
-                    method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-                        'Symfony\Component\Form\Extension\Core\Type\TextareaType' :
-                        'textarea',
-                    ['required' => false])
+                ->add('metaKeyword', TextareaType::class, ['required' => false])
+                ->add('metaDescription', TextareaType::class, ['required' => false])
             ->end()
         ;
 

--- a/Admin/SiteAdmin.php
+++ b/Admin/SiteAdmin.php
@@ -17,7 +17,10 @@ use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Route\RouteCollection;
 use Sonata\AdminBundle\Show\ShowMapper;
+use Sonata\CoreBundle\Form\Type\DateTimePickerType;
 use Sonata\PageBundle\Route\RoutePageGenerator;
+use Symfony\Component\Form\Extension\Core\Type\LocaleType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 
 /**
  * Admin definition for the Site class.
@@ -111,42 +114,16 @@ class SiteAdmin extends AbstractAdmin
                 ->add('isDefault', null, ['required' => false])
                 ->add('enabled', null, ['required' => false])
                 ->add('host')
-                ->add('locale',
-                    // NEXT_MAJOR: remove these three lines and uncomment the one following
-                    method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-                        'Symfony\Component\Form\Extension\Core\Type\LocaleType' :
-                        'locale',
-                    ['required' => false]
-                )
+                ->add('locale', LocaleType::class, ['required' => false])
                 ->add('relativePath', null, ['required' => false])
-                ->add('enabledFrom',
-                    // NEXT_MAJOR: remove these three lines and uncomment the one following
-                    method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-                        'Sonata\CoreBundle\Form\Type\DateTimePickerType' :
-                        'sonata_type_datetime_picker',
-                    ['dp_side_by_side' => true])
-                ->add('enabledTo',
-                    // NEXT_MAJOR: remove these three lines and uncomment the one following
-                    method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-                        'Sonata\CoreBundle\Form\Type\DateTimePickerType' :
-                        'sonata_type_datetime_picker',
-                    ['required' => false, 'dp_side_by_side' => true]
+                ->add('enabledFrom', DateTimePickerType::class, ['dp_side_by_side' => true])
+                ->add('enabledTo', DateTimePickerType::class, ['required' => false, 'dp_side_by_side' => true]
                 )
             ->end()
             ->with('form_site.label_seo', ['class' => 'col-md-6'])
                 ->add('title', null, ['required' => false])
-                ->add('metaDescription',
-                    // NEXT_MAJOR: remove these three lines and uncomment the one following
-                    method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-                        'Symfony\Component\Form\Extension\Core\Type\TextareaType' :
-                        'textarea',
-                    ['required' => false])
-                ->add('metaKeywords',
-                    // NEXT_MAJOR: remove these three lines and uncomment the one following
-                    method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-                        'Symfony\Component\Form\Extension\Core\Type\TextareaType' :
-                        'textarea',
-                    ['required' => false])
+                ->add('metaDescription', TextareaType::class, ['required' => false])
+                ->add('metaKeywords', TextareaType::class, ['required' => false])
             ->end()
         ;
     }

--- a/Admin/SnapshotAdmin.php
+++ b/Admin/SnapshotAdmin.php
@@ -16,6 +16,7 @@ use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\Cache\CacheManagerInterface;
+use Sonata\CoreBundle\Form\Type\DateTimePickerType;
 
 /**
  * Admin definition for the Snapshot class.
@@ -70,18 +71,8 @@ class SnapshotAdmin extends AbstractAdmin
     {
         $formMapper
             ->add('enabled', null, ['required' => false])
-            ->add('publicationDateStart',
-                // NEXT_MAJOR: remove these three lines and uncomment the one following
-                method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-                    'Sonata\CoreBundle\Form\Type\DateTimePickerType' :
-                    'sonata_type_datetime_picker',
-                ['dp_side_by_side' => true])
-            ->add('publicationDateEnd',
-                // NEXT_MAJOR: remove these three lines and uncomment the one following
-                method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-                    'Sonata\CoreBundle\Form\Type\DateTimePickerType' :
-                    'sonata_type_datetime_picker',
-                ['required' => false, 'dp_side_by_side' => true])
+            ->add('publicationDateStart', DateTimePickerType::class, ['dp_side_by_side' => true])
+            ->add('publicationDateEnd', DateTimePickerType::class, ['required' => false, 'dp_side_by_side' => true])
         ;
     }
 

--- a/Form/Type/PageSelectorType.php
+++ b/Form/Type/PageSelectorType.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\PageBundle\Form\Type;
 
+use Sonata\AdminBundle\Form\Type\ModelType;
 use Sonata\PageBundle\Model\PageInterface;
 use Sonata\PageBundle\Model\PageManagerInterface;
 use Sonata\PageBundle\Model\SiteInterface;
@@ -136,10 +137,7 @@ class PageSelectorType extends AbstractType
      */
     public function getParent()
     {
-        // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
-        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Sonata\AdminBundle\Form\Type\ModelType'
-            : 'sonata_type_model';
+        return ModelType::class;
     }
 
     /**

--- a/Form/Type/PageTypeChoiceType.php
+++ b/Form/Type/PageTypeChoiceType.php
@@ -13,6 +13,7 @@ namespace Sonata\PageBundle\Form\Type;
 
 use Sonata\PageBundle\Page\PageServiceManagerInterface;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
@@ -76,10 +77,7 @@ class PageTypeChoiceType extends AbstractType
      */
     public function getParent()
     {
-        // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
-        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
-            : 'choice';
+        return ChoiceType::class;
     }
 
     /**

--- a/Form/Type/TemplateChoiceType.php
+++ b/Form/Type/TemplateChoiceType.php
@@ -13,6 +13,7 @@ namespace Sonata\PageBundle\Form\Type;
 
 use Sonata\PageBundle\Page\TemplateManagerInterface;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
@@ -73,10 +74,7 @@ class TemplateChoiceType extends AbstractType
      */
     public function getParent()
     {
-        // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
-        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
-            : 'choice';
+        return ChoiceType::class;
     }
 
     /**


### PR DESCRIPTION
I am targeting this branch, because symfony minimum required was recently increased.

## Changelog

```markdown

### Removed
- Removed pre symfony 2.8 checks, used new PHP syntax
```

## Subject

Since minimum sf version was increased to 2.8, I removed all useless checks and used new PHP syntax for classnames.
