### PR TITLE
Removed old form alias usage

### DIFF
--- a/src/Admin/BlockAdmin.php
+++ b/src/Admin/BlockAdmin.php
@@ -18,6 +18,7 @@ use Sonata\BlockBundle\Block\BlockServiceInterface;
 use Sonata\BlockBundle\Form\Type\ServiceListType;
 use Sonata\PageBundle\Model\PageInterface;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -202,7 +203,7 @@ class BlockAdmin extends BaseBlockAdmin
                     }
 
                     if (count($choices) > 1) {
-                        $settingsField->add('template', 'choice', ['choices' => $choices]);
+                        $settingsField->add('template', ChoiceType::class, ['choices' => $choices]);
                     }
                 }
             }

--- a/src/Admin/PageAdmin.php
+++ b/src/Admin/PageAdmin.php
@@ -29,6 +29,7 @@ use Sonata\PageBundle\Model\PageInterface;
 use Sonata\PageBundle\Model\PageManagerInterface;
 use Sonata\PageBundle\Model\SiteInterface;
 use Sonata\PageBundle\Model\SiteManagerInterface;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 
@@ -307,7 +308,7 @@ class PageAdmin extends AbstractAdmin
                     ],
                     'choice_translation_domain' => false,
                 ],
-                'field_type' => 'choice',
+                'field_type' => ChoiceType::class,
             ])
         ;
     }

--- a/src/Block/PageListBlockService.php
+++ b/src/Block/PageListBlockService.php
@@ -19,6 +19,8 @@ use Sonata\CoreBundle\Model\Metadata;
 use Sonata\PageBundle\Model\Page;
 use Sonata\PageBundle\Model\PageManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -48,11 +50,11 @@ class PageListBlockService extends AbstractAdminBlockService
     {
         $formMapper->add('settings', 'sonata_type_immutable_array', [
             'keys' => [
-                ['title', 'text', [
+                ['title', TextType::class, [
                     'label' => 'form.label_title',
                     'required' => false,
                 ]],
-                ['mode', 'choice', [
+                ['mode', ChoiceType::class, [
                     'label' => 'form.label_mode',
                     'choices' => [
                         'public' => 'form.choice_public',


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a patch.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
 - Removed old form alias usage
```
