### PR TITLE
Removed php5 version checks

### DIFF
--- a/DependencyInjection/SonataPageExtension.php
+++ b/DependencyInjection/SonataPageExtension.php
@@ -84,10 +84,6 @@ class SonataPageExtension extends Extension
         $this->configurePageDefaults($container, $config);
         $this->configurePageServices($container, $config);
 
-        if (PHP_VERSION_ID < 70000) {
-            $this->configureClassesToCompile();
-        }
-
         $container->setParameter('sonata.page.assets', $config['assets']);
         $container->setParameter('sonata.page.slugify_service', $config['slugify_service']);
 
@@ -498,74 +494,5 @@ class SonataPageExtension extends Extension
         // set the default page service to use when no page type has been set. (backward compatibility)
         $definition = $container->getDefinition('sonata.page.page_service_manager');
         $definition->addMethodCall('setDefault', [new Reference($config['default_page_service'])]);
-    }
-
-    /**
-     * Add class to compile.
-     */
-    public function configureClassesToCompile()
-    {
-        $this->addClassesToCompile([
-            'Sonata\\PageBundle\\Block\\ChildrenPagesBlockService',
-            'Sonata\\PageBundle\\Block\\ContainerBlockService',
-            'Sonata\\PageBundle\\Cache\\BlockEsiCache',
-            'Sonata\\PageBundle\\Cache\\BlockJsCache',
-            'Sonata\\PageBundle\\Cache\\BlockSsiCache',
-            'Sonata\\PageBundle\\CmsManager\\BaseCmsPageManager',
-            'Sonata\\PageBundle\\CmsManager\\CmsManagerInterface',
-            'Sonata\\PageBundle\\CmsManager\\CmsManagerSelector',
-            'Sonata\\PageBundle\\CmsManager\\CmsManagerSelectorInterface',
-            'Sonata\\PageBundle\\CmsManager\\CmsPageManager',
-            'Sonata\\PageBundle\\CmsManager\\CmsSnapshotManager',
-            'Sonata\\PageBundle\\CmsManager\\DecoratorStrategy',
-            'Sonata\\PageBundle\\CmsManager\\DecoratorStrategyInterface',
-            'Sonata\\PageBundle\\Entity\\BaseBlock',
-            'Sonata\\PageBundle\\Entity\\BasePage',
-            'Sonata\\PageBundle\\Entity\\BaseSite',
-            'Sonata\\PageBundle\\Entity\\BaseSnapshot',
-            'Sonata\\PageBundle\\Entity\\BlockInteractor',
-            'Sonata\\PageBundle\\Entity\\BlockManager',
-            'Sonata\\PageBundle\\Entity\\PageManager',
-            'Sonata\\PageBundle\\Entity\\SiteManager',
-            'Sonata\\PageBundle\\Entity\\SnapshotManager',
-            'Sonata\\PageBundle\\Entity\\Transformer',
-            'Sonata\\PageBundle\\Generator\\Mustache',
-            'Sonata\\PageBundle\\Listener\\ExceptionListener',
-            'Sonata\\PageBundle\\Listener\\RequestListener',
-            'Sonata\\PageBundle\\Listener\\ResponseListener',
-            'Sonata\\PageBundle\\Model\\Block',
-            'Sonata\\PageBundle\\Model\\BlockInteractorInterface',
-            'Sonata\\PageBundle\\Model\\Page',
-            'Sonata\\PageBundle\\Model\\PageBlockInterface',
-            'Sonata\\PageBundle\\Model\\PageInterface',
-            'Sonata\\PageBundle\\Model\\PageManagerInterface',
-            'Sonata\\PageBundle\\Model\\Site',
-            'Sonata\\PageBundle\\Model\\SiteInterface',
-            'Sonata\\PageBundle\\Model\\SiteManagerInterface',
-            'Sonata\\PageBundle\\Model\\Snapshot',
-            'Sonata\\PageBundle\\Model\\SnapshotChildrenCollection',
-            'Sonata\\PageBundle\\Model\\SnapshotInterface',
-            'Sonata\\PageBundle\\Model\\SnapshotManagerInterface',
-            'Sonata\\PageBundle\\Model\\SnapshotPageProxy',
-            'Sonata\\PageBundle\\Model\\SnapshotPageProxyFactory',
-            'Sonata\\PageBundle\\Model\\SnapshotPageProxyFactoryInterface',
-            'Sonata\\PageBundle\\Model\\SnapshotPageProxyInterface',
-            'Sonata\\PageBundle\\Model\\Template',
-            'Sonata\\PageBundle\\Page\\PageServiceManager',
-            'Sonata\\PageBundle\\Page\\PageServiceManagerInterface',
-            'Sonata\\PageBundle\\Page\\Service\\BasePageService',
-            'Sonata\\PageBundle\\Page\\Service\\DefaultPageService',
-            'Sonata\\PageBundle\\Page\\Service\\PageServiceInterface',
-            'Sonata\\PageBundle\\Page\\TemplateManager',
-            'Sonata\\PageBundle\\Page\\TemplateManagerInterface',
-            'Sonata\\PageBundle\\Request\\SiteRequestContext',
-            'Sonata\\PageBundle\\Route\\CmsPageRouter',
-            'Sonata\\PageBundle\\Site\\BaseSiteSelector',
-            'Sonata\\PageBundle\\Site\\HostPathSiteSelector',
-            'Sonata\\PageBundle\\Site\\HostSiteSelector',
-            'Sonata\\PageBundle\\Site\\SiteSelectorInterface',
-            'Sonata\\PageBundle\\Twig\\Extension\\PageExtension',
-            'Sonata\\PageBundle\\Twig\\GlobalVariables',
-        ]);
     }
 }

