### PR TITLE
add configuration to skip asking editor to redirect

### DIFF
--- a/docs/reference/advanced_configuration.rst
+++ b/docs/reference/advanced_configuration.rst
@@ -26,6 +26,7 @@ Full configuration options:
 
         # Default configuration for extension with alias: "sonata_page"
         sonata_page:
+            skip_redirection: false # Skip asking Editor to redirect
             is_inline_edition_on:  false
             use_streamed_response:  false
             multisite:            ~ # Required

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -63,6 +63,10 @@ You can use %kernel.debug%, if you want to publish in dev mode, but not in prod.
 EOF;
 
         $node
+            ->scalarNode('skip_redirection')
+                ->info('To skip asking Editor to redirect')
+                ->defaultFalse()
+            ->end()
             ->scalarNode('is_inline_edition_on')
                 ->defaultFalse()
             ->end()

--- a/src/DependencyInjection/SonataPageExtension.php
+++ b/src/DependencyInjection/SonataPageExtension.php
@@ -82,6 +82,7 @@ class SonataPageExtension extends Extension
         $container->setParameter('sonata.page.assets', $config['assets']);
         $container->setParameter('sonata.page.slugify_service', $config['slugify_service']);
 
+        $container->setParameter('sonata.page.skip_redirection', $config['skip_redirection']);
         $container->setParameter('sonata.page.is_inline_edition_on', $config['is_inline_edition_on']);
         $container->setParameter('sonata.page.hide_disabled_blocks', $config['hide_disabled_blocks']);
         $container->getDefinition('sonata.page.decorator_strategy')

--- a/src/Listener/ResponseListener.php
+++ b/src/Listener/ResponseListener.php
@@ -49,20 +49,31 @@ class ResponseListener
     protected $templating;
 
     /**
+     * @var bool
+     */
+    private $skipRedirection;
+
+    /**
      * @param CmsManagerSelectorInterface $cmsSelector        CMS manager selector
      * @param PageServiceManagerInterface $pageServiceManager Page service manager
      * @param DecoratorStrategyInterface  $decoratorStrategy  Decorator strategy
      * @param EngineInterface             $templating         The template engine
+     * @param bool                        $skipRedirection    To skip the redirection by configuration
+     *
+     * NEXT_MAJOR: Remove default value for $skipRedirection
      */
-    public function __construct(CmsManagerSelectorInterface $cmsSelector,
-                                PageServiceManagerInterface $pageServiceManager,
-                                DecoratorStrategyInterface $decoratorStrategy,
-                                EngineInterface $templating)
-    {
+    public function __construct(
+        CmsManagerSelectorInterface $cmsSelector,
+        PageServiceManagerInterface $pageServiceManager,
+        DecoratorStrategyInterface $decoratorStrategy,
+        EngineInterface $templating,
+        $skipRedirection = false
+    ) {
         $this->cmsSelector = $cmsSelector;
         $this->pageServiceManager = $pageServiceManager;
         $this->decoratorStrategy = $decoratorStrategy;
         $this->templating = $templating;
+        $this->skipRedirection = $skipRedirection;
     }
 
     /**
@@ -90,7 +101,12 @@ class ResponseListener
         $page = $cms->getCurrentPage();
 
         // display a validation page before redirecting, so the editor can edit the current page
-        if ($page && $response->isRedirection() && $this->cmsSelector->isEditor() && !$request->get('_sonata_page_skip')) {
+        if (
+            $page && $response->isRedirection() &&
+            $this->cmsSelector->isEditor() &&
+            !$request->get('_sonata_page_skip') &&
+            !$this->skipRedirection
+        ) {
             $response = new Response($this->templating->render('SonataPageBundle:Page:redirect.html.twig', [
                 'response' => $response,
                 'page' => $page,

--- a/src/Resources/config/page.xml
+++ b/src/Resources/config/page.xml
@@ -52,6 +52,7 @@
             <argument type="service" id="sonata.page.page_service_manager"/>
             <argument type="service" id="sonata.page.decorator_strategy"/>
             <argument type="service" id="templating"/>
+            <argument>%sonata.page.skip_redirection%</argument>
         </service>
         <service id="sonata.page.request_listener" class="%sonata.page.request_listener.class%">
             <tag name="kernel.event_listener" event="kernel.request" method="onCoreRequest" priority="30"/>

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -157,6 +157,7 @@ class ConfigurationTest extends TestCase
 
             'slugify_service' => 'sonata.core.slugify.native',
             'direct_publication' => false,
+            'skip_redirection' => false,
         ];
 
         $this->assertEquals($expected, $config);
@@ -242,6 +243,7 @@ class ConfigurationTest extends TestCase
 
             'slugify_service' => 'sonata.core.slugify.native',
             'direct_publication' => false,
+            'skip_redirection' => false,
         ];
 
         $this->assertEquals($expected, $config);


### PR DESCRIPTION
I am targeting this branch, because it is a new feature.

## Changelog

```markdown
### Added
- Added new configuration `skip_redirection` to skip asking Editor to redirect
```

## To do

- [x] Update the Tests
- [x] Update the documentation

## Subject

This feature is needed to make a configuration to skip redirection page to be presented between redirections. 
