### PR TITLE
Improved seo vs. page metadata

### DIFF
--- a/src/Page/Service/DefaultPageService.php
+++ b/src/Page/Service/DefaultPageService.php
@@ -71,8 +71,12 @@ class DefaultPageService extends BasePageService
             return;
         }
 
-        if ($page->getTitle() || $page->getName()) {
-            $this->seoPage->setTitle($page->getTitle() ?: $page->getName());
+        /*
+         * Always prefer the page title, if set.
+         * Do not use the (internal) page name as a fallback
+         */
+        if ($page->getTitle()) {
+            $this->seoPage->setTitle($page->getTitle());
         }
 
         if ($page->getMetaDescription()) {

--- a/tests/Page/Service/DefaultPageServiceTest.php
+++ b/tests/Page/Service/DefaultPageServiceTest.php
@@ -61,7 +61,7 @@ class DefaultPageServiceTest extends TestCase
 
         // mock a page instance
         $page = $this->createMock('Sonata\PageBundle\Model\PageInterface');
-        $page->expects($this->exactly(2))->method('getTitle')->will($this->returnValue('page title'));
+        $page->expects($this->any())->method('getTitle')->will($this->returnValue('page title'));
         $page->expects($this->atLeastOnce())->method('getMetaDescription')->will($this->returnValue('page meta description'));
         $page->expects($this->atLeastOnce())->method('getMetaKeyword')->will($this->returnValue('page meta keywords'));
         $page->expects($this->once())->method('getTemplateCode')->will($this->returnValue('template code'));


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a bugfix (again)

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
 - The internal page name is not used as a seo title fallback anymore
```


## Subject

Shame on me, #880 introduced this stupid bug again. To be safe for the future, I added a short comment why this line should be keept.
