### PR TITLE
fix site readonly attr

### DIFF
--- a/Admin/PageAdmin.php
+++ b/Admin/PageAdmin.php
@@ -327,7 +327,7 @@ class PageAdmin extends AbstractAdmin
         if (!$this->getSubject() || (!$this->getSubject()->isInternal() && !$this->getSubject()->isError())) {
             $formMapper
                 ->with('form_page.group_main_label')
-                    ->add('url', TextType::class, ['attr' => ['readonly' => 'readonly']])
+                    ->add('url', TextType::class, ['attr' => ['readonly' => true]])
                 ->end()
             ;
         }
@@ -335,7 +335,7 @@ class PageAdmin extends AbstractAdmin
         if ($this->hasSubject() && !$this->getSubject()->getId()) {
             $formMapper
                 ->with('form_page.group_main_label')
-                    ->add('site', null, ['required' => true, 'read_only' => true])
+                    ->add('site', null, ['required' => true, 'attr' => ['readonly' => true]])
                 ->end()
             ;
         }


### PR DESCRIPTION
I am targeting this branch, because there was still an "old" read_only flag.

## Changelog

```markdown
### Fixed
- read_only error for site selection in page admin
```

## Subject

There still was an "old" read_only flag. I moved it to 'attr' and used the boolean flag in both cases where it was used.