### PR TITLE
do not use deprecated array for block menu service

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,10 @@
 UPGRADE 3.x
 ===========
 
+### Deprecated
+
+Initializing `Sonata\PageBundle\Block\BreadcrumbBlockService` class without the `menuRegistry` parameter is deprecated, Use `Sonata\BlockBundle\Menu\MenuRegistryInterface` as last argument.
+
 UPGRADE FROM 3.3 to 3.4
 =======================
 

--- a/src/Block/BreadcrumbBlockService.php
+++ b/src/Block/BreadcrumbBlockService.php
@@ -14,6 +14,7 @@ namespace Sonata\PageBundle\Block;
 use Knp\Menu\FactoryInterface;
 use Knp\Menu\Provider\MenuProviderInterface;
 use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Menu\MenuRegistryInterface;
 use Sonata\PageBundle\CmsManager\CmsManagerSelectorInterface;
 use Sonata\PageBundle\Model\PageInterface;
 use Sonata\SeoBundle\Block\Breadcrumb\BaseBreadcrumbMenuBlockService;
@@ -38,12 +39,32 @@ class BreadcrumbBlockService extends BaseBreadcrumbMenuBlockService
      * @param MenuProviderInterface       $menuProvider
      * @param FactoryInterface            $factory
      * @param CmsManagerSelectorInterface $cmsSelector
+     * @param MenuRegistryInterface|array $menuRegistry
+     *
+     * NEXT_MAJOR: Use MenuRegistryInterface as a type of $menuRegistry argument
      */
-    public function __construct($context, $name, EngineInterface $templating, MenuProviderInterface $menuProvider, FactoryInterface $factory, CmsManagerSelectorInterface $cmsSelector)
+    public function __construct($context, $name, EngineInterface $templating, MenuProviderInterface $menuProvider, FactoryInterface $factory, CmsManagerSelectorInterface $cmsSelector, $menuRegistry = [])
     {
         $this->cmsSelector = $cmsSelector;
 
-        parent::__construct($context, $name, $templating, $menuProvider, $factory);
+        /*
+         * NEXT_MAJOR: Remove if statements
+         */
+        if (!$menuRegistry instanceof MenuRegistryInterface && !is_array($menuRegistry)) {
+            throw new \InvalidArgumentException(sprintf(
+                'MenuRegistry must be either type of array or instance of %s',
+                MenuRegistryInterface::class
+            ));
+        } elseif (is_array($menuRegistry)) {
+            @trigger_error(sprintf(
+                'Initializing %s without menuRegistry parameter is deprecated since 3.x and will'.
+                ' be removed in 4.0. Use an instance of %s as last argument.',
+                __CLASS__,
+                MenuRegistryInterface::class
+            ), E_USER_DEPRECATED);
+        }
+
+        parent::__construct($context, $name, $templating, $menuProvider, $factory, $menuRegistry);
     }
 
     /**

--- a/src/Resources/config/block.xml
+++ b/src/Resources/config/block.xml
@@ -39,6 +39,7 @@
             <argument type="service" id="knp_menu.menu_provider"/>
             <argument type="service" id="knp_menu.factory"/>
             <argument type="service" id="sonata.page.cms_manager_selector"/>
+            <argument type="service" id="sonata.block.menu.registry"/>
         </service>
         <service id="sonata.page.block.shared_block" class="%sonata.page.block.shared_block.class%">
             <tag name="sonata.block"/>


### PR DESCRIPTION
I am targeting this branch, because this is a BC.

See: https://github.com/sonata-project/SonataSeoBundle/pull/241

## Changelog

```markdown
### Changed
- do not use deprecated array for block menu service
```

## To do

- [x] Add an upgrade note
