### PR TITLE
Pass form data instead of request object to form::submit

### DIFF
--- a/Controller/SnapshotAdminController.php
+++ b/Controller/SnapshotAdminController.php
@@ -50,7 +50,7 @@ class SnapshotAdminController extends Controller
         $form = $this->createForm(CreateSnapshotType::class, $snapshot);
 
         if ($request->getMethod() == 'POST') {
-            $form->submit($request);
+            $form->submit($request->request->get($form->getName()));
 
             if ($form->isValid()) {
                 $snapshotManager = $this->get('sonata.page.manager.snapshot');


### PR DESCRIPTION
I am targeting this branch, because a sf3 compatibility fix.

## Changelog

```markdown
### Fixed
- Pass form data instead of request object to form::submit

```

## Subject

Passing the request object to `Form::submit()` is deprecated since 2.3 and removed in 3.0 (https://github.com/symfony/symfony/blob/2.8/src/Symfony/Component/Form/Form.php#L512). So this PR will remove a deprecation warning in < sf3.0 and fixes a bug as sf3.x can't handle a request object as the form data
