### PR TITLE
Make it possible to use Page SEO title again

### DIFF
--- a/Page/Service/DefaultPageService.php
+++ b/Page/Service/DefaultPageService.php
@@ -71,7 +71,7 @@ class DefaultPageService extends BasePageService
             return;
         }
 
-        if (!$this->seoPage->getTitle()) {
+        if ($page->getTitle() || $page->getName()) {
             $this->seoPage->setTitle($page->getTitle() ?: $page->getName());
         }
 

--- a/Tests/Page/Service/DefaultPageServiceTest.php
+++ b/Tests/Page/Service/DefaultPageServiceTest.php
@@ -61,8 +61,7 @@ class DefaultPageServiceTest extends PHPUnit_Framework_TestCase
 
         // mock a page instance
         $page = $this->createMock('Sonata\PageBundle\Model\PageInterface');
-        $this->seoPage->expects($this->once())->method('getTitle')->will($this->returnValue(null));
-        $page->expects($this->once())->method('getTitle')->will($this->returnValue('page title'));
+        $page->expects($this->exactly(2))->method('getTitle')->will($this->returnValue('page title'));
         $page->expects($this->atLeastOnce())->method('getMetaDescription')->will($this->returnValue('page meta description'));
         $page->expects($this->atLeastOnce())->method('getMetaKeyword')->will($this->returnValue('page meta keywords'));
         $page->expects($this->once())->method('getTemplateCode')->will($this->returnValue('template code'));


### PR DESCRIPTION
I am targeting this branch, because seo title was not working.

Related to #767 
Closes #800

## Changelog

```markdown
### Fixed
- Not working SEO page title
```

## Subject

All pages were showing only the default title. SEO title was not used. Now we override it when a title or name is set.