--- a/Tests/DependencyInjection/SonataPageExtensionTest.php
+++ b/Tests/DependencyInjection/SonataPageExtensionTest.php
@@ -21,28 +21,6 @@ use Sonata\PageBundle\DependencyInjection\SonataPageExtension;
  */
 class SonataPageExtensionTest extends AbstractExtensionTestCase
 {
-    /**
-     * Tests the configureClassesToCompile method.
-     */
-    public function testConfigureClassesToCompile()
-    {
-        if (PHP_VERSION_ID >= 70000) {
-            $this->markTestSkipped('ClassesToCompile is deprecated in symfony 3.3 and php >= 7.0');
-        }
-
-        $extension = new SonataPageExtension();
-        $extension->configureClassesToCompile();
-
-        $this->assertNotContains(
-            'Sonata\\PageBundle\\Request\\SiteRequest',
-            $extension->getClassesToCompile()
-        );
-        $this->assertNotContains(
-            'Sonata\\PageBundle\\Request\\SiteRequestInterface',
-            $extension->getClassesToCompile()
-        );
-    }
-
     public function testRequestContextServiceIsDefined()
     {
         $this->container->setParameter('kernel.bundles', []);

--- a/Tests/Twig/Extension/PageExtensionTest.php
+++ b/Tests/Twig/Extension/PageExtensionTest.php
@@ -40,7 +40,6 @@ class PageExtensionTest extends PHPUnit_Framework_TestCase
 
     public function testController()
     {
-        $this->skipInPHP55();
         $cmsManager = $this->createMock('Sonata\PageBundle\CmsManager\CmsManagerSelectorInterface');
         $site = $this->createMock('Sonata\PageBundle\Model\SiteInterface');
         $site->method('getRelativePath')->willReturn('/foo/bar');
@@ -75,7 +74,6 @@ class PageExtensionTest extends PHPUnit_Framework_TestCase
 
     public function testControllerWithoutSite()
     {
-        $this->skipInPHP55();
         $cmsManager = $this->createMock('Sonata\PageBundle\CmsManager\CmsManagerSelectorInterface');
         $siteSelector = $this->createMock('Sonata\PageBundle\Site\SiteSelectorInterface');
         $router = $this->createMock('Symfony\Component\Routing\RouterInterface');
@@ -99,14 +97,5 @@ class PageExtensionTest extends PHPUnit_Framework_TestCase
             $httpKernelExtension->expects($this->once())->method('controller')->with('bar', [], []);
         }
         $extension->controller('bar');
-    }
-
-    private function skipInPHP55()
-    {
-        if (version_compare(PHP_VERSION, '5.5.0', '>=') && version_compare(PHP_VERSION, '5.6.0', '<=')) {
-            $this->markTestSkipped(
-                'This test should be skipped in php 5.5 due to an issue with phpunit.'
-            );
-        }
     }
 }

--- a/Tests/Validator/UniqueUrlValidatorTest.php
+++ b/Tests/Validator/UniqueUrlValidatorTest.php
@@ -22,7 +22,6 @@ class UniqueUrlValidatorTest extends PHPUnit_Framework_TestCase
      */
     public function testValidateWithNoPageFound()
     {
-        $this->skipInPHP55();
         $site = $this->createMock('Sonata\PageBundle\Model\SiteInterface');
 
         $page = $this->createMock('Sonata\PageBundle\Model\PageInterface');
@@ -43,7 +42,6 @@ class UniqueUrlValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateWithPageFound()
     {
-        $this->skipInPHP55();
         $site = $this->createMock('Sonata\PageBundle\Model\SiteInterface');
 
         $page = $this->createMock('Sonata\PageBundle\Model\PageInterface');
@@ -68,7 +66,6 @@ class UniqueUrlValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateWithRootUrlAndNoParent()
     {
-        $this->skipInPHP55();
         $site = $this->createMock('Sonata\PageBundle\Model\SiteInterface');
 
         $page = $this->createMock('Sonata\PageBundle\Model\PageInterface');
@@ -94,7 +91,6 @@ class UniqueUrlValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateWithPageDynamic()
     {
-        $this->skipInPHP55();
         $site = $this->createMock('Sonata\PageBundle\Model\SiteInterface');
 
         $page = $this->createMock('Sonata\PageBundle\Model\PageInterface');
@@ -120,14 +116,5 @@ class UniqueUrlValidatorTest extends PHPUnit_Framework_TestCase
             'Symfony\Component\Validator\Context\ExecutionContextInterface' :
             'Symfony\Component\Validator\ExecutionContextInterface'
         );
-    }
-
-    private function skipInPHP55()
-    {
-        if (version_compare(PHP_VERSION, '5.5.0', '>=') && version_compare(PHP_VERSION, '5.6.0', '<=')) {
-            $this->markTestSkipped(
-                'This test should be skipped in php 5.5 due to an issue with phpunit.'
-            );
-        }
     }
 }


### PR DESCRIPTION
I am targeting this branch, because support for all version below php7.1 are removed on 3.x.

## Changelog

```markdown
### Removed
- Removed php5 version checks
```

## Subject

Some cleanup to remove php5 version checks