### PR TITLE
Fix Twig 2.0 check for block 'content' existence

### DIFF
--- a/src/Resources/views/layout.html.twig
+++ b/src/Resources/views/layout.html.twig
@@ -37,7 +37,7 @@ file that was distributed with this source code.
                     {% if content is defined %}
                         {{ content|raw }}
                     {% else %}
-                        {% set content = block('content') %}
+                        {% set content = block('content') is defined ? block('content') : '' %}
                         {% if content|length > 0 %}
                             {{ content|raw }}
                         {% elseif page is defined %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

This PR is complementary of this one #860 
While accessing a page with empty content the following error is returned if using Twig 2.0
![image](https://user-images.githubusercontent.com/1230954/32787717-8cbbcec0-c957-11e7-9703-28868cf469d6.png)

## Changelog
```markdown
### Fixed
- compatibility with Twig 2.0 was improved
```
