### PR TITLE
Remove code checks for <sf2.8

### DIFF
--- a/Block/BlockContextManager.php
+++ b/Block/BlockContextManager.php
@@ -29,18 +29,10 @@ class BlockContextManager extends BaseBlockContextManager
             'page_id' => false,
         ]);
 
-        // TODO: Remove it when bumping requirements to SF 2.6+
-        if (method_exists($optionsResolver, 'setDefined')) {
-            $optionsResolver
-                ->addAllowedTypes('manager', ['string', 'bool'])
-                ->addAllowedTypes('page_id', ['int', 'string', 'bool'])
-            ;
-        } else {
-            $optionsResolver->addAllowedTypes([
-                'manager' => ['string', 'bool'],
-                'page_id' => ['int', 'string', 'bool'],
-            ]);
-        }
+        $optionsResolver
+            ->addAllowedTypes('manager', ['string', 'bool'])
+            ->addAllowedTypes('page_id', ['int', 'string', 'bool'])
+        ;
 
         $optionsResolver->setRequired([
             'manager',

--- a/CmsManager/CmsManagerSelector.php
+++ b/CmsManager/CmsManagerSelector.php
@@ -15,7 +15,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
 use Symfony\Component\Security\Http\Logout\LogoutHandlerInterface;
@@ -79,7 +78,7 @@ class CmsManagerSelector implements CmsManagerSelectorInterface, LogoutHandlerIn
      */
     public function onSecurityInteractiveLogin(InteractiveLoginEvent $event)
     {
-        if ($this->getSecurityContext()->getToken() &&
+        if ($this->container->get('security.token_storage')->getToken() &&
             $this->container->get('sonata.page.admin.page')->isGranted('EDIT')) {
             $this->getSession()->set('sonata/page/isEditor', true);
         }
@@ -118,18 +117,5 @@ class CmsManagerSelector implements CmsManagerSelectorInterface, LogoutHandlerIn
         }
 
         return;
-    }
-
-    /**
-     * @return TokenStorageInterface
-     */
-    private function getSecurityContext()
-    {
-        // NEXT_MAJOR: Remove hack when bumping requirements to SF 2.6+
-        if (interface_exists('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')) {
-            return $this->container->get('security.token_storage');
-        }
-
-        return $this->container->get('security.context');
     }
 }

--- a/Command/CreateSiteCommand.php
+++ b/Command/CreateSiteCommand.php
@@ -58,14 +58,7 @@ EOT
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        /*
-         * NEXT_MAJOR: remove if statement and use the question helper only (true value of if) when dropping sf < 2.5
-         */
-        if ($this->getHelperSet()->has('question')) {
-            $helper = $this->getHelperSet()->get('question');
-        } else {
-            $helper = $this->getHelperSet()->get('dialog');
-        }
+        $helper = $this->getHelper('question');
 
         $values = [
             'name' => null,
@@ -82,24 +75,8 @@ EOT
             $values[$name] = $input->getOption($name);
 
             while (null == $values[$name]) {
-                /*
-                 * NEXT_MAJOR: remove if statement and use the question helper only (true value of if) when dropping sf < 2.5
-                 */
-                if ($this->getHelperSet()->has('question')) {
-                    $question = new Question(
-                        sprintf('Please define a value for <info>Site.%s</info> : ', $name)
-                    );
-                    $values[$name] = $helper->ask(
-                        $input,
-                        $output,
-                        $question
-                    );
-                } else {
-                    $values[$name] = $helper->ask(
-                        $output,
-                        sprintf('Please define a value for <info>Site.%s</info> : ', $name)
-                    );
-                }
+                $question = new Question(sprintf('Please define a value for <info>Site.%s</info> : ', $name));
+                $values[$name] = $helper->ask($input, $output, $question);
             }
         }
 
@@ -130,23 +107,8 @@ Creating website with the following information :
 INFO
         );
 
-        /*
-         * NEXT_MAJOR: remove if statement and use the question helper only (true value of if) when dropping sf < 2.5
-         */
-        if ($this->getHelperSet()->has('question')) {
-            $question = new ConfirmationQuestion(
-                'Confirm site creation (Y/N)',
-                false,
-                '/^(y)/i'
-            );
-            $confirmation = $helper->ask($input, $output, $question);
-        } else {
-            $confirmation = $input->getOption('no-confirmation') || $helper->askConfirmation(
-                $output,
-                'Confirm site creation?',
-                false
-            );
-        }
+        $question = new ConfirmationQuestion('Confirm site creation (Y/N)', false, '/^(y)/i');
+        $confirmation = $helper->ask($input, $output, $question);
         if ($confirmation) {
             $this->getSiteManager()->save($site);
 

--- a/Controller/PageController.php
+++ b/Controller/PageController.php
@@ -68,7 +68,7 @@ class PageController extends Controller
 
         $cms->setCurrentPage($page);
 
-        // NEXT_MAJOR: remove the usage of $this->getRequest() by injecting the request action method (sf 2.4+)
+        // NEXT_MAJOR: remove the usage of $this->getRequest() by injecting the request action method in 4.0 (BC break)
         return $this->getPageServiceManager()->execute($page, $this->getRequest());
     }
 
