### PR TITLE
Fixed passing snapshot factory as wrong argument

### DIFF
--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -23,6 +23,7 @@
         <service id="sonata.page.manager.snapshot" class="%sonata.page.manager.snapshot.class%">
             <argument>%sonata.page.snapshot.class%</argument>
             <argument type="service" id="doctrine"/>
+            <argument/>
             <argument type="service" id="sonata.page.proxy.snapshot.factory"/>
         </service>
         <service id="sonata.page.manager.block" class="%sonata.page.manager.block.class%">


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Fixes https://github.com/sonata-project/SonataPageBundle/pull/697

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
 - Fixed passing snapshot factory as wrong argument to `Sonata\PageBundle\Entity\SnapshotManager`
```

## Subject

The 3rd parameter is for templates. The 4th is the snapshot factory.
