### PR TITLE
use page as context for breadcrumbs

### DIFF
--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -19,10 +19,7 @@ file that was distributed with this source code.
 
             {% block sonata_page_breadcrumb %}
                 <div class="row">
-                    {% if sonata_seo_context is not defined %}
-                        {% set sonata_seo_context = 'homepage' %}
-                    {% endif %}
-                    {{ sonata_block_render_event('breadcrumb', { 'context': sonata_seo_context, 'current_uri': app.request.requestUri }) }}
+                    {{ sonata_block_render_event('breadcrumb', { 'context': 'page', 'current_uri': app.request.requestUri }) }}
                 </div>
             {% endblock %}
 


### PR DESCRIPTION
I am targeting this branch, because breadcrumbs are not loaded correctly by default.

Relates to #751

## Changelog

```markdown
### Changed
- use 'page' instead of 'homepage' as default context for breadcrumbs
```

## Subject

As mentioned in #751, breadcrumbs are not loaded correctly. In that PR is alot of complexity, which I personally don't see the purpose of, but this may be related to the way I set up my project.
It appears that simply using the 'page' context will create correct breadcrumbs, pointing to the correct localised pages.