### PR TITLE
Mark page as edited on block removing

### DIFF
--- a/Admin/BaseBlockAdmin.php
+++ b/Admin/BaseBlockAdmin.php
@@ -146,6 +146,12 @@ abstract class BaseBlockAdmin extends AbstractAdmin
     public function preRemove($object)
     {
         $this->blockManager->get($object)->preRemove($object);
+
+        $page = $object->getPage();
+
+        if ($page instanceof PageInterface) {
+            $page->setEdited(true);
+        }
     }
 
     /**

--- a/Tests/Admin/BaseBlockAdminTest.php
+++ b/Tests/Admin/BaseBlockAdminTest.php
@@ -12,6 +12,11 @@
 namespace Sonata\PageBundle\Tests\Admin;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\BlockBundle\Block\BlockServiceManagerInterface;
+use Sonata\BlockBundle\Block\Service\AbstractAdminBlockService;
+use Sonata\PageBundle\Admin\BaseBlockAdmin;
+use Sonata\PageBundle\Model\PageBlockInterface;
+use Sonata\PageBundle\Model\PageInterface;
 
 class BaseBlockAdminTest extends TestCase
 {
@@ -31,5 +36,26 @@ class BaseBlockAdminTest extends TestCase
         $query = $this->createMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface');
         $idx = [];
         $blockAdmin->preBatchAction('delete', $query, $idx, true);
+    }
+
+    public function testSettingAsEditedOnPreRemove()
+    {
+        $page = $this->createMock(PageInterface::class);
+        $page->expects($this->once())->method('setEdited')->with(true);
+
+        $block = $this->createMock(PageBlockInterface::class);
+        $block->expects($this->once())->method('getPage')->will($this->returnValue($page));
+
+        $blockService = $this->createMock(AbstractAdminBlockService::class);
+        $blockService->expects($this->any())->method('preRemove')->with($block);
+
+        $blockServiceManager = $this->createMock(BlockServiceManagerInterface::class);
+        $blockServiceManager->expects($this->once())->method('get')->with($block)->will($this->returnValue($blockService));
+
+        $blockAdmin = $this->getMockBuilder(BaseBlockAdmin::class)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+        $blockAdmin->setBlockManager($blockServiceManager);
+        $blockAdmin->preRemove($block);
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

I am targetting this branch, because this is a BC fix.

This is a rebase of #688

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->

``` markdown
### Fixed
- Removing blocks doesn't mark page as edited
```
## Subject

For now, this code included in `prePersist` and `preUpdate` events and missing in `prePremove`.

<!-- Describe your Pull Request content here -->
