### PR TITLE
Fixed wrong route in pagelist block

### DIFF
--- a/src/Resources/views/Block/block_pagelist.html.twig
+++ b/src/Resources/views/Block/block_pagelist.html.twig
@@ -49,7 +49,7 @@
             {% endif %}
 
             {% if settings.mode == 'admin' and sonata_admin is defined %}
-                <a href="{{ sonata_admin.url('sonata.page.admin.page', 'compose', {filter:{hybrid:{value:'cms' }}}) }}" class="btn btn-primary btn-block">
+                <a href="{{ sonata_admin.url('sonata.page.admin.page', 'list', {filter:{hybrid:{value:'cms' }}}) }}" class="btn btn-primary btn-block">
                     <i class="fa fa-list"></i> {{ 'view_all_pages'|trans({}, 'SonataPageBundle') }}
                 </a>
             {% endif %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a bugfix.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
 - Fixed wrong route in pagelist block
```

## Subject

The wrong route generator was called.