### PR TITLE
Rename getRequest method for sf2.8 compatibility

### DIFF
--- a/Controller/PageController.php
+++ b/Controller/PageController.php
@@ -68,8 +68,8 @@ class PageController extends Controller
 
         $cms->setCurrentPage($page);
 
-        // NEXT_MAJOR: remove the usage of $this->getRequest() by injecting the request action method in 4.0 (BC break)
-        return $this->getPageServiceManager()->execute($page, $this->getRequest());
+        // NEXT_MAJOR: remove the usage of $this->getRequestObject() by injecting the request action method in 4.0 (BC break)
+        return $this->getPageServiceManager()->execute($page, $this->getRequestObject());
     }
 
     /**
@@ -107,7 +107,7 @@ class PageController extends Controller
     /**
      * @return Request
      */
-    private function getRequest()
+    private function getRequestObject()
     {
         return $this->container->get('request_stack')->getCurrentRequest();
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it's a sf2.8 fix for PR #872.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Renamed internal method to fix sf2.8 incompatibility
```

## Subject

sf2.8 compatibility fix see [comment in PR #872](https://github.com/sonata-project/SonataPageBundle/pull/872#issuecomment-338478866)