@@ -109,10 +109,6 @@ class PageController extends Controller
      */
     private function getRequest()
     {
-        if ($this->container->has('request_stack')) {
-            return $this->container->get('request_stack')->getCurrentRequest();
-        }
-
-        return $this->container->get('request');
+        return $this->container->get('request_stack')->getCurrentRequest();
     }
 }

--- a/DependencyInjection/SonataPageExtension.php
+++ b/DependencyInjection/SonataPageExtension.php
@@ -41,15 +41,10 @@ class SonataPageExtension extends Extension
 
         // NEXT_MAJOR: remove this code block
         $definition = $container->getDefinition('sonata.page.router.request_context');
-        if (method_exists($definition, 'setFactory')) {
-            $definition->setFactory([
-                new Reference('sonata.page.site.selector'),
-                'getRequestContext',
-            ]);
-        } else {
-            $definition->setFactoryService('sonata.page.site.selector');
-            $definition->setFactoryMethod('getRequestContext');
-        }
+        $definition->setFactory([
+            new Reference('sonata.page.site.selector'),
+            'getRequestContext',
+        ]);
 
         if (isset($bundles['FOSRestBundle']) && isset($bundles['NelmioApiDocBundle'])) {
             $loader->load('serializer.xml');

--- a/Tests/Validator/UniqueUrlValidatorTest.php
+++ b/Tests/Validator/UniqueUrlValidatorTest.php
@@ -14,6 +14,7 @@ namespace Sonata\PageBundle\Tests\Validator;
 use PHPUnit\Framework\TestCase;
 use Sonata\PageBundle\Validator\Constraints\UniqueUrl;
 use Sonata\PageBundle\Validator\UniqueUrlValidator;
+use Symfony\Component\Validator\Context\ExecutionContext;
 
 class UniqueUrlValidatorTest extends TestCase
 {
@@ -111,10 +112,20 @@ class UniqueUrlValidatorTest extends TestCase
 
     private function getContext()
     {
-        return $this->createMock(
-            class_exists('Symfony\Component\Validator\Context\ExecutionContextInterface') ?
-            'Symfony\Component\Validator\Context\ExecutionContextInterface' :
-            'Symfony\Component\Validator\ExecutionContextInterface'
-        );
+        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
+        $validator = $this->createMock('Symfony\Component\Validator\Validator\ValidatorInterface');
+        $contextualValidator = $this->createMock('Symfony\Component\Validator\Validator\ContextualValidatorInterface');
+
+        $context = new ExecutionContext($validator, 'root', $translator);
+
+        $context->setGroup('MyGroup');
+        $context->setNode('InvalidValue', null, null, 'property.path');
+        $context->setConstraint(new UniqueUrl());
+        $validator->expects($this->any())
+            ->method('inContext')
+            ->with($context)
+            ->will($this->returnValue($contextualValidator));
+
+        return $context;
     }
 }

--- a/Validator/UniqueUrlValidator.php
+++ b/Validator/UniqueUrlValidator.php
@@ -71,31 +71,13 @@ class UniqueUrlValidator extends ConstraintValidator
             }
 
             if ('/' == $currentPage->getUrl() && !$currentPage->getParent()) {
-                // NEXT_MAJOR: remove the if block below
-                if (!method_exists($this->context, 'buildViolation')) {
-                    $this->context->addViolationAt(
-                        'parent',
-                        'error.uniq_url.parent_unselect'
-                    );
-
-                    return;
-                }
                 $this->context->buildViolation('error.uniq_url.parent_unselect')
                     ->atPath('parent')
                     ->addViolation();
 
                 return;
             }
-            // NEXT_MAJOR: remove the if block below
-            if (!method_exists($this->context, 'buildViolation')) {
-                $this->context->addViolationAt(
-                    'url',
-                    'error.uniq_url',
-                    ['%url%' => $currentPage->getUrl()]
-                );
 
-                return;
-            }
             $this->context->buildViolation('error.uniq_url', ['%url%' => $currentPage->getUrl()])
                 ->atPath('url')
                 ->addViolation();


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because of code cleanup after sf/php bump.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- pre sf2.8 code checks
```

## Subject

Some code cleanup after the symfony/php version bump