### PR TITLE
Replace FQCN strings with ::class constants

### DIFF
--- a/src/Block/SharedBlockBlockService.php
+++ b/src/Block/SharedBlockBlockService.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\PageBundle\Block;
 
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Block\Service\AbstractAdminBlockService;
@@ -187,7 +188,7 @@ class SharedBlockBlockService extends AbstractAdminBlockService
         $fieldDescription->setOption('edit', 'list');
         $fieldDescription->setAssociationMapping([
                 'fieldName' => 'block',
-                'type' => \Doctrine\ORM\Mapping\ClassMetadataInfo::MANY_TO_ONE,
+                'type' => ClassMetadataInfo::MANY_TO_ONE,
             ]);
 
         return $formMapper->create('blockId', 'sonata_type_model_list', [

--- a/src/Controller/PageAdminController.php
+++ b/src/Controller/PageAdminController.php
@@ -12,6 +12,9 @@
 namespace Sonata\PageBundle\Controller;
 
 use Sonata\AdminBundle\Controller\CRUDController as Controller;
+use Symfony\Bridge\Twig\AppVariable;
+use Symfony\Bridge\Twig\Extension\FormExtension;
+use Symfony\Bridge\Twig\Form\TwigRenderer;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -98,10 +101,10 @@ class PageAdminController extends Controller
         // BC for Symfony < 3.2 where this runtime does not exist
         $twig = $this->get('twig');
         $theme = $this->admin->getFilterTheme();
-        if (!method_exists('Symfony\Bridge\Twig\AppVariable', 'getToken')) {
-            $twig->getExtension('Symfony\Bridge\Twig\Extension\FormExtension')->renderer->setTheme($formView, $theme);
+        if (!method_exists(AppVariable::class, 'getToken')) {
+            $twig->getExtension(FormExtension::class)->renderer->setTheme($formView, $theme);
         } else {
-            $twig->getRuntime('Symfony\Bridge\Twig\Form\TwigRenderer')->setTheme($formView, $theme);
+            $twig->getRuntime(TwigRenderer::class)->setTheme($formView, $theme);
         }
 
         return $this->render($this->admin->getTemplate('tree'), [

--- a/src/DependencyInjection/SonataPageExtension.php
+++ b/src/DependencyInjection/SonataPageExtension.php
@@ -397,7 +397,7 @@ class SonataPageExtension extends Extension
         // add all templates to manager
         $definitions = [];
         foreach ($config['templates'] as $code => $info) {
-            $definition = new Definition('Sonata\PageBundle\Model\Template', [
+            $definition = new Definition(Template::class, [
                 $info['name'],
                 $info['path'],
                 $info['containers'],

--- a/src/Entity/BasePage.php
+++ b/src/Entity/BasePage.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\PageBundle\Entity;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Sonata\PageBundle\Model\Page;
 
 /**
@@ -27,8 +28,8 @@ abstract class BasePage extends Page
     {
         parent::__construct();
 
-        $this->children = new \Doctrine\Common\Collections\ArrayCollection();
-        $this->blocks = new \Doctrine\Common\Collections\ArrayCollection();
+        $this->children = new ArrayCollection();
+        $this->blocks = new ArrayCollection();
     }
 
     public function prePersist()

--- a/src/Entity/SnapshotManager.php
+++ b/src/Entity/SnapshotManager.php
@@ -62,7 +62,7 @@ class SnapshotManager extends BaseEntityManager implements SnapshotManagerInterf
                 'The $snapshotPageProxyFactory parameter is required with the next major release.',
                 E_USER_DEPRECATED
             );
-            $snapshotPageProxyFactory = new SnapshotPageProxyFactory('Sonata\PageBundle\Model\SnapshotPageProxy');
+            $snapshotPageProxyFactory = new SnapshotPageProxyFactory(SnapshotPageProxy::class);
         }
 
         $this->templates = $templates;

--- a/src/Entity/Transformer.php
+++ b/src/Entity/Transformer.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\PageBundle\Entity;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\EntityManagerInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\BlockBundle\Model\BlockManagerInterface;
@@ -242,7 +243,7 @@ class Transformer implements TransformerInterface
                 $pages[$page->getId()] = $page;
             }
 
-            $this->children[$parent->getId()] = new \Doctrine\Common\Collections\ArrayCollection($pages);
+            $this->children[$parent->getId()] = new ArrayCollection($pages);
         }
 
         return $this->children[$parent->getId()];

--- a/src/Form/Type/PageTypeChoiceType.php
+++ b/src/Form/Type/PageTypeChoiceType.php
@@ -14,6 +14,7 @@ namespace Sonata\PageBundle\Form\Type;
 use Sonata\PageBundle\Page\PageServiceManagerInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
@@ -48,7 +49,7 @@ class PageTypeChoiceType extends AbstractType
         ];
 
         // NEXT_MAJOR: Remove (when requirement of Symfony is >= 3.0)
-        if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+        if (method_exists(FormTypeInterface::class, 'setDefaultOptions')) {
             $defaults['choices_as_values'] = true;
         }
 

--- a/src/Form/Type/TemplateChoiceType.php
+++ b/src/Form/Type/TemplateChoiceType.php
@@ -14,6 +14,7 @@ namespace Sonata\PageBundle\Form\Type;
 use Sonata\PageBundle\Page\TemplateManagerInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
@@ -48,7 +49,7 @@ class TemplateChoiceType extends AbstractType
         ];
 
         // NEXT_MAJOR: Remove (when requirement of Symfony is >= 3.0)
-        if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+        if (method_exists(FormTypeInterface::class, 'setDefaultOptions')) {
             $defaults['choices_as_values'] = true;
         }
 

--- a/src/Request/RequestFactory.php
+++ b/src/Request/RequestFactory.php
@@ -17,9 +17,9 @@ use Symfony\Component\HttpKernel\Kernel;
 class RequestFactory
 {
     private static $types = [
-        'host' => 'Symfony\Component\HttpFoundation\Request',
-        'host_with_path' => 'Sonata\PageBundle\Request\SiteRequest',
-        'host_with_path_by_locale' => 'Sonata\PageBundle\Request\SiteRequest',
+        'host' => Request::class,
+        'host_with_path' => SiteRequest::class,
+        'host_with_path_by_locale' => SiteRequest::class,
     ];
 
     /**

--- a/src/SonataPageBundle.php
+++ b/src/SonataPageBundle.php
@@ -15,6 +15,14 @@ use Sonata\CoreBundle\Form\FormHelper;
 use Sonata\PageBundle\DependencyInjection\Compiler\CacheCompilerPass;
 use Sonata\PageBundle\DependencyInjection\Compiler\GlobalVariablesCompilerPass;
 use Sonata\PageBundle\DependencyInjection\Compiler\PageServiceCompilerPass;
+use Sonata\PageBundle\Form\Type\ApiBlockType;
+use Sonata\PageBundle\Form\Type\ApiPageType;
+use Sonata\PageBundle\Form\Type\ApiSiteType;
+use Sonata\PageBundle\Form\Type\CreateSnapshotType;
+use Sonata\PageBundle\Form\Type\PageSelectorType;
+use Sonata\PageBundle\Form\Type\PageTypeChoiceType;
+use Sonata\PageBundle\Form\Type\TemplateChoiceType;
+use Symfony\Cmf\Bundle\RoutingBundle\Form\Type\RouteTypeType;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -85,14 +93,14 @@ class SonataPageBundle extends Bundle
     public function registerFormMapping()
     {
         FormHelper::registerFormTypeMapping([
-            'sonata_page_api_form_site' => 'Sonata\PageBundle\Form\Type\ApiSiteType',
-            'sonata_page_api_form_page' => 'Sonata\PageBundle\Form\Type\ApiPageType',
-            'sonata_page_api_form_block' => 'Sonata\PageBundle\Form\Type\ApiBlockType',
-            'sonata_page_selector' => 'Sonata\PageBundle\Form\Type\PageSelectorType',
-            'sonata_page_create_snapshot' => 'Sonata\PageBundle\Form\Type\CreateSnapshotType',
-            'sonata_page_template' => 'Sonata\PageBundle\Form\Type\TemplateChoiceType',
-            'sonata_page_type_choice' => 'Sonata\PageBundle\Form\Type\PageTypeChoiceType',
-            'cmf_routing_route_type' => 'Symfony\Cmf\Bundle\RoutingBundle\Form\Type\RouteTypeType',
+            'sonata_page_api_form_site' => ApiSiteType::class,
+            'sonata_page_api_form_page' => ApiPageType::class,
+            'sonata_page_api_form_block' => ApiBlockType::class,
+            'sonata_page_selector' => PageSelectorType::class,
+            'sonata_page_create_snapshot' => CreateSnapshotType::class,
+            'sonata_page_template' => TemplateChoiceType::class,
+            'sonata_page_type_choice' => PageTypeChoiceType::class,
+            'cmf_routing_route_type' => RouteTypeType::class,
         ]);
     }
 }

--- a/src/Twig/Extension/PageExtension.php
+++ b/src/Twig/Extension/PageExtension.php
@@ -18,6 +18,7 @@ use Sonata\PageBundle\Model\PageBlockInterface;
 use Sonata\PageBundle\Model\PageInterface;
 use Sonata\PageBundle\Model\SnapshotPageProxy;
 use Sonata\PageBundle\Site\SiteSelectorInterface;
+use Symfony\Bridge\Twig\AppVariable;
 use Symfony\Bridge\Twig\Extension\HttpKernelExtension;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Controller\ControllerReference;
@@ -283,7 +284,7 @@ class PageExtension extends AbstractExtension implements InitRuntimeInterface
         }
 
         // Simplify this when dropping twig-bridge < 3.2 support
-        if (method_exists('Symfony\Bridge\Twig\AppVariable', 'getToken')) {
+        if (method_exists(AppVariable::class, 'getToken')) {
             return HttpKernelExtension::controller($controller, $attributes, $query);
         }
 

--- a/tests/Admin/BaseBlockAdminTest.php
+++ b/tests/Admin/BaseBlockAdminTest.php
@@ -12,6 +12,8 @@
 namespace Sonata\PageBundle\Tests\Admin;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\BlockBundle\Block\BlockServiceManagerInterface;
 use Sonata\BlockBundle\Block\Service\AbstractAdminBlockService;
 use Sonata\PageBundle\Admin\BaseBlockAdmin;
@@ -22,18 +24,18 @@ class BaseBlockAdminTest extends TestCase
 {
     public function testSettingAsEditedOnPreBatchDeleteAction()
     {
-        $page = $this->createMock('Sonata\PageBundle\Model\PageInterface');
+        $page = $this->createMock(PageInterface::class);
         $page->expects($this->once())->method('setEdited')->with(true);
 
-        $parent = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $parent = $this->createMock(AdminInterface::class);
         $parent->expects($this->once())->method('getSubject')->will($this->returnValue($page));
 
-        $blockAdmin = $this->getMockBuilder('Sonata\PageBundle\Admin\BaseBlockAdmin')
+        $blockAdmin = $this->getMockBuilder(BaseBlockAdmin::class)
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $blockAdmin->setParent($parent);
 
-        $query = $this->createMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface');
+        $query = $this->createMock(ProxyQueryInterface::class);
         $idx = [];
         $blockAdmin->preBatchAction('delete', $query, $idx, true);
     }

--- a/tests/Admin/Extension/CreateSnapshotAdminExtensionTest.php
+++ b/tests/Admin/Extension/CreateSnapshotAdminExtensionTest.php
@@ -12,18 +12,22 @@
 namespace Sonata\PageBundle\Tests\Admin\Extension;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\NotificationBundle\Backend\BackendInterface;
 use Sonata\PageBundle\Admin\Extension\CreateSnapshotAdminExtension;
+use Sonata\PageBundle\Model\PageBlockInterface;
+use Sonata\PageBundle\Model\PageInterface;
 
 class CreateSnapshotAdminExtensionTest extends TestCase
 {
     public function testPostUpdateOnPage()
     {
-        $page = $this->createMock('Sonata\PageBundle\Model\PageInterface');
+        $page = $this->createMock(PageInterface::class);
         $page->expects($this->once())->method('getId')->will($this->returnValue(42));
 
-        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->createMock(AdminInterface::class);
 
-        $backend = $this->createMock('Sonata\NotificationBundle\Backend\BackendInterface');
+        $backend = $this->createMock(BackendInterface::class);
         $backend->expects($this->once())->method('createAndPublish')->with(
             'sonata.page.create_snapshot',
             ['pageId' => 42]
@@ -35,12 +39,12 @@ class CreateSnapshotAdminExtensionTest extends TestCase
 
     public function testPostPersistOnPage()
     {
-        $page = $this->createMock('Sonata\PageBundle\Model\PageInterface');
+        $page = $this->createMock(PageInterface::class);
         $page->expects($this->once())->method('getId')->will($this->returnValue(42));
 
-        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->createMock(AdminInterface::class);
 
-        $backend = $this->createMock('Sonata\NotificationBundle\Backend\BackendInterface');
+        $backend = $this->createMock(BackendInterface::class);
         $backend->expects($this->once())->method('createAndPublish')->with(
             'sonata.page.create_snapshot',
             ['pageId' => 42]
@@ -52,15 +56,15 @@ class CreateSnapshotAdminExtensionTest extends TestCase
 
     public function testPostUpdateOnBlock()
     {
-        $page = $this->createMock('Sonata\PageBundle\Model\PageInterface');
+        $page = $this->createMock(PageInterface::class);
         $page->expects($this->once())->method('getId')->will($this->returnValue(42));
 
-        $block = $this->createMock('Sonata\PageBundle\Model\PageBlockInterface');
+        $block = $this->createMock(PageBlockInterface::class);
         $block->expects($this->once())->method('getPage')->will($this->returnValue($page));
 
-        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->createMock(AdminInterface::class);
 
-        $backend = $this->createMock('Sonata\NotificationBundle\Backend\BackendInterface');
+        $backend = $this->createMock(BackendInterface::class);
         $backend->expects($this->once())->method('createAndPublish')->with(
             'sonata.page.create_snapshot',
             ['pageId' => 42]
@@ -72,15 +76,15 @@ class CreateSnapshotAdminExtensionTest extends TestCase
 
     public function testPostPersistOnBlock()
     {
-        $page = $this->createMock('Sonata\PageBundle\Model\PageInterface');
+        $page = $this->createMock(PageInterface::class);
         $page->expects($this->once())->method('getId')->will($this->returnValue(42));
 
-        $block = $this->createMock('Sonata\PageBundle\Model\PageBlockInterface');
+        $block = $this->createMock(PageBlockInterface::class);
         $block->expects($this->once())->method('getPage')->will($this->returnValue($page));
 
-        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->createMock(AdminInterface::class);
 
-        $backend = $this->createMock('Sonata\NotificationBundle\Backend\BackendInterface');
+        $backend = $this->createMock(BackendInterface::class);
         $backend->expects($this->once())->method('createAndPublish')->with(
             'sonata.page.create_snapshot',
             ['pageId' => 42]

--- a/tests/Admin/PageAdminTest.php
+++ b/tests/Admin/PageAdminTest.php
@@ -14,7 +14,10 @@ namespace Sonata\PageBundle\Tests\Admin;
 use Knp\Menu\MenuFactory;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Sonata\AdminBundle\Route\RouteGeneratorInterface;
 use Sonata\PageBundle\Admin\PageAdmin;
+use Sonata\PageBundle\Controller\PageController;
+use Sonata\PageBundle\Model\Site;
 use Sonata\PageBundle\Tests\Model\Page;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -26,16 +29,16 @@ class PageAdminTest extends TestCase
         $request = new Request(['id' => 42]);
         $admin = new PageAdmin(
             'admin.page',
-            'Sonata\PageBundle\Model\Page',
-            'Sonata\PageBundle\Controller\PageController'
+            Page::class,
+            PageController::class
         );
         $admin->setMenuFactory(new MenuFactory());
         $admin->setRequest($request);
 
-        $site = $this->prophesize('Sonata\PageBundle\Model\Site');
+        $site = $this->prophesize(Site::class);
         $site->getRelativePath()->willReturn('/my-subsite');
 
-        $page = $this->prophesize('Sonata\PageBundle\Model\Page');
+        $page = $this->prophesize(Page::class);
         $page->getRouteName()->willReturn(Page::PAGE_ROUTE_CMS_NAME);
         $page->getUrl()->willReturn('/my-page');
         $page->isHybrid()->willReturn(false);
@@ -43,7 +46,7 @@ class PageAdminTest extends TestCase
         $page->getSite()->willReturn($site->reveal());
         $admin->setSubject($page->reveal());
 
-        $routeGenerator = $this->prophesize('Sonata\AdminBundle\Route\RouteGeneratorInterface');
+        $routeGenerator = $this->prophesize(RouteGeneratorInterface::class);
         $routeGenerator->generateMenuUrl(
             $admin,
             Argument::any(),

--- a/tests/Block/BlockContextManagerTest.php
+++ b/tests/Block/BlockContextManagerTest.php
@@ -12,7 +12,11 @@
 namespace Sonata\PageBundle\Tests\Block;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Block\BlockLoaderInterface;
+use Sonata\BlockBundle\Block\BlockServiceManagerInterface;
 use Sonata\BlockBundle\Block\Service\AbstractBlockService;
+use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\PageBundle\Block\BlockContextManager;
 
 /**
@@ -24,19 +28,19 @@ class BlockContextManagerTest extends TestCase
     {
         $service = $this->getMockForAbstractClass(AbstractBlockService::class);
 
-        $blockLoader = $this->createMock('Sonata\BlockBundle\Block\BlockLoaderInterface');
+        $blockLoader = $this->createMock(BlockLoaderInterface::class);
 
-        $serviceManager = $this->createMock('Sonata\BlockBundle\Block\BlockServiceManagerInterface');
+        $serviceManager = $this->createMock(BlockServiceManagerInterface::class);
         $serviceManager->expects($this->once())->method('get')->will($this->returnValue($service));
 
-        $block = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block = $this->createMock(BlockInterface::class);
         $block->expects($this->once())->method('getSettings')->will($this->returnValue([]));
 
         $manager = new BlockContextManager($blockLoader, $serviceManager);
 
         $blockContext = $manager->get($block);
 
-        $this->assertInstanceOf('Sonata\BlockBundle\Block\BlockContextInterface', $blockContext);
+        $this->assertInstanceOf(BlockContextInterface::class, $blockContext);
 
         $this->assertEquals([
             'manager' => false,

--- a/tests/Block/ContainerBlockServiceTest.php
+++ b/tests/Block/ContainerBlockServiceTest.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\PageBundle\Tests\Block;
 
+use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BlockContext;
 use Sonata\BlockBundle\Model\Block;
 use Sonata\BlockBundle\Test\AbstractBlockServiceTestCase;
@@ -47,7 +48,7 @@ class ContainerBlockServiceTest extends AbstractBlockServiceTestCase
         $this->assertEquals('SonataPageBundle:Block:block_container.html.twig', $this->templating->view);
         $this->assertEquals('block.code', $this->templating->parameters['block']->getSetting('code'));
         $this->assertEquals('block.name', $this->templating->parameters['block']->getName());
-        $this->assertInstanceOf('Sonata\BlockBundle\Model\Block', $this->templating->parameters['block']);
+        $this->assertInstanceOf(Block::class, $this->templating->parameters['block']);
     }
 
     /**
@@ -92,7 +93,7 @@ class ContainerBlockServiceTest extends AbstractBlockServiceTestCase
             'name' => 'block.code',
         ]);
 
-        $formMapper = $this->getMockBuilder('Sonata\\AdminBundle\\Form\\FormMapper')
+        $formMapper = $this->getMockBuilder(FormMapper::class)
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/tests/Block/PageListBlockServiceTest.php
+++ b/tests/Block/PageListBlockServiceTest.php
@@ -13,9 +13,11 @@ namespace Sonata\PageBundle\Tests\Block;
 
 use Sonata\BlockBundle\Block\BlockContext;
 use Sonata\BlockBundle\Model\Block;
+use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\BlockBundle\Test\AbstractBlockServiceTestCase;
 use Sonata\PageBundle\Block\PageListBlockService;
 use Sonata\PageBundle\Model\Page;
+use Sonata\PageBundle\Model\PageInterface;
 use Sonata\PageBundle\Model\PageManagerInterface;
 
 class PageListBlockServiceTest extends AbstractBlockServiceTestCase
@@ -29,7 +31,7 @@ class PageListBlockServiceTest extends AbstractBlockServiceTestCase
     {
         parent::setUp();
 
-        $this->pageManager = $this->createMock('Sonata\PageBundle\Model\PageManagerInterface');
+        $this->pageManager = $this->createMock(PageManagerInterface::class);
     }
 
     public function testDefaultSettings()
@@ -46,9 +48,9 @@ class PageListBlockServiceTest extends AbstractBlockServiceTestCase
 
     public function testExecute()
     {
-        $page1 = $this->createMock('Sonata\PageBundle\Model\PageInterface');
-        $page2 = $this->createMock('Sonata\PageBundle\Model\PageInterface');
-        $systemPage = $this->createMock('Sonata\PageBundle\Model\PageInterface');
+        $page1 = $this->createMock(PageInterface::class);
+        $page2 = $this->createMock(PageInterface::class);
+        $systemPage = $this->createMock(PageInterface::class);
 
         $this->pageManager->expects($this->at(0))->method('findBy')
             ->with($this->equalTo([
@@ -77,7 +79,7 @@ class PageListBlockServiceTest extends AbstractBlockServiceTestCase
 
         $this->assertSame($blockContext, $this->templating->parameters['context']);
         $this->assertInternalType('array', $this->templating->parameters['settings']);
-        $this->assertInstanceOf('Sonata\BlockBundle\Model\BlockInterface', $this->templating->parameters['block']);
+        $this->assertInstanceOf(BlockInterface::class, $this->templating->parameters['block']);
         $this->assertCount(2, $this->templating->parameters['elements']);
         $this->assertContains($page1, $this->templating->parameters['elements']);
         $this->assertContains($page2, $this->templating->parameters['elements']);

--- a/tests/Cache/BlockEsiCacheTest.php
+++ b/tests/Cache/BlockEsiCacheTest.php
@@ -12,7 +12,11 @@
 namespace Sonata\PageBundle\Tests\Page;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\BlockBundle\Block\BlockContextManagerInterface;
+use Sonata\BlockBundle\Block\BlockRendererInterface;
+use Sonata\Cache\CacheElement;
 use Sonata\PageBundle\Cache\BlockEsiCache;
+use Symfony\Component\Routing\RouterInterface;
 
 class BlockEsiCacheTest extends TestCase
 {
@@ -23,11 +27,11 @@ class BlockEsiCacheTest extends TestCase
     {
         $this->expectException(\RuntimeException::class);
 
-        $router = $this->createMock('Symfony\Component\Routing\RouterInterface');
+        $router = $this->createMock(RouterInterface::class);
 
-        $blockRenderer = $this->createMock('Sonata\BlockBundle\Block\BlockRendererInterface');
+        $blockRenderer = $this->createMock(BlockRendererInterface::class);
 
-        $contextManager = $this->createMock('Sonata\BlockBundle\Block\BlockContextManagerInterface');
+        $contextManager = $this->createMock(BlockContextManagerInterface::class);
 
         $cache = new BlockEsiCache('My Token', [], $router, 'ban', $blockRenderer, $contextManager);
 
@@ -49,11 +53,11 @@ class BlockEsiCacheTest extends TestCase
 
     public function testInitCache()
     {
-        $router = $this->createMock('Symfony\Component\Routing\RouterInterface');
+        $router = $this->createMock(RouterInterface::class);
         $router->expects($this->any())->method('generate')->will($this->returnValue('https://sonata-project.org/cache/XXX/page/esi/page/5/4?updated_at=as'));
 
-        $blockRenderer = $this->createMock('Sonata\BlockBundle\Block\BlockRendererInterface');
-        $contextManager = $this->createMock('Sonata\BlockBundle\Block\BlockContextManagerInterface');
+        $blockRenderer = $this->createMock(BlockRendererInterface::class);
+        $contextManager = $this->createMock(BlockContextManagerInterface::class);
 
         $cache = new BlockEsiCache('My Token', [], $router, 'ban', $blockRenderer, $contextManager);
 
@@ -69,13 +73,13 @@ class BlockEsiCacheTest extends TestCase
 
         $cacheElement = $cache->set($keys, 'data');
 
-        $this->assertInstanceOf('Sonata\Cache\CacheElement', $cacheElement);
+        $this->assertInstanceOf(CacheElement::class, $cacheElement);
 
         $this->assertTrue($cache->has(['id' => 7]));
 
         $cacheElement = $cache->get($keys);
 
-        $this->assertInstanceOf('Sonata\Cache\CacheElement', $cacheElement);
+        $this->assertInstanceOf(CacheElement::class, $cacheElement);
 
         $this->assertEquals('<esi:include src="https://sonata-project.org/cache/XXX/page/esi/page/5/4?updated_at=as" />', $cacheElement->getData()->getContent());
     }

--- a/tests/Cache/BlockJsCacheTest.php
+++ b/tests/Cache/BlockJsCacheTest.php
@@ -12,7 +12,12 @@
 namespace Sonata\PageBundle\Tests\Page;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\BlockBundle\Block\BlockContextManagerInterface;
+use Sonata\BlockBundle\Block\BlockRendererInterface;
+use Sonata\Cache\CacheElement;
 use Sonata\PageBundle\Cache\BlockJsCache;
+use Sonata\PageBundle\CmsManager\CmsManagerSelectorInterface;
+use Symfony\Component\Routing\RouterInterface;
 
 class BlockJsCacheTest extends TestCase
 {
@@ -23,11 +28,11 @@ class BlockJsCacheTest extends TestCase
     {
         $this->expectException(\RuntimeException::class);
 
-        $router = $this->createMock('Symfony\Component\Routing\RouterInterface');
+        $router = $this->createMock(RouterInterface::class);
 
-        $cmsManager = $this->createMock('Sonata\PageBundle\CmsManager\CmsManagerSelectorInterface');
-        $blockRenderer = $this->createMock('Sonata\BlockBundle\Block\BlockRendererInterface');
-        $contextManager = $this->createMock('Sonata\BlockBundle\Block\BlockContextManagerInterface');
+        $cmsManager = $this->createMock(CmsManagerSelectorInterface::class);
+        $blockRenderer = $this->createMock(BlockRendererInterface::class);
+        $contextManager = $this->createMock(BlockContextManagerInterface::class);
 
         $cache = new BlockJsCache($router, $cmsManager, $blockRenderer, $contextManager);
 
@@ -49,12 +54,12 @@ class BlockJsCacheTest extends TestCase
 
     public function testInitCache()
     {
-        $router = $this->createMock('Symfony\Component\Routing\RouterInterface');
+        $router = $this->createMock(RouterInterface::class);
         $router->expects($this->once())->method('generate')->will($this->returnValue('https://sonata-project.org/page/cache/js/block.js'));
 
-        $cmsSelectorManager = $this->createMock('Sonata\PageBundle\CmsManager\CmsManagerSelectorInterface');
-        $blockRenderer = $this->createMock('Sonata\BlockBundle\Block\BlockRendererInterface');
-        $contextManager = $this->createMock('Sonata\BlockBundle\Block\BlockContextManagerInterface');
+        $cmsSelectorManager = $this->createMock(CmsManagerSelectorInterface::class);
+        $blockRenderer = $this->createMock(BlockRendererInterface::class);
+        $contextManager = $this->createMock(BlockContextManagerInterface::class);
 
         $cache = new BlockJsCache($router, $cmsSelectorManager, $blockRenderer, $contextManager);
 
@@ -70,13 +75,13 @@ class BlockJsCacheTest extends TestCase
 
         $cacheElement = $cache->set($keys, 'data');
 
-        $this->assertInstanceOf('Sonata\Cache\CacheElement', $cacheElement);
+        $this->assertInstanceOf(CacheElement::class, $cacheElement);
 
         $this->assertTrue($cache->has(['id' => 7]));
 
         $cacheElement = $cache->get($keys);
 
-        $this->assertInstanceOf('Sonata\Cache\CacheElement', $cacheElement);
+        $this->assertInstanceOf(CacheElement::class, $cacheElement);
 
         $expected = <<<'EXPECTED'
 <div id="block-cms-4" >

--- a/tests/Cache/BlockSsiCacheTest.php
+++ b/tests/Cache/BlockSsiCacheTest.php
@@ -12,7 +12,11 @@
 namespace Sonata\PageBundle\Tests\Page;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\BlockBundle\Block\BlockContextManagerInterface;
+use Sonata\BlockBundle\Block\BlockRendererInterface;
+use Sonata\Cache\CacheElement;
 use Sonata\PageBundle\Cache\BlockSsiCache;
+use Symfony\Component\Routing\RouterInterface;
 
 class BlockSsiCacheTest extends TestCase
 {
@@ -23,10 +27,10 @@ class BlockSsiCacheTest extends TestCase
     {
         $this->expectException(\RuntimeException::class);
 
-        $router = $this->createMock('Symfony\Component\Routing\RouterInterface');
+        $router = $this->createMock(RouterInterface::class);
 
-        $blockRenderer = $this->createMock('Sonata\BlockBundle\Block\BlockRendererInterface');
-        $contextManager = $this->createMock('Sonata\BlockBundle\Block\BlockContextManagerInterface');
+        $blockRenderer = $this->createMock(BlockRendererInterface::class);
+        $contextManager = $this->createMock(BlockContextManagerInterface::class);
 
         $cache = new BlockSsiCache('', $router, $blockRenderer, $contextManager);
 
@@ -48,11 +52,11 @@ class BlockSsiCacheTest extends TestCase
 
     public function testInitCache()
     {
-        $router = $this->createMock('Symfony\Component\Routing\RouterInterface');
+        $router = $this->createMock(RouterInterface::class);
         $router->expects($this->any())->method('generate')->will($this->returnValue('/cache/page/esi/XXXXX/page/5/4?updated_at=as'));
 
-        $blockRenderer = $this->createMock('Sonata\BlockBundle\Block\BlockRendererInterface');
-        $contextManager = $this->createMock('Sonata\BlockBundle\Block\BlockContextManagerInterface');
+        $blockRenderer = $this->createMock(BlockRendererInterface::class);
+        $contextManager = $this->createMock(BlockContextManagerInterface::class);
 
         $cache = new BlockSsiCache('', $router, $blockRenderer, $contextManager);
 
@@ -68,13 +72,13 @@ class BlockSsiCacheTest extends TestCase
 
         $cacheElement = $cache->set($keys, 'data');
 
-        $this->assertInstanceOf('Sonata\Cache\CacheElement', $cacheElement);
+        $this->assertInstanceOf(CacheElement::class, $cacheElement);
 
         $this->assertTrue($cache->has(['id' => 7]));
 
         $cacheElement = $cache->get($keys);
 
-        $this->assertInstanceOf('Sonata\Cache\CacheElement', $cacheElement);
+        $this->assertInstanceOf(CacheElement::class, $cacheElement);
 
         $this->assertEquals('<!--# include virtual="/cache/page/esi/XXXXX/page/5/4?updated_at=as" -->', $cacheElement->getData()->getContent());
     }

--- a/tests/CmsManager/CmsPageManagerTest.php
+++ b/tests/CmsManager/CmsPageManagerTest.php
@@ -13,7 +13,12 @@ namespace Sonata\PageBundle\Tests\Page;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\PageBundle\CmsManager\CmsPageManager;
+use Sonata\PageBundle\Exception\PageNotFoundException;
 use Sonata\PageBundle\Model\Block as AbstractBlock;
+use Sonata\PageBundle\Model\BlockInteractorInterface;
+use Sonata\PageBundle\Model\PageBlockInterface;
+use Sonata\PageBundle\Model\PageInterface;
+use Sonata\PageBundle\Model\PageManagerInterface;
 use Sonata\PageBundle\Tests\Model\Page;
 use Sonata\PageBundle\Tests\Model\Site;
 
@@ -44,7 +49,7 @@ class CmsPageManagerTest extends TestCase
     public function setUp()
     {
         $this->blockInteractor = $this->getMockBlockInteractor();
-        $this->pageManager = $this->createMock('Sonata\PageBundle\Model\PageManagerInterface');
+        $this->pageManager = $this->createMock(PageManagerInterface::class);
         $this->manager = new CmsPageManager($this->pageManager, $this->blockInteractor);
     }
 
@@ -74,7 +79,7 @@ class CmsPageManagerTest extends TestCase
 
         $container = $this->manager->findContainer('newcontainer', $page);
 
-        $this->assertInstanceOf('Sonata\PageBundle\Model\PageBlockInterface', $container, 'should be a block');
+        $this->assertInstanceOf(PageBlockInterface::class, $container, 'should be a block');
         $this->assertEquals('newcontainer', $container->getSetting('code'));
     }
 
@@ -83,7 +88,7 @@ class CmsPageManagerTest extends TestCase
      */
     public function testGetPageWithUrl()
     {
-        $pageManager = $this->createMock('Sonata\PageBundle\Model\PageManagerInterface');
+        $pageManager = $this->createMock(PageManagerInterface::class);
 
         $pageManager->expects($this->any())->method('findOneBy')->will($this->returnValue(new Page()));
         $this->blockInteractor->expects($this->any())->method('loadPageBlocks')->will($this->returnValue([]));
@@ -93,7 +98,7 @@ class CmsPageManagerTest extends TestCase
         $page = '/test';
         $site = new Site();
 
-        $this->assertInstanceOf('Sonata\PageBundle\Model\PageInterface', $manager->getPage($site, $page));
+        $this->assertInstanceOf(PageInterface::class, $manager->getPage($site, $page));
     }
 
     /**
@@ -101,10 +106,10 @@ class CmsPageManagerTest extends TestCase
      */
     public function testGetPageWithUrlException()
     {
-        $this->expectException(\Sonata\PageBundle\Exception\PageNotFoundException::class);
+        $this->expectException(PageNotFoundException::class);
         $this->expectExceptionMessage('Unable to find the page : url = /test');
 
-        $pageManager = $this->createMock('Sonata\PageBundle\Model\PageManagerInterface');
+        $pageManager = $this->createMock(PageManagerInterface::class);
 
         $this->blockInteractor->expects($this->any())->method('loadPageBlocks')->will($this->returnValue([]));
 
@@ -124,7 +129,7 @@ class CmsPageManagerTest extends TestCase
      */
     public function testGetPageWithRouteName()
     {
-        $pageManager = $this->createMock('Sonata\PageBundle\Model\PageManagerInterface');
+        $pageManager = $this->createMock(PageManagerInterface::class);
 
         $pageManager->expects($this->any())->method('findOneBy')->will($this->returnValue(new Page()));
         $this->blockInteractor->expects($this->any())->method('loadPageBlocks')->will($this->returnValue([]));
@@ -134,7 +139,7 @@ class CmsPageManagerTest extends TestCase
         $page = 'test';
         $site = new Site();
 
-        $this->assertInstanceOf('Sonata\PageBundle\Model\PageInterface', $manager->getPage($site, $page));
+        $this->assertInstanceOf(PageInterface::class, $manager->getPage($site, $page));
     }
 
     /**
@@ -142,10 +147,10 @@ class CmsPageManagerTest extends TestCase
      */
     public function testGetPageWithRouteNameException()
     {
-        $this->expectException(\Sonata\PageBundle\Exception\PageNotFoundException::class);
+        $this->expectException(PageNotFoundException::class);
         $this->expectExceptionMessage('Unable to find the page : url = /test');
 
-        $pageManager = $this->createMock('Sonata\PageBundle\Model\PageManagerInterface');
+        $pageManager = $this->createMock(PageManagerInterface::class);
 
         $this->blockInteractor->expects($this->any())->method('loadPageBlocks')->will($this->returnValue([]));
 
@@ -165,7 +170,7 @@ class CmsPageManagerTest extends TestCase
      */
     public function testGetPageWithId()
     {
-        $pageManager = $this->createMock('Sonata\PageBundle\Model\PageManagerInterface');
+        $pageManager = $this->createMock(PageManagerInterface::class);
 
         $pageManager->expects($this->any())->method('findOneBy')->will($this->returnValue(new Page()));
         $this->blockInteractor->expects($this->any())->method('loadPageBlocks')->will($this->returnValue([]));
@@ -175,7 +180,7 @@ class CmsPageManagerTest extends TestCase
         $page = 1;
         $site = new Site();
 
-        $this->assertInstanceOf('Sonata\PageBundle\Model\PageInterface', $manager->getPage($site, $page));
+        $this->assertInstanceOf(PageInterface::class, $manager->getPage($site, $page));
     }
 
     /**
@@ -183,10 +188,10 @@ class CmsPageManagerTest extends TestCase
      */
     public function testGetPageWithIdException()
     {
-        $this->expectException(\Sonata\PageBundle\Exception\PageNotFoundException::class);
+        $this->expectException(PageNotFoundException::class);
         $this->expectExceptionMessage('Unable to find the page : id = 1');
 
-        $pageManager = $this->createMock('Sonata\PageBundle\Model\PageManagerInterface');
+        $pageManager = $this->createMock(PageManagerInterface::class);
 
         $this->blockInteractor->expects($this->any())->method('loadPageBlocks')->will($this->returnValue([]));
 
@@ -206,7 +211,7 @@ class CmsPageManagerTest extends TestCase
      */
     public function testGetPageWithoutParam()
     {
-        $pageManager = $this->createMock('Sonata\PageBundle\Model\PageManagerInterface');
+        $pageManager = $this->createMock(PageManagerInterface::class);
 
         $pageManager->expects($this->any())->method('findOneBy')->will($this->returnValue(new Page()));
         $this->blockInteractor->expects($this->any())->method('loadPageBlocks')->will($this->returnValue([]));
@@ -216,7 +221,7 @@ class CmsPageManagerTest extends TestCase
         $page = null;
         $site = new Site();
 
-        $this->assertInstanceOf('Sonata\PageBundle\Model\PageInterface', $manager->getPage($site, $page));
+        $this->assertInstanceOf(PageInterface::class, $manager->getPage($site, $page));
     }
 
     /**
@@ -224,10 +229,10 @@ class CmsPageManagerTest extends TestCase
      */
     public function testGetPageWithoutParamException()
     {
-        $this->expectException(\Sonata\PageBundle\Exception\PageNotFoundException::class);
+        $this->expectException(PageNotFoundException::class);
         $this->expectExceptionMessage('Unable to retrieve the page');
 
-        $pageManager = $this->createMock('Sonata\PageBundle\Model\PageManagerInterface');
+        $pageManager = $this->createMock(PageManagerInterface::class);
 
         $this->blockInteractor->expects($this->any())->method('loadPageBlocks')->will($this->returnValue([]));
 
@@ -256,7 +261,7 @@ class CmsPageManagerTest extends TestCase
             return $block;
         };
 
-        $mock = $this->createMock('Sonata\PageBundle\Model\BlockInteractorInterface');
+        $mock = $this->createMock(BlockInteractorInterface::class);
         $mock->expects($this->any())->method('createNewContainer')->will($this->returnCallback($callback));
 
         return $mock;

--- a/tests/CmsManager/CmsSnapshotManagerTest.php
+++ b/tests/CmsManager/CmsSnapshotManagerTest.php
@@ -12,8 +12,17 @@
 namespace Sonata\PageBundle\Tests\Page;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\PageBundle\CmsManager\CmsSnapshotManager;
+use Sonata\PageBundle\Exception\PageNotFoundException;
 use Sonata\PageBundle\Model\Block;
+use Sonata\PageBundle\Model\BlockInteractorInterface;
+use Sonata\PageBundle\Model\PageInterface;
+use Sonata\PageBundle\Model\SiteInterface;
+use Sonata\PageBundle\Model\SnapshotInterface;
+use Sonata\PageBundle\Model\SnapshotManagerInterface;
+use Sonata\PageBundle\Model\SnapshotPageProxyInterface;
+use Sonata\PageBundle\Model\TransformerInterface;
 use Sonata\PageBundle\Tests\Model\Page;
 
 class SnapshotBlock extends Block
@@ -33,7 +42,7 @@ class SnapshotBlock extends Block
 class CmsSnapshotManagerTest extends TestCase
 {
     /**
-     * @var \Sonata\PageBundle\CmsManager\CmsSnapshotManager
+     * @var CmsSnapshotManager
      */
     protected $manager;
 
@@ -49,8 +58,8 @@ class CmsSnapshotManagerTest extends TestCase
     public function setUp()
     {
         $this->blockInteractor = $this->getMockBlockInteractor();
-        $this->snapshotManager = $this->createMock('Sonata\PageBundle\Model\SnapshotManagerInterface');
-        $this->transformer = $this->createMock('Sonata\PageBundle\Model\TransformerInterface');
+        $this->snapshotManager = $this->createMock(SnapshotManagerInterface::class);
+        $this->transformer = $this->createMock(TransformerInterface::class);
         $this->manager = new CmsSnapshotManager($this->snapshotManager, $this->transformer);
     }
 
@@ -84,11 +93,11 @@ class CmsSnapshotManagerTest extends TestCase
 
     public function testGetPageWithUnknownPage()
     {
-        $this->expectException(\Sonata\PageBundle\Exception\PageNotFoundException::class);
+        $this->expectException(PageNotFoundException::class);
 
         $this->snapshotManager->expects($this->once())->method('findEnableSnapshot')->will($this->returnValue(null));
 
-        $site = $this->createMock('Sonata\PageBundle\Model\SiteInterface');
+        $site = $this->createMock(SiteInterface::class);
 
         $snapshotManager = new CmsSnapshotManager($this->snapshotManager, $this->transformer);
 
@@ -97,16 +106,16 @@ class CmsSnapshotManagerTest extends TestCase
 
     public function testGetPageWithId()
     {
-        $cBlock = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
+        $cBlock = $this->createMock(BlockInterface::class);
         $cBlock->expects($this->any())->method('hasChildren')->will($this->returnValue(false));
         $cBlock->expects($this->any())->method('getId')->will($this->returnValue(2));
 
-        $pBlock = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
+        $pBlock = $this->createMock(BlockInterface::class);
         $pBlock->expects($this->any())->method('getChildren')->will($this->returnValue([$cBlock]));
         $pBlock->expects($this->any())->method('hasChildren')->will($this->returnValue(true));
         $pBlock->expects($this->any())->method('getId')->will($this->returnValue(1));
 
-        $page = $this->createMock('Sonata\PageBundle\Model\PageInterface');
+        $page = $this->createMock(PageInterface::class);
         $page->expects($this->any())->method('getBlocks')->will($this->returnCallback(function () use ($pBlock) {
             static $count;
 
@@ -119,7 +128,7 @@ class CmsSnapshotManagerTest extends TestCase
             return [$pBlock];
         }));
 
-        $snapshot = $this->createMock('Sonata\PageBundle\Model\SnapshotInterface');
+        $snapshot = $this->createMock(SnapshotInterface::class);
         $snapshot->expects($this->once())->method('getContent')->will($this->returnValue([
             // we don't care here about real values, the mock transformer will return the valid $pBlock instance
             'blocks' => [],
@@ -128,22 +137,22 @@ class CmsSnapshotManagerTest extends TestCase
         $this->snapshotManager->expects($this->once())->method('findEnableSnapshot')->will($this->returnValue($snapshot));
         $this->transformer->expects($this->once())->method('load')->will($this->returnValue($page));
 
-        $site = $this->createMock('Sonata\PageBundle\Model\SiteInterface');
+        $site = $this->createMock(SiteInterface::class);
 
         $snapshotManager = new CmsSnapshotManager($this->snapshotManager, $this->transformer);
 
         $page = $snapshotManager->getPage($site, 1);
 
-        $this->assertInstanceOf('Sonata\PageBundle\Model\SnapshotPageProxyInterface', $page);
+        $this->assertInstanceOf(SnapshotPageProxyInterface::class, $page);
 
-        $this->assertInstanceOf('Sonata\BlockBundle\Model\BlockInterface', $snapshotManager->getBlock(1));
-        $this->assertInstanceOf('Sonata\BlockBundle\Model\BlockInterface', $snapshotManager->getBlock(2));
+        $this->assertInstanceOf(BlockInterface::class, $snapshotManager->getBlock(1));
+        $this->assertInstanceOf(BlockInterface::class, $snapshotManager->getBlock(2));
     }
 
     /**
      * Returns a mock block interactor.
      *
-     * @return \Sonata\PageBundle\Model\BlockInteractorInterface
+     * @return BlockInteractorInterface
      */
     protected function getMockBlockInteractor()
     {
@@ -154,7 +163,7 @@ class CmsSnapshotManagerTest extends TestCase
             return $block;
         };
 
-        $mock = $this->createMock('Sonata\PageBundle\Model\BlockInteractorInterface');
+        $mock = $this->createMock(BlockInteractorInterface::class);
         $mock->expects($this->any())->method('createNewContainer')->will($this->returnCallback($callback));
 
         return $mock;

--- a/tests/Command/BaseCommandTest.php
+++ b/tests/Command/BaseCommandTest.php
@@ -13,6 +13,8 @@ namespace Sonata\PageBundle\Tests\Command;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\PageBundle\Command\BaseCommand;
+use Sonata\PageBundle\Entity\SiteManager;
+use Symfony\Component\Console\Input\InputInterface;
 
 /**
  * @author Vincent Composieux <vincent.composieux@gmail.com>
@@ -29,7 +31,7 @@ class BaseCommandTest extends TestCase
      */
     public function setUp()
     {
-        $this->command = $this->getMockBuilder('Sonata\PageBundle\Command\BaseCommand')
+        $this->command = $this->getMockBuilder(BaseCommand::class)
             ->disableOriginalConstructor()
             ->setMethods(['getSiteManager'])
             ->getMock();
@@ -44,9 +46,9 @@ class BaseCommandTest extends TestCase
         $method = new \ReflectionMethod($this->command, 'getSites');
         $method->setAccessible(true);
 
-        $input = $this->createMock('Symfony\Component\Console\Input\InputInterface');
+        $input = $this->createMock(InputInterface::class);
 
-        $siteManager = $this->getMockBuilder('Sonata\PageBundle\Entity\SiteManager')
+        $siteManager = $this->getMockBuilder(SiteManager::class)
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/tests/Command/CloneSiteCommandTest.php
+++ b/tests/Command/CloneSiteCommandTest.php
@@ -15,10 +15,14 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sonata\BlockBundle\Model\BlockManagerInterface;
 use Sonata\PageBundle\Command\CloneSiteCommand;
+use Sonata\PageBundle\Model\PageBlockInterface;
+use Sonata\PageBundle\Model\PageInterface;
 use Sonata\PageBundle\Model\PageManagerInterface;
+use Sonata\PageBundle\Model\SiteInterface;
 use Sonata\PageBundle\Model\SiteManagerInterface;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * @author Christian Gripp <mail@core23.de>
@@ -47,11 +51,11 @@ class CloneSiteCommandTest extends TestCase
 
     protected function setUp()
     {
-        $this->siteManager = $this->prophesize('Sonata\PageBundle\Model\SiteManagerInterface');
-        $this->pageManager = $this->prophesize('Sonata\PageBundle\Model\PageManagerInterface');
-        $this->blockManager = $this->prophesize('Sonata\BlockBundle\Model\BlockManagerInterface');
+        $this->siteManager = $this->prophesize(SiteManagerInterface::class);
+        $this->pageManager = $this->prophesize(PageManagerInterface::class);
+        $this->blockManager = $this->prophesize(BlockManagerInterface::class);
 
-        $container = $this->prophesize('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->prophesize(ContainerInterface::class);
         $container->get('sonata.page.manager.site')->willReturn($this->siteManager->reveal());
         $container->get('sonata.page.manager.page')->willReturn($this->pageManager->reveal());
         $container->get('sonata.page.manager.block')->willReturn($this->blockManager->reveal());
@@ -65,19 +69,19 @@ class CloneSiteCommandTest extends TestCase
 
     public function testExecute()
     {
-        $sourceSite = $this->prophesize('Sonata\PageBundle\Model\SiteInterface');
-        $destSite = $this->prophesize('Sonata\PageBundle\Model\SiteInterface');
+        $sourceSite = $this->prophesize(SiteInterface::class);
+        $destSite = $this->prophesize(SiteInterface::class);
 
         $this->siteManager->find(23)->willReturn($sourceSite->reveal());
         $this->siteManager->find(42)->willReturn($destSite->reveal());
 
-        $page1 = $this->prophesize('Sonata\PageBundle\Model\PageInterface');
+        $page1 = $this->prophesize(PageInterface::class);
         $page1->getId()->willReturn(1);
         $page1->getTitle()->willReturn('Page 1');
         $page1->getParent()->willReturn(null);
         $page1->isHybrid()->willReturn(true);
 
-        $page2 = $this->prophesize('Sonata\PageBundle\Model\PageInterface');
+        $page2 = $this->prophesize(PageInterface::class);
         $page2->getId()->willReturn(2);
         $page2->getTitle()->willReturn('Page 2');
         $page2->getParent()->willReturn($page1->reveal());
@@ -86,7 +90,7 @@ class CloneSiteCommandTest extends TestCase
 
         $page1->getTarget()->willReturn($page2->reveal());
 
-        $page3 = $this->prophesize('Sonata\PageBundle\Model\PageInterface');
+        $page3 = $this->prophesize(PageInterface::class);
         $page3->getId()->willReturn(3);
         $page3->isHybrid()->willReturn(false);
 
@@ -116,7 +120,7 @@ class CloneSiteCommandTest extends TestCase
         $this->pageManager->save($newPage2)->shouldBeCalled();
         $this->pageManager->save($newPage2, true)->shouldBeCalled();
 
-        $block = $this->prophesize('Sonata\PageBundle\Model\PageBlockInterface');
+        $block = $this->prophesize(PageBlockInterface::class);
         $block->getId()->willReturn(4711);
         $block->getParent()->willReturn(null);
 
@@ -151,7 +155,7 @@ class CloneSiteCommandTest extends TestCase
 
     public function testExecuteNoSourceId()
     {
-        $this->expectException('\InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Please provide a "--source-id=SITE_ID" option.');
 
         $this->siteManager->findAll()->willReturn([]);
@@ -169,7 +173,7 @@ class CloneSiteCommandTest extends TestCase
 
     public function testExecuteNoDestId()
     {
-        $this->expectException('\InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Please provide a "--dest-id=SITE_ID" option.');
 
         $this->siteManager->findAll()->willReturn([]);
@@ -187,7 +191,7 @@ class CloneSiteCommandTest extends TestCase
 
     public function testExecuteNoPrefix()
     {
-        $this->expectException('\InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Please provide a "--prefix=PREFIX" option.');
 
         $this->siteManager->findAll()->willReturn([]);

--- a/tests/Command/CreateBlockContainerCommandTest.php
+++ b/tests/Command/CreateBlockContainerCommandTest.php
@@ -18,7 +18,10 @@ use Sonata\PageBundle\Command\CreateBlockContainerCommand;
 use Sonata\PageBundle\Entity\BlockInteractor;
 use Sonata\PageBundle\Entity\BlockManager;
 use Sonata\PageBundle\Entity\PageManager;
+use Sonata\PageBundle\Model\PageBlockInterface;
 use Sonata\PageBundle\Tests\Model\Page;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class CreateBlockContainerCommandTest extends TestCase
@@ -45,13 +48,13 @@ class CreateBlockContainerCommandTest extends TestCase
 
     public function setUp()
     {
-        $this->blockInteractor = $this->prophesize('Sonata\PageBundle\Entity\BlockInteractor');
+        $this->blockInteractor = $this->prophesize(BlockInteractor::class);
 
-        $this->pageManager = $this->prophesize('Sonata\PageBundle\Entity\PageManager');
+        $this->pageManager = $this->prophesize(PageManager::class);
 
-        $this->blockManager = $this->prophesize('Sonata\PageBundle\Entity\BlockManager');
+        $this->blockManager = $this->prophesize(BlockManager::class);
 
-        $this->container = $this->prophesize('Symfony\Component\DependencyInjection\ContainerInterface');
+        $this->container = $this->prophesize(ContainerInterface::class);
         $this->container->get('sonata.page.block_interactor')->willReturn($this->blockInteractor);
         $this->container->get('sonata.page.manager.page')->willReturn($this->pageManager);
         $this->container->get('sonata.page.manager.block')->willReturn($this->blockManager);
@@ -62,7 +65,7 @@ class CreateBlockContainerCommandTest extends TestCase
      */
     public function testCreateBlock()
     {
-        $block = $this->prophesize('Sonata\PageBundle\Model\PageBlockInterface');
+        $block = $this->prophesize(PageBlockInterface::class);
         $this->blockInteractor->createNewContainer(Argument::any())->willReturn($block->reveal());
 
         $page = new Page();
@@ -72,12 +75,12 @@ class CreateBlockContainerCommandTest extends TestCase
         $command = new CreateBlockContainerCommand();
         $command->setContainer($this->container->reveal());
 
-        $input = $this->prophesize('Symfony\Component\Console\Input\InputInterface');
+        $input = $this->prophesize(InputInterface::class);
         $input->getArgument('templateCode')->willReturn('foo');
         $input->getArgument('blockCode')->willReturn('content_bar');
         $input->getArgument('blockName')->willReturn('Baz!');
 
-        $output = $this->prophesize('Symfony\Component\Console\Output\OutputInterface');
+        $output = $this->prophesize(OutputInterface::class);
 
         $method = new \ReflectionMethod($command, 'execute');
         $method->setAccessible(true);

--- a/tests/Controller/Api/AjaxControllerTest.php
+++ b/tests/Controller/Api/AjaxControllerTest.php
@@ -12,6 +12,13 @@
 namespace Sonata\PageBundle\Tests\Controller\Api;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Block\BlockContextManagerInterface;
+use Sonata\BlockBundle\Block\BlockRendererInterface;
+use Sonata\BlockBundle\Exception\BlockNotFoundException;
+use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\PageBundle\CmsManager\CmsManagerInterface;
+use Sonata\PageBundle\CmsManager\CmsManagerSelectorInterface;
 use Sonata\PageBundle\Controller\AjaxController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -23,16 +30,16 @@ class AjaxControllerTest extends TestCase
 {
     public function testWithInvalidBlock()
     {
-        $this->expectException(\Sonata\BlockBundle\Exception\BlockNotFoundException::class);
+        $this->expectException(BlockNotFoundException::class);
 
-        $cmsManager = $this->createMock('Sonata\PageBundle\CmsManager\CmsManagerInterface');
+        $cmsManager = $this->createMock(CmsManagerInterface::class);
 
-        $selector = $this->createMock('Sonata\PageBundle\CmsManager\CmsManagerSelectorInterface');
+        $selector = $this->createMock(CmsManagerSelectorInterface::class);
         $selector->expects($this->once())->method('retrieve')->will($this->returnValue($cmsManager));
 
-        $renderer = $this->createMock('Sonata\BlockBundle\Block\BlockRendererInterface');
+        $renderer = $this->createMock(BlockRendererInterface::class);
 
-        $contextManager = $this->createMock('\Sonata\BlockBundle\Block\BlockContextManagerInterface');
+        $contextManager = $this->createMock(BlockContextManagerInterface::class);
 
         $controller = new AjaxController($selector, $renderer, $contextManager);
 
@@ -43,20 +50,20 @@ class AjaxControllerTest extends TestCase
 
     public function testRenderer()
     {
-        $block = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block = $this->createMock(BlockInterface::class);
 
-        $cmsManager = $this->createMock('Sonata\PageBundle\CmsManager\CmsManagerInterface');
+        $cmsManager = $this->createMock(CmsManagerInterface::class);
         $cmsManager->expects($this->once())->method('getBlock')->will($this->returnValue($block));
 
-        $selector = $this->createMock('Sonata\PageBundle\CmsManager\CmsManagerSelectorInterface');
+        $selector = $this->createMock(CmsManagerSelectorInterface::class);
         $selector->expects($this->once())->method('retrieve')->will($this->returnValue($cmsManager));
 
-        $renderer = $this->createMock('Sonata\BlockBundle\Block\BlockRendererInterface');
+        $renderer = $this->createMock(BlockRendererInterface::class);
         $renderer->expects($this->once())->method('render')->will($this->returnValue(new Response()));
 
-        $blockContext = $this->createMock('Sonata\BlockBundle\Block\BlockContextInterface');
+        $blockContext = $this->createMock(BlockContextInterface::class);
 
-        $contextManager = $this->createMock('\Sonata\BlockBundle\Block\BlockContextManagerInterface');
+        $contextManager = $this->createMock(BlockContextManagerInterface::class);
         $contextManager->expects($this->once())->method('get')->will($this->returnValue($blockContext));
 
         $controller = new AjaxController($selector, $renderer, $contextManager);
@@ -65,6 +72,6 @@ class AjaxControllerTest extends TestCase
 
         $response = $controller->execute($request, 10, 12);
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
+        $this->assertInstanceOf(Response::class, $response);
     }
 }

--- a/tests/Controller/Api/BlockControllerTest.php
+++ b/tests/Controller/Api/BlockControllerTest.php
@@ -11,9 +11,16 @@
 
 namespace Sonata\PageBundle\Tests\Controller\Api;
 
+use FOS\RestBundle\View\View;
 use PHPUnit\Framework\TestCase;
+use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\BlockBundle\Model\BlockManagerInterface;
 use Sonata\PageBundle\Controller\Api\BlockController;
+use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
  * @author Vincent Composieux <vincent.composieux@gmail.com>
@@ -22,14 +29,14 @@ class BlockControllerTest extends TestCase
 {
     public function testGetBlockAction()
     {
-        $block = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block = $this->createMock(BlockInterface::class);
 
         $this->assertEquals($block, $this->createBlockController($block)->getBlockAction(1));
     }
 
     public function testGetBlockActionNotFoundException()
     {
-        $this->expectException(\Symfony\Component\HttpKernel\Exception\NotFoundHttpException::class);
+        $this->expectException(NotFoundHttpException::class);
         $this->expectExceptionMessage('Block (42) not found');
 
         $this->createBlockController()->getBlockAction(42);
@@ -37,48 +44,48 @@ class BlockControllerTest extends TestCase
 
     public function testPutBlockAction()
     {
-        $block = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block = $this->createMock(BlockInterface::class);
 
-        $blockManager = $this->createMock('Sonata\BlockBundle\Model\BlockManagerInterface');
+        $blockManager = $this->createMock(BlockManagerInterface::class);
         $blockManager->expects($this->once())->method('save')->will($this->returnValue($block));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form = $this->getMockBuilder(Form::class)->disableOriginalConstructor()->getMock();
         $form->expects($this->once())->method('submit');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($block));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createBlockController($block, $blockManager, $formFactory)->putBlockAction(1, new Request());
 
-        $this->assertInstanceOf('FOS\RestBundle\View\View', $view);
+        $this->assertInstanceOf(View::class, $view);
     }
 
     public function testPutBlockInvalidAction()
     {
-        $block = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block = $this->createMock(BlockInterface::class);
 
-        $blockManager = $this->createMock('Sonata\BlockBundle\Model\BlockManagerInterface');
+        $blockManager = $this->createMock(BlockManagerInterface::class);
         $blockManager->expects($this->never())->method('save')->will($this->returnValue($block));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form = $this->getMockBuilder(Form::class)->disableOriginalConstructor()->getMock();
         $form->expects($this->once())->method('submit');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createBlockController($block, $blockManager, $formFactory)->putBlockAction(1, new Request());
 
-        $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $view);
+        $this->assertInstanceOf(FormInterface::class, $view);
     }
 
     public function testDeleteBlockAction()
     {
-        $block = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block = $this->createMock(BlockInterface::class);
 
-        $blockManager = $this->createMock('Sonata\BlockBundle\Model\BlockManagerInterface');
+        $blockManager = $this->createMock(BlockManagerInterface::class);
         $blockManager->expects($this->once())->method('delete');
 
         $view = $this->createBlockController($block, $blockManager)->deleteBlockAction(1);
@@ -88,9 +95,9 @@ class BlockControllerTest extends TestCase
 
     public function testDeleteBlockInvalidAction()
     {
-        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
+        $this->expectException(NotFoundHttpException::class);
 
-        $blockManager = $this->createMock('Sonata\BlockBundle\Model\BlockManagerInterface');
+        $blockManager = $this->createMock(BlockManagerInterface::class);
         $blockManager->expects($this->never())->method('delete');
 
         $this->createBlockController(null, $blockManager)->deleteBlockAction(1);
@@ -106,13 +113,13 @@ class BlockControllerTest extends TestCase
     public function createBlockController($block = null, $blockManager = null, $formFactory = null)
     {
         if (null === $blockManager) {
-            $blockManager = $this->createMock('Sonata\BlockBundle\Model\BlockManagerInterface');
+            $blockManager = $this->createMock(BlockManagerInterface::class);
         }
         if (null !== $block) {
             $blockManager->expects($this->once())->method('findOneBy')->will($this->returnValue($block));
         }
         if (null === $formFactory) {
-            $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+            $formFactory = $this->createMock(FormFactoryInterface::class);
         }
 
         return new BlockController($blockManager, $formFactory);

--- a/tests/Controller/Api/PageControllerTest.php
+++ b/tests/Controller/Api/PageControllerTest.php
@@ -11,9 +11,24 @@
 
 namespace Sonata\PageBundle\Tests\Controller\Api;
 
+use FOS\RestBundle\Request\ParamFetcherInterface;
+use FOS\RestBundle\View\View;
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Datagrid\Pager;
+use Sonata\BlockBundle\Model\BlockManagerInterface;
+use Sonata\NotificationBundle\Backend\BackendInterface;
 use Sonata\PageBundle\Controller\Api\PageController;
+use Sonata\PageBundle\Model\Block;
+use Sonata\PageBundle\Model\PageBlockInterface;
+use Sonata\PageBundle\Model\PageInterface;
+use Sonata\PageBundle\Model\PageManagerInterface;
+use Sonata\PageBundle\Model\SiteInterface;
+use Sonata\PageBundle\Model\SiteManagerInterface;
+use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
@@ -22,9 +37,9 @@ class PageControllerTest extends TestCase
 {
     public function testGetPagesAction()
     {
-        $pager = $this->getMockBuilder('Sonata\AdminBundle\Datagrid\Pager')->disableOriginalConstructor()->getMock();
+        $pager = $this->getMockBuilder(Pager::class)->disableOriginalConstructor()->getMock();
 
-        $paramFetcher = $this->getMockBuilder('FOS\RestBundle\Request\ParamFetcherInterface')
+        $paramFetcher = $this->getMockBuilder(ParamFetcherInterface::class)
             ->setMethods(['addParam', 'setController', 'get', 'all'])
             ->getMock();
 
@@ -32,7 +47,7 @@ class PageControllerTest extends TestCase
         $paramFetcher->expects($this->exactly(3))->method('get');
         $paramFetcher->expects($this->once())->method('all')->will($this->returnValue([]));
 
-        $pageManager = $this->getMockBuilder('Sonata\PageBundle\Model\PageManagerInterface')->getMock();
+        $pageManager = $this->getMockBuilder(PageManagerInterface::class)->getMock();
         $pageManager->expects($this->once())->method('getPager')->will($this->returnValue($pager));
 
         $this->assertSame($pager, $this->createPageController(null, null, $pageManager)->getPagesAction($paramFetcher));
@@ -40,14 +55,14 @@ class PageControllerTest extends TestCase
 
     public function testGetPageAction()
     {
-        $page = $this->createMock('Sonata\PageBundle\Model\PageInterface');
+        $page = $this->createMock(PageInterface::class);
 
         $this->assertEquals($page, $this->createPageController($page)->getPageAction(1));
     }
 
     public function testGetPageActionNotFoundException()
     {
-        $this->expectException(\Symfony\Component\HttpKernel\Exception\NotFoundHttpException::class);
+        $this->expectException(NotFoundHttpException::class);
         $this->expectExceptionMessage('Page (42) not found');
 
         $this->createPageController()->getPageAction(42);
@@ -55,8 +70,8 @@ class PageControllerTest extends TestCase
 
     public function testGetPageBlocksAction()
     {
-        $page = $this->createMock('Sonata\PageBundle\Model\PageInterface');
-        $block = $this->createMock('Sonata\PageBundle\Model\PageBlockInterface');
+        $page = $this->createMock(PageInterface::class);
+        $block = $this->createMock(PageBlockInterface::class);
 
         $page->expects($this->once())->method('getBlocks')->will($this->returnValue([$block]));
 
@@ -65,87 +80,87 @@ class PageControllerTest extends TestCase
 
     public function testPostPageAction()
     {
-        $page = $this->createMock('Sonata\PageBundle\Model\PageInterface');
+        $page = $this->createMock(PageInterface::class);
 
-        $pageManager = $this->createMock('Sonata\PageBundle\Model\PageManagerInterface');
+        $pageManager = $this->createMock(PageManagerInterface::class);
         $pageManager->expects($this->once())->method('save')->will($this->returnValue($page));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form = $this->getMockBuilder(Form::class)->disableOriginalConstructor()->getMock();
         $form->expects($this->once())->method('submit');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($page));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createPageController(null, null, $pageManager, null, $formFactory)->postPageAction(new Request());
 
-        $this->assertInstanceOf('FOS\RestBundle\View\View', $view);
+        $this->assertInstanceOf(View::class, $view);
     }
 
     public function testPostPageInvalidAction()
     {
-        $page = $this->createMock('Sonata\PageBundle\Model\PageInterface');
+        $page = $this->createMock(PageInterface::class);
 
-        $pageManager = $this->createMock('Sonata\PageBundle\Model\PageManagerInterface');
+        $pageManager = $this->createMock(PageManagerInterface::class);
         $pageManager->expects($this->never())->method('save')->will($this->returnValue($page));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form = $this->getMockBuilder(Form::class)->disableOriginalConstructor()->getMock();
         $form->expects($this->once())->method('submit');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createPageController(null, null, $pageManager, null, $formFactory)->postPageAction(new Request());
 
-        $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $view);
+        $this->assertInstanceOf(FormInterface::class, $view);
     }
 
     public function testPutPageAction()
     {
-        $page = $this->createMock('Sonata\PageBundle\Model\PageInterface');
+        $page = $this->createMock(PageInterface::class);
 
-        $pageManager = $this->createMock('Sonata\PageBundle\Model\PageManagerInterface');
+        $pageManager = $this->createMock(PageManagerInterface::class);
         $pageManager->expects($this->once())->method('save')->will($this->returnValue($page));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form = $this->getMockBuilder(Form::class)->disableOriginalConstructor()->getMock();
         $form->expects($this->once())->method('submit');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($page));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createPageController($page, null, $pageManager, null, $formFactory)->putPageAction(1, new Request());
 
-        $this->assertInstanceOf('FOS\RestBundle\View\View', $view);
+        $this->assertInstanceOf(View::class, $view);
     }
 
     public function testPutPageInvalidAction()
     {
-        $page = $this->createMock('Sonata\PageBundle\Model\PageInterface');
+        $page = $this->createMock(PageInterface::class);
 
-        $pageManager = $this->createMock('Sonata\PageBundle\Model\PageManagerInterface');
+        $pageManager = $this->createMock(PageManagerInterface::class);
         $pageManager->expects($this->never())->method('save')->will($this->returnValue($page));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form = $this->getMockBuilder(Form::class)->disableOriginalConstructor()->getMock();
         $form->expects($this->once())->method('submit');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createPageController($page, null, $pageManager, null, $formFactory)->putPageAction(1, new Request());
 
-        $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $view);
+        $this->assertInstanceOf(FormInterface::class, $view);
     }
 
     public function testDeletePageAction()
     {
-        $page = $this->createMock('Sonata\PageBundle\Model\PageInterface');
+        $page = $this->createMock(PageInterface::class);
 
-        $pageManager = $this->createMock('Sonata\PageBundle\Model\PageManagerInterface');
+        $pageManager = $this->createMock(PageManagerInterface::class);
         $pageManager->expects($this->once())->method('delete');
 
         $view = $this->createPageController($page, null, $pageManager)->deletePageAction(1);
@@ -155,9 +170,9 @@ class PageControllerTest extends TestCase
 
     public function testDeletePageInvalidAction()
     {
-        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
+        $this->expectException(NotFoundHttpException::class);
 
-        $pageManager = $this->createMock('Sonata\PageBundle\Model\PageManagerInterface');
+        $pageManager = $this->createMock(PageManagerInterface::class);
         $pageManager->expects($this->never())->method('delete');
 
         $this->createPageController(null, null, $pageManager)->deletePageAction(1);
@@ -165,57 +180,57 @@ class PageControllerTest extends TestCase
 
     public function testPostPageBlockAction()
     {
-        $block = $this->createMock('Sonata\PageBundle\Model\Block');
+        $block = $this->createMock(Block::class);
         $block->expects($this->once())->method('setPage');
 
-        $page = $this->createMock('Sonata\PageBundle\Model\PageInterface');
+        $page = $this->createMock(PageInterface::class);
 
-        $pageManager = $this->createMock('Sonata\PageBundle\Model\PageManagerInterface');
+        $pageManager = $this->createMock(PageManagerInterface::class);
 
-        $blockManager = $this->createMock('Sonata\BlockBundle\Model\BlockManagerInterface');
+        $blockManager = $this->createMock(BlockManagerInterface::class);
         $blockManager->expects($this->once())->method('save')->will($this->returnValue($block));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form = $this->getMockBuilder(Form::class)->disableOriginalConstructor()->getMock();
         $form->expects($this->once())->method('submit');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($block));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createPageController($page, null, $pageManager, $blockManager, $formFactory)->postPageBlockAction(1, new Request());
 
-        $this->assertInstanceOf('FOS\RestBundle\View\View', $view);
+        $this->assertInstanceOf(View::class, $view);
     }
 
     public function testPostPageBlockInvalidAction()
     {
-        $block = $this->createMock('Sonata\PageBundle\Model\Block');
+        $block = $this->createMock(Block::class);
 
-        $page = $this->createMock('Sonata\PageBundle\Model\PageInterface');
+        $page = $this->createMock(PageInterface::class);
 
-        $pageManager = $this->createMock('Sonata\PageBundle\Model\PageManagerInterface');
+        $pageManager = $this->createMock(PageManagerInterface::class);
 
-        $blockManager = $this->createMock('Sonata\BlockBundle\Model\BlockManagerInterface');
+        $blockManager = $this->createMock(BlockManagerInterface::class);
         $blockManager->expects($this->never())->method('save')->will($this->returnValue($block));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form = $this->getMockBuilder(Form::class)->disableOriginalConstructor()->getMock();
         $form->expects($this->once())->method('submit');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createPageController($page, null, $pageManager, $blockManager, $formFactory)->postPageBlockAction(1, new Request());
 
-        $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $view);
+        $this->assertInstanceOf(FormInterface::class, $view);
     }
 
     public function testPostPageSnapshotAction()
     {
-        $page = $this->createMock('Sonata\PageBundle\Model\PageInterface');
+        $page = $this->createMock(PageInterface::class);
 
-        $backend = $this->createMock('Sonata\NotificationBundle\Backend\BackendInterface');
+        $backend = $this->createMock(BackendInterface::class);
         $backend->expects($this->once())->method('createAndPublish');
 
         $view = $this->createPageController($page, null, null, null, null, $backend)->postPageSnapshotAction(1);
@@ -225,12 +240,12 @@ class PageControllerTest extends TestCase
 
     public function testPostPagesSnapshotsAction()
     {
-        $site = $this->createMock('Sonata\PageBundle\Model\SiteInterface');
+        $site = $this->createMock(SiteInterface::class);
 
-        $siteManager = $this->createMock('Sonata\PageBundle\Model\SiteManagerInterface');
+        $siteManager = $this->createMock(SiteManagerInterface::class);
         $siteManager->expects($this->once())->method('findAll')->will($this->returnValue([$site]));
 
-        $backend = $this->createMock('Sonata\NotificationBundle\Backend\BackendInterface');
+        $backend = $this->createMock(BackendInterface::class);
         $backend->expects($this->once())->method('createAndPublish');
 
         $view = $this->createPageController(null, $siteManager, null, null, null, $backend)->postPagesSnapshotsAction();
@@ -251,22 +266,22 @@ class PageControllerTest extends TestCase
     public function createPageController($page = null, $siteManager = null, $pageManager = null, $blockManager = null, $formFactory = null, $backend = null)
     {
         if (null === $siteManager) {
-            $siteManager = $this->createMock('Sonata\PageBundle\Model\SiteManagerInterface');
+            $siteManager = $this->createMock(SiteManagerInterface::class);
         }
         if (null === $pageManager) {
-            $pageManager = $this->createMock('Sonata\PageBundle\Model\PageManagerInterface');
+            $pageManager = $this->createMock(PageManagerInterface::class);
         }
         if (null === $blockManager) {
-            $blockManager = $this->createMock('Sonata\BlockBundle\Model\BlockManagerInterface');
+            $blockManager = $this->createMock(BlockManagerInterface::class);
         }
         if (null !== $page) {
             $pageManager->expects($this->once())->method('findOneBy')->will($this->returnValue($page));
         }
         if (null === $formFactory) {
-            $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+            $formFactory = $this->createMock(FormFactoryInterface::class);
         }
         if (null === $backend) {
-            $backend = $this->createMock('Sonata\NotificationBundle\Backend\BackendInterface');
+            $backend = $this->createMock(BackendInterface::class);
         }
 
         return new PageController($siteManager, $pageManager, $blockManager, $formFactory, $backend);

--- a/tests/Controller/Api/SiteControllerTest.php
+++ b/tests/Controller/Api/SiteControllerTest.php
@@ -11,9 +11,17 @@
 
 namespace Sonata\PageBundle\Tests\Controller\Api;
 
+use FOS\RestBundle\Request\ParamFetcherInterface;
+use FOS\RestBundle\View\View;
 use PHPUnit\Framework\TestCase;
 use Sonata\PageBundle\Controller\Api\SiteController;
+use Sonata\PageBundle\Model\SiteInterface;
+use Sonata\PageBundle\Model\SiteManagerInterface;
+use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
  * @author Benoit de Jacobet <benoit.de-jacobet@ekino.com>
@@ -22,10 +30,10 @@ class SiteControllerTest extends TestCase
 {
     public function testGetSitesAction()
     {
-        $siteManager = $this->getMockBuilder('Sonata\PageBundle\Model\SiteManagerInterface')->getMock();
+        $siteManager = $this->getMockBuilder(SiteManagerInterface::class)->getMock();
         $siteManager->expects($this->once())->method('getPager')->will($this->returnValue([]));
 
-        $paramFetcher = $this->getMockBuilder('FOS\RestBundle\Request\ParamFetcherInterface')
+        $paramFetcher = $this->getMockBuilder(ParamFetcherInterface::class)
             ->setMethods(['addParam', 'setController', 'get', 'all'])
             ->getMock();
 
@@ -38,14 +46,14 @@ class SiteControllerTest extends TestCase
 
     public function testGetSiteAction()
     {
-        $site = $this->createMock('Sonata\PageBundle\Model\SiteInterface');
+        $site = $this->createMock(SiteInterface::class);
 
         $this->assertEquals($site, $this->createSiteController($site)->getSiteAction(1));
     }
 
     public function testGetSiteActionNotFoundException()
     {
-        $this->expectException(\Symfony\Component\HttpKernel\Exception\NotFoundHttpException::class);
+        $this->expectException(NotFoundHttpException::class);
         $this->expectExceptionMessage('Site (1) not found');
 
         $this->createSiteController()->getSiteAction(1);
@@ -53,87 +61,87 @@ class SiteControllerTest extends TestCase
 
     public function testPostSiteAction()
     {
-        $site = $this->createMock('Sonata\PageBundle\Model\SiteInterface');
+        $site = $this->createMock(SiteInterface::class);
 
-        $siteManager = $this->createMock('Sonata\PageBundle\Model\SiteManagerInterface');
+        $siteManager = $this->createMock(SiteManagerInterface::class);
         $siteManager->expects($this->once())->method('save')->will($this->returnValue($site));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form = $this->getMockBuilder(Form::class)->disableOriginalConstructor()->getMock();
         $form->expects($this->once())->method('submit');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($site));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createSiteController(null, $siteManager, $formFactory)->postSiteAction(new Request());
 
-        $this->assertInstanceOf('FOS\RestBundle\View\View', $view);
+        $this->assertInstanceOf(View::class, $view);
     }
 
     public function testPostSiteInvalidAction()
     {
-        $site = $this->createMock('Sonata\PageBundle\Model\SiteInterface');
+        $site = $this->createMock(SiteInterface::class);
 
-        $siteManager = $this->createMock('Sonata\PageBundle\Model\SiteManagerInterface');
+        $siteManager = $this->createMock(SiteManagerInterface::class);
         $siteManager->expects($this->never())->method('save')->will($this->returnValue($site));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form = $this->getMockBuilder(Form::class)->disableOriginalConstructor()->getMock();
         $form->expects($this->once())->method('submit');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createSiteController(null, $siteManager, $formFactory)->postSiteAction(new Request());
 
-        $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $view);
+        $this->assertInstanceOf(FormInterface::class, $view);
     }
 
     public function testPutSiteAction()
     {
-        $site = $this->createMock('Sonata\PageBundle\Model\SiteInterface');
+        $site = $this->createMock(SiteInterface::class);
 
-        $siteManager = $this->createMock('Sonata\PageBundle\Model\SiteManagerInterface');
+        $siteManager = $this->createMock(SiteManagerInterface::class);
         $siteManager->expects($this->once())->method('save')->will($this->returnValue($site));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form = $this->getMockBuilder(Form::class)->disableOriginalConstructor()->getMock();
         $form->expects($this->once())->method('submit');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($site));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createSiteController($site, $siteManager, $formFactory)->putSiteAction(1, new Request());
 
-        $this->assertInstanceOf('FOS\RestBundle\View\View', $view);
+        $this->assertInstanceOf(View::class, $view);
     }
 
     public function testPutSiteInvalidAction()
     {
-        $site = $this->createMock('Sonata\PageBundle\Model\SiteInterface');
+        $site = $this->createMock(SiteInterface::class);
 
-        $siteManager = $this->createMock('Sonata\PageBundle\Model\SiteManagerInterface');
+        $siteManager = $this->createMock(SiteManagerInterface::class);
         $siteManager->expects($this->never())->method('save')->will($this->returnValue($site));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form = $this->getMockBuilder(Form::class)->disableOriginalConstructor()->getMock();
         $form->expects($this->once())->method('submit');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createSiteController($site, $siteManager, $formFactory)->putSiteAction(1, new Request());
 
-        $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $view);
+        $this->assertInstanceOf(FormInterface::class, $view);
     }
 
     public function testDeleteSiteAction()
     {
-        $site = $this->createMock('Sonata\PageBundle\Model\SiteInterface');
+        $site = $this->createMock(SiteInterface::class);
 
-        $siteManager = $this->createMock('Sonata\PageBundle\Model\SiteManagerInterface');
+        $siteManager = $this->createMock(SiteManagerInterface::class);
         $siteManager->expects($this->once())->method('delete');
 
         $view = $this->createSiteController($site, $siteManager)->deleteSiteAction(1);
@@ -143,9 +151,9 @@ class SiteControllerTest extends TestCase
 
     public function testDeleteSiteInvalidAction()
     {
-        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
+        $this->expectException(NotFoundHttpException::class);
 
-        $siteManager = $this->createMock('Sonata\PageBundle\Model\SiteManagerInterface');
+        $siteManager = $this->createMock(SiteManagerInterface::class);
         $siteManager->expects($this->never())->method('delete');
 
         $this->createSiteController(null, $siteManager)->deleteSiteAction(1);
@@ -161,13 +169,13 @@ class SiteControllerTest extends TestCase
     public function createSiteController($site = null, $siteManager = null, $formFactory = null)
     {
         if (null === $siteManager) {
-            $siteManager = $this->createMock('Sonata\PageBundle\Model\SiteManagerInterface');
+            $siteManager = $this->createMock(SiteManagerInterface::class);
         }
         if (null !== $site) {
             $siteManager->expects($this->once())->method('findOneBy')->will($this->returnValue($site));
         }
         if (null === $formFactory) {
-            $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+            $formFactory = $this->createMock(FormFactoryInterface::class);
         }
 
         return new SiteController($siteManager, $formFactory);

--- a/tests/Controller/Api/SnapshotControllerTest.php
+++ b/tests/Controller/Api/SnapshotControllerTest.php
@@ -11,8 +11,12 @@
 
 namespace Sonata\PageBundle\Tests\Controller\Api;
 
+use FOS\RestBundle\Request\ParamFetcherInterface;
 use PHPUnit\Framework\TestCase;
 use Sonata\PageBundle\Controller\Api\SnapshotController;
+use Sonata\PageBundle\Model\SnapshotInterface;
+use Sonata\PageBundle\Model\SnapshotManagerInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
  * @author Benoit de Jacobet <benoit.de-jacobet@ekino.com>
@@ -21,10 +25,10 @@ class SnapshotControllerTest extends TestCase
 {
     public function testGetSnapshotsAction()
     {
-        $snapshotManager = $this->getMockBuilder('Sonata\PageBundle\Model\SnapshotManagerInterface')->getMock();
+        $snapshotManager = $this->getMockBuilder(SnapshotManagerInterface::class)->getMock();
         $snapshotManager->expects($this->once())->method('getPager')->will($this->returnValue([]));
 
-        $paramFetcher = $this->getMockBuilder('FOS\RestBundle\Request\ParamFetcherInterface')
+        $paramFetcher = $this->getMockBuilder(ParamFetcherInterface::class)
             ->setMethods(['addParam', 'setController', 'get', 'all'])
             ->getMock();
 
@@ -37,14 +41,14 @@ class SnapshotControllerTest extends TestCase
 
     public function testGetSnapshotAction()
     {
-        $snapshot = $this->createMock('Sonata\PageBundle\Model\SnapshotInterface');
+        $snapshot = $this->createMock(SnapshotInterface::class);
 
         $this->assertEquals($snapshot, $this->createSnapshotController($snapshot)->getSnapshotAction(1));
     }
 
     public function testGetSnapshotActionNotFoundException()
     {
-        $this->expectException(\Symfony\Component\HttpKernel\Exception\NotFoundHttpException::class);
+        $this->expectException(NotFoundHttpException::class);
         $this->expectExceptionMessage('Snapshot (1) not found');
 
         $this->createSnapshotController()->getSnapshotAction(1);
@@ -52,9 +56,9 @@ class SnapshotControllerTest extends TestCase
 
     public function testDeleteSnapshotAction()
     {
-        $snapshot = $this->createMock('Sonata\PageBundle\Model\SnapshotInterface');
+        $snapshot = $this->createMock(SnapshotInterface::class);
 
-        $snapshotManager = $this->createMock('Sonata\PageBundle\Model\SnapshotManagerInterface');
+        $snapshotManager = $this->createMock(SnapshotManagerInterface::class);
         $snapshotManager->expects($this->once())->method('delete');
 
         $view = $this->createSnapshotController($snapshot, $snapshotManager)->deleteSnapshotAction(1);
@@ -64,9 +68,9 @@ class SnapshotControllerTest extends TestCase
 
     public function testDeletePageInvalidAction()
     {
-        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
+        $this->expectException(NotFoundHttpException::class);
 
-        $snapshotManager = $this->createMock('Sonata\PageBundle\Model\SnapshotManagerInterface');
+        $snapshotManager = $this->createMock(SnapshotManagerInterface::class);
         $snapshotManager->expects($this->never())->method('delete');
 
         $this->createSnapshotController(null, $snapshotManager)->deleteSnapshotAction(1);
@@ -81,7 +85,7 @@ class SnapshotControllerTest extends TestCase
     public function createSnapshotController($snapshot = null, $snapshotManager = null)
     {
         if (null === $snapshotManager) {
-            $snapshotManager = $this->createMock('Sonata\PageBundle\Model\SnapshotManagerInterface');
+            $snapshotManager = $this->createMock(SnapshotManagerInterface::class);
         }
         if (null !== $snapshot) {
             $snapshotManager->expects($this->once())->method('findOneBy')->will($this->returnValue($snapshot));

--- a/tests/Entity/BlockManagerTest.php
+++ b/tests/Entity/BlockManagerTest.php
@@ -11,7 +11,13 @@
 
 namespace Sonata\PageBundle\Tests\Entity;
 
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\ORM\AbstractQuery;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\QueryBuilder;
 use PHPUnit\Framework\TestCase;
+use Sonata\PageBundle\Entity\BasePage;
 use Sonata\PageBundle\Entity\BlockManager;
 
 class BlockManagerTest extends TestCase
@@ -30,12 +36,12 @@ class BlockManagerTest extends TestCase
 
     protected function getBlockManager($qbCallback)
     {
-        $query = $this->getMockForAbstractClass('Doctrine\ORM\AbstractQuery', [], '', false, true, true, ['execute']);
+        $query = $this->getMockForAbstractClass(AbstractQuery::class, [], '', false, true, true, ['execute']);
         $query->expects($this->any())->method('execute')->will($this->returnValue(true));
 
-        $qb = $this->getMockBuilder('Doctrine\ORM\QueryBuilder')
+        $qb = $this->getMockBuilder(QueryBuilder::class)
             ->setConstructorArgs([
-                $this->getMockBuilder('Doctrine\ORM\EntityManager')
+                $this->getMockBuilder(EntityManager::class)
                     ->disableOriginalConstructor()
                     ->getMock(),
             ])
@@ -47,15 +53,15 @@ class BlockManagerTest extends TestCase
 
         $qbCallback($qb);
 
-        $repository = $this->getMockBuilder('Doctrine\ORM\EntityRepository')->disableOriginalConstructor()->getMock();
+        $repository = $this->getMockBuilder(EntityRepository::class)->disableOriginalConstructor()->getMock();
         $repository->expects($this->any())->method('createQueryBuilder')->will($this->returnValue($qb));
 
-        $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')->disableOriginalConstructor()->getMock();
+        $em = $this->getMockBuilder(EntityManager::class)->disableOriginalConstructor()->getMock();
         $em->expects($this->any())->method('getRepository')->will($this->returnValue($repository));
 
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock(ManagerRegistry::class);
         $registry->expects($this->any())->method('getManagerForClass')->will($this->returnValue($em));
 
-        return new BlockManager('Sonata\PageBundle\Entity\BasePage', $registry);
+        return new BlockManager(BasePage::class, $registry);
     }
 }

--- a/tests/Entity/PageManagerTest.php
+++ b/tests/Entity/PageManagerTest.php
@@ -11,7 +11,14 @@
 
 namespace Sonata\PageBundle\Tests\Entity;
 
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\ORM\AbstractQuery;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\QueryBuilder;
 use PHPUnit\Framework\TestCase;
+use Sonata\PageBundle\Entity\BasePage;
 use Sonata\PageBundle\Entity\PageManager;
 use Sonata\PageBundle\Tests\Model\Page;
 
@@ -19,7 +26,7 @@ class PageManagerTest extends TestCase
 {
     public function testFixUrl()
     {
-        $entityManager = $this->getMockBuilder('Doctrine\Common\Persistence\ManagerRegistry')
+        $entityManager = $this->getMockBuilder(ManagerRegistry::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -63,7 +70,7 @@ class PageManagerTest extends TestCase
 
     public function testWithSlashAtTheEnd()
     {
-        $entityManager = $this->getMockBuilder('Doctrine\Common\Persistence\ManagerRegistry')
+        $entityManager = $this->getMockBuilder(ManagerRegistry::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -90,11 +97,11 @@ class PageManagerTest extends TestCase
 
     public function testCreateWithGlobalDefaults()
     {
-        $entityManager = $this->getMockBuilder('Doctrine\Common\Persistence\ManagerRegistry')
+        $entityManager = $this->getMockBuilder(ManagerRegistry::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $manager = new PageManager('Sonata\PageBundle\Tests\Model\Page', $entityManager, [], ['my_route' => ['decorate' => false, 'name' => 'Salut!']]);
+        $manager = new PageManager(Page::class, $entityManager, [], ['my_route' => ['decorate' => false, 'name' => 'Salut!']]);
 
         $page = $manager->create(['name' => 'My Name', 'routeName' => 'my_route']);
 
@@ -249,12 +256,12 @@ class PageManagerTest extends TestCase
 
     protected function getPageManager($qbCallback)
     {
-        $query = $this->getMockForAbstractClass('Doctrine\ORM\AbstractQuery', [], '', false, true, true, ['execute']);
+        $query = $this->getMockForAbstractClass(AbstractQuery::class, [], '', false, true, true, ['execute']);
         $query->expects($this->any())->method('execute')->will($this->returnValue(true));
 
-        $qb = $this->getMockBuilder('Doctrine\ORM\QueryBuilder')
+        $qb = $this->getMockBuilder(QueryBuilder::class)
             ->setConstructorArgs([
-                $this->getMockBuilder('Doctrine\ORM\EntityManager')
+                $this->getMockBuilder(EntityManager::class)
                     ->disableOriginalConstructor()
                     ->getMock(),
             ])
@@ -266,22 +273,22 @@ class PageManagerTest extends TestCase
 
         $qbCallback($qb);
 
-        $repository = $this->getMockBuilder('Doctrine\ORM\EntityRepository')->disableOriginalConstructor()->getMock();
+        $repository = $this->getMockBuilder(EntityRepository::class)->disableOriginalConstructor()->getMock();
         $repository->expects($this->any())->method('createQueryBuilder')->will($this->returnValue($qb));
 
-        $metadata = $this->createMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $metadata = $this->createMock(ClassMetadata::class);
         $metadata->expects($this->any())->method('getFieldNames')->will($this->returnValue([
             'name',
             'routeName',
         ]));
 
-        $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')->disableOriginalConstructor()->getMock();
+        $em = $this->getMockBuilder(EntityManager::class)->disableOriginalConstructor()->getMock();
         $em->expects($this->any())->method('getRepository')->will($this->returnValue($repository));
         $em->expects($this->any())->method('getClassMetadata')->will($this->returnValue($metadata));
 
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock(ManagerRegistry::class);
         $registry->expects($this->any())->method('getManagerForClass')->will($this->returnValue($em));
 
-        return new PageManager('Sonata\PageBundle\Entity\BasePage', $registry);
+        return new PageManager(BasePage::class, $registry);
     }
 }

--- a/tests/Entity/SiteManagerTest.php
+++ b/tests/Entity/SiteManagerTest.php
@@ -11,7 +11,14 @@
 
 namespace Sonata\PageBundle\Tests\Entity;
 
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\ORM\AbstractQuery;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\QueryBuilder;
 use PHPUnit\Framework\TestCase;
+use Sonata\PageBundle\Entity\BaseSite;
 use Sonata\PageBundle\Entity\SiteManager;
 
 class SiteManagerTest extends TestCase
@@ -114,12 +121,12 @@ class SiteManagerTest extends TestCase
 
     protected function getSiteManager($qbCallback)
     {
-        $query = $this->getMockForAbstractClass('Doctrine\ORM\AbstractQuery', [], '', false, true, true, ['execute']);
+        $query = $this->getMockForAbstractClass(AbstractQuery::class, [], '', false, true, true, ['execute']);
         $query->expects($this->any())->method('execute')->will($this->returnValue(true));
 
-        $qb = $this->getMockBuilder('Doctrine\ORM\QueryBuilder')
+        $qb = $this->getMockBuilder(QueryBuilder::class)
             ->setConstructorArgs([
-                $this->getMockBuilder('Doctrine\ORM\EntityManager')
+                $this->getMockBuilder(EntityManager::class)
                     ->disableOriginalConstructor()
                     ->getMock(),
             ])
@@ -131,22 +138,22 @@ class SiteManagerTest extends TestCase
 
         $qbCallback($qb);
 
-        $repository = $this->getMockBuilder('Doctrine\ORM\EntityRepository')->disableOriginalConstructor()->getMock();
+        $repository = $this->getMockBuilder(EntityRepository::class)->disableOriginalConstructor()->getMock();
         $repository->expects($this->any())->method('createQueryBuilder')->will($this->returnValue($qb));
 
-        $metadata = $this->createMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $metadata = $this->createMock(ClassMetadata::class);
         $metadata->expects($this->any())->method('getFieldNames')->will($this->returnValue([
             'name',
             'host',
         ]));
 
-        $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')->disableOriginalConstructor()->getMock();
+        $em = $this->getMockBuilder(EntityManager::class)->disableOriginalConstructor()->getMock();
         $em->expects($this->any())->method('getRepository')->will($this->returnValue($repository));
         $em->expects($this->any())->method('getClassMetadata')->will($this->returnValue($metadata));
 
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock(ManagerRegistry::class);
         $registry->expects($this->any())->method('getManagerForClass')->will($this->returnValue($em));
 
-        return new SiteManager('Sonata\PageBundle\Entity\BaseSite', $registry);
+        return new SiteManager(BaseSite::class, $registry);
     }
 }

--- a/tests/Form/Type/PageSelectorTypeTest.php
+++ b/tests/Form/Type/PageSelectorTypeTest.php
@@ -13,6 +13,7 @@ namespace Sonata\PageBundle\Tests\Form\Type;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\PageBundle\Form\Type\PageSelectorType;
+use Sonata\PageBundle\Model\PageManagerInterface;
 use Sonata\PageBundle\Tests\Model\Page;
 use Sonata\PageBundle\Tests\Model\Site;
 use Symfony\Component\Form\Extension\Core\View\ChoiceView as LegacyChoiceView;
@@ -72,7 +73,7 @@ class PageSelectorTypeTest extends TestCase
 
     public function getPageManager()
     {
-        $manager = $this->createMock('Sonata\PageBundle\Model\PageManagerInterface');
+        $manager = $this->createMock(PageManagerInterface::class);
 
         $manager->expects($this->any())
             ->method('loadPages')

--- a/tests/Form/Type/TemplateChoiceTypeTest.php
+++ b/tests/Form/Type/TemplateChoiceTypeTest.php
@@ -13,6 +13,8 @@ namespace Sonata\PageBundle\Tests\Form\Type;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\PageBundle\Form\Type\TemplateChoiceType;
+use Sonata\PageBundle\Model\Template;
+use Sonata\PageBundle\Page\TemplateManagerInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -35,7 +37,7 @@ class TemplateChoiceTypeTest extends TestCase
      */
     public function setUp()
     {
-        $this->manager = $this->createMock('Sonata\PageBundle\Page\TemplateManagerInterface');
+        $this->manager = $this->createMock(TemplateManagerInterface::class);
         $this->type = new TemplateChoiceType($this->manager);
     }
 
@@ -70,7 +72,7 @@ class TemplateChoiceTypeTest extends TestCase
      */
     protected function getMockTemplate($name, $path = 'path/to/file')
     {
-        $template = $this->getMockbuilder('Sonata\PageBundle\Model\Template')->disableOriginalConstructor()->getMock();
+        $template = $this->getMockbuilder(Template::class)->disableOriginalConstructor()->getMock();
         $template->expects($this->any())->method('getName')->will($this->returnValue($name));
         $template->expects($this->any())->method('getPath')->will($this->returnValue($path));
 

--- a/tests/Listener/ExceptionListenerTest.php
+++ b/tests/Listener/ExceptionListenerTest.php
@@ -12,12 +12,22 @@
 namespace Sonata\PageBundle\Tests\Listener;
 
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Sonata\PageBundle\CmsManager\CmsManagerInterface;
+use Sonata\PageBundle\CmsManager\CmsManagerSelectorInterface;
+use Sonata\PageBundle\CmsManager\DecoratorStrategyInterface;
+use Sonata\PageBundle\Exception\InternalErrorException;
 use Sonata\PageBundle\Listener\ExceptionListener;
+use Sonata\PageBundle\Model\PageInterface;
+use Sonata\PageBundle\Model\SiteInterface;
+use Sonata\PageBundle\Page\PageServiceManagerInterface;
+use Sonata\PageBundle\Site\SiteSelectorInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Templating\EngineInterface;
 
 /**
  * Test the page bundle exception listener.
@@ -70,13 +80,13 @@ class ExceptionListenerTest extends TestCase
     public function setUp()
     {
         // mock dependencies
-        $this->siteSelector = $this->createMock('Sonata\PageBundle\Site\SiteSelectorInterface');
-        $this->cmsSelector = $this->createMock('Sonata\PageBundle\CmsManager\CmsManagerSelectorInterface');
-        $this->templating = $this->createMock('Symfony\Component\Templating\EngineInterface');
-        $this->decoratorStrategy = $this->createMock('Sonata\PageBundle\CmsManager\DecoratorStrategyInterface');
-        $this->pageServiceManager = $this->createMock('Sonata\PageBundle\Page\PageServiceManagerInterface');
-        $this->cmsSelector = $this->createMock('Sonata\PageBundle\CmsManager\CmsManagerSelectorInterface');
-        $this->logger = $this->createMock('Psr\Log\LoggerInterface');
+        $this->siteSelector = $this->createMock(SiteSelectorInterface::class);
+        $this->cmsSelector = $this->createMock(CmsManagerSelectorInterface::class);
+        $this->templating = $this->createMock(EngineInterface::class);
+        $this->decoratorStrategy = $this->createMock(DecoratorStrategyInterface::class);
+        $this->pageServiceManager = $this->createMock(PageServiceManagerInterface::class);
+        $this->cmsSelector = $this->createMock(CmsManagerSelectorInterface::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
 
         $errors = [
             '404' => 'route_404',
@@ -93,7 +103,7 @@ class ExceptionListenerTest extends TestCase
     {
         // GIVEN
         // mock exception
-        $exception = $this->createMock('Sonata\PageBundle\Exception\InternalErrorException');
+        $exception = $this->createMock(InternalErrorException::class);
         $event = $this->getMockEvent($exception);
 
         // mock templating to expect a twig rendering
@@ -104,7 +114,7 @@ class ExceptionListenerTest extends TestCase
         $this->listener->onKernelException($event);
 
         // THEN
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $event->getResponse(), 'Should return a response in event');
+        $this->assertInstanceOf(Response::class, $event->getResponse(), 'Should return a response in event');
         $this->assertEquals(500, $event->getResponse()->getStatusCode(), 'Should return 500 status code');
     }
 
@@ -132,7 +142,7 @@ class ExceptionListenerTest extends TestCase
         $this->listener->onKernelException($event);
 
         // THEN
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $event->getResponse(), 'Should return a response in event');
+        $this->assertInstanceOf(Response::class, $event->getResponse(), 'Should return a response in event');
         $this->assertEquals(404, $event->getResponse()->getStatusCode(), 'Should return 404 status code');
     }
 
@@ -143,35 +153,35 @@ class ExceptionListenerTest extends TestCase
     {
         // GIVEN
         // mock exception
-        $exception = $this->createMock('\Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
+        $exception = $this->createMock(NotFoundHttpException::class);
         $exception->expects($this->any())->method('getStatusCode')->will($this->returnValue(404));
         $event = $this->getMockEvent($exception);
 
         $this->assertEquals('en', $event->getRequest()->getLocale());
 
         // mock a site
-        $site = $this->createMock('Sonata\PageBundle\Model\SiteInterface');
+        $site = $this->createMock(SiteInterface::class);
         $site->expects($this->exactly(2))->method('getLocale')->will($this->returnValue('fr'));
 
         // mock an error page
-        $page = $this->createMock('Sonata\PageBundle\Model\PageInterface');
+        $page = $this->createMock(PageInterface::class);
         $page->expects($this->exactly(2))->method('getSite')->will($this->returnValue($site));
 
         // mock cms manager to return the mock error page and set it as current page
-        $this->cmsManager = $this->createMock('Sonata\PageBundle\CmsManager\CmsManagerInterface');
+        $this->cmsManager = $this->createMock(CmsManagerInterface::class);
         $this->cmsManager->expects($this->once())->method('getPageByRouteName')->with($this->anything(), $this->equalTo('route_404'))->will($this->returnValue($page));
         $this->cmsManager->expects($this->once())->method('setCurrentPage')->with($this->equalTo($page));
         $this->cmsSelector->expects($this->any())->method('retrieve')->will($this->returnValue($this->cmsManager));
 
         // mocked site selector should return a site
-        $this->siteSelector->expects($this->any())->method('retrieve')->will($this->returnValue($this->createMock('Sonata\PageBundle\Model\SiteInterface')));
+        $this->siteSelector->expects($this->any())->method('retrieve')->will($this->returnValue($this->createMock(SiteInterface::class)));
 
         // mocked decorator strategy should allow decorate
         $this->decoratorStrategy->expects($this->any())->method('isRouteNameDecorable')->will($this->returnValue(true));
         $this->decoratorStrategy->expects($this->any())->method('isRouteUriDecorable')->will($this->returnValue(true));
 
         // mocked page service manager should execute the page and return a response
-        $response = $this->createMock('Symfony\Component\HttpFoundation\Response');
+        $response = $this->createMock(Response::class);
         $this->pageServiceManager->expects($this->once())->method('execute')->with($this->equalTo($page))->will($this->returnValue($response));
 
         // WHEN
@@ -187,11 +197,11 @@ class ExceptionListenerTest extends TestCase
      *
      * @param \Exception $exception
      *
-     * @return \Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent
+     * @return GetResponseForExceptionEvent
      */
     protected function getMockEvent($exception)
     {
-        $kernel = $this->createMock('Symfony\Component\HttpKernel\HttpKernelInterface');
+        $kernel = $this->createMock(HttpKernelInterface::class);
         $request = new Request();
 
         return new GetResponseForExceptionEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST, $exception);

--- a/tests/Listener/RequestListenerTest.php
+++ b/tests/Listener/RequestListenerTest.php
@@ -12,7 +12,15 @@
 namespace Sonata\PageBundle\Tests\Listener;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\PageBundle\CmsManager\CmsManagerInterface;
+use Sonata\PageBundle\CmsManager\CmsManagerSelectorInterface;
+use Sonata\PageBundle\CmsManager\DecoratorStrategyInterface;
+use Sonata\PageBundle\Exception\InternalErrorException;
 use Sonata\PageBundle\Listener\RequestListener;
+use Sonata\PageBundle\Model\PageInterface;
+use Sonata\PageBundle\Model\SiteInterface;
+use Sonata\PageBundle\Site\SiteSelectorInterface;
+use Sonata\SeoBundle\Seo\SeoPageInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
@@ -24,26 +32,26 @@ class RequestListenerTest extends TestCase
 {
     public function testValidSite()
     {
-        $page = $this->createMock('Sonata\PageBundle\Model\PageInterface');
+        $page = $this->createMock(PageInterface::class);
         $page->expects($this->once())->method('getEnabled')->will($this->returnValue(true));
 
-        $seoPage = $this->createMock('Sonata\SeoBundle\Seo\SeoPageInterface');
+        $seoPage = $this->createMock(SeoPageInterface::class);
 
-        $decoratorStrategy = $this->createMock('Sonata\PageBundle\CmsManager\DecoratorStrategyInterface');
+        $decoratorStrategy = $this->createMock(DecoratorStrategyInterface::class);
         $decoratorStrategy->expects($this->once())->method('isRequestDecorable')->will($this->returnValue(true));
 
-        $cmsManager = $this->createMock('Sonata\PageBundle\CmsManager\CmsManagerInterface');
+        $cmsManager = $this->createMock(CmsManagerInterface::class);
         $cmsManager->expects($this->once())->method('getPageByRouteName')->will($this->returnValue($page));
 
-        $cmsSelector = $this->createMock('Sonata\PageBundle\CmsManager\CmsManagerSelectorInterface');
+        $cmsSelector = $this->createMock(CmsManagerSelectorInterface::class);
         $cmsSelector->expects($this->once())->method('retrieve')->will($this->returnValue($cmsManager));
 
-        $site = $this->createMock('Sonata\PageBundle\Model\SiteInterface');
+        $site = $this->createMock(SiteInterface::class);
 
-        $siteSelector = $this->createMock('Sonata\PageBundle\Site\SiteSelectorInterface');
+        $siteSelector = $this->createMock(SiteSelectorInterface::class);
         $siteSelector->expects($this->once())->method('retrieve')->will($this->returnValue($site));
 
-        $kernel = $this->createMock('Symfony\Component\HttpKernel\HttpKernelInterface');
+        $kernel = $this->createMock(HttpKernelInterface::class);
         $request = new Request();
 
         $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
@@ -54,22 +62,22 @@ class RequestListenerTest extends TestCase
 
     public function testNoSite()
     {
-        $this->expectException(\Sonata\PageBundle\Exception\InternalErrorException::class);
+        $this->expectException(InternalErrorException::class);
 
-        $cmsManager = $this->createMock('Sonata\PageBundle\CmsManager\CmsManagerInterface');
+        $cmsManager = $this->createMock(CmsManagerInterface::class);
 
-        $seoPage = $this->createMock('Sonata\SeoBundle\Seo\SeoPageInterface');
+        $seoPage = $this->createMock(SeoPageInterface::class);
 
-        $decoratorStrategy = $this->createMock('Sonata\PageBundle\CmsManager\DecoratorStrategyInterface');
+        $decoratorStrategy = $this->createMock(DecoratorStrategyInterface::class);
         $decoratorStrategy->expects($this->once())->method('isRequestDecorable')->will($this->returnValue(true));
 
-        $cmsSelector = $this->createMock('Sonata\PageBundle\CmsManager\CmsManagerSelectorInterface');
+        $cmsSelector = $this->createMock(CmsManagerSelectorInterface::class);
         $cmsSelector->expects($this->once())->method('retrieve')->will($this->returnValue($cmsManager));
 
-        $siteSelector = $this->createMock('Sonata\PageBundle\Site\SiteSelectorInterface');
+        $siteSelector = $this->createMock(SiteSelectorInterface::class);
         $siteSelector->expects($this->once())->method('retrieve')->will($this->returnValue(false));
 
-        $kernel = $this->createMock('Symfony\Component\HttpKernel\HttpKernelInterface');
+        $kernel = $this->createMock(HttpKernelInterface::class);
         $request = new Request();
 
         $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);

--- a/tests/Listener/ResponseListenerTest.php
+++ b/tests/Listener/ResponseListenerTest.php
@@ -12,8 +12,14 @@
 namespace Sonata\PageBundle\Tests\Listener;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\PageBundle\CmsManager\CmsManagerInterface;
+use Sonata\PageBundle\CmsManager\CmsManagerSelectorInterface;
+use Sonata\PageBundle\CmsManager\DecoratorStrategyInterface;
+use Sonata\PageBundle\Exception\InternalErrorException;
 use Sonata\PageBundle\Listener\ResponseListener;
 use Sonata\PageBundle\Model\PageInterface;
+use Sonata\PageBundle\Page\PageServiceManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
@@ -54,12 +60,12 @@ class ResponseListenerTest extends TestCase
      */
     public function setUp()
     {
-        $this->decoratorStrategy = $this->createMock('Sonata\PageBundle\CmsManager\DecoratorStrategyInterface');
-        $this->pageServiceManager = $this->createMock('Sonata\PageBundle\Page\PageServiceManagerInterface');
-        $this->cmsManager = $this->createMock('Sonata\PageBundle\CmsManager\CmsManagerInterface');
-        $this->cmsSelector = $this->createMock('Sonata\PageBundle\CmsManager\CmsManagerSelectorInterface');
+        $this->decoratorStrategy = $this->createMock(DecoratorStrategyInterface::class);
+        $this->pageServiceManager = $this->createMock(PageServiceManagerInterface::class);
+        $this->cmsManager = $this->createMock(CmsManagerInterface::class);
+        $this->cmsSelector = $this->createMock(CmsManagerSelectorInterface::class);
         $this->cmsSelector->expects($this->once())->method('retrieve')->will($this->returnValue($this->cmsManager));
-        $this->templating = $this->createMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
+        $this->templating = $this->createMock(EngineInterface::class);
 
         $this->listener = new ResponseListener($this->cmsSelector, $this->pageServiceManager, $this->decoratorStrategy, $this->templating);
     }
@@ -69,7 +75,7 @@ class ResponseListenerTest extends TestCase
      */
     public function testWithoutPage()
     {
-        $this->expectException(\Sonata\PageBundle\Exception\InternalErrorException::class);
+        $this->expectException(InternalErrorException::class);
 
         // GIVEN
 
@@ -116,7 +122,7 @@ class ResponseListenerTest extends TestCase
         $content = 'inner';
 
         // a mock page entity that accepts to be decorated
-        $page = $this->createMock('Sonata\PageBundle\Model\PageInterface');
+        $page = $this->createMock(PageInterface::class);
         $page->expects($this->once())->method('isHybrid')->will($this->returnValue(true));
         $page->expects($this->once())->method('getDecorate')->will($this->returnValue(true));
 
@@ -179,11 +185,11 @@ class ResponseListenerTest extends TestCase
      *
      * @param string $content
      *
-     * @return \Symfony\Component\HttpKernel\Event\FilterResponseEvent
+     * @return FilterResponseEvent
      */
     protected function getMockEvent($content)
     {
-        $kernel = $this->createMock('Symfony\Component\HttpKernel\HttpKernelInterface');
+        $kernel = $this->createMock(HttpKernelInterface::class);
         $request = new Request();
         $response = new Response($content);
 

--- a/tests/Model/BlockInteractorTest.php
+++ b/tests/Model/BlockInteractorTest.php
@@ -13,7 +13,10 @@ namespace Sonata\PageBundle\Tests\Model;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\BlockBundle\Model\Block;
+use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\BlockBundle\Model\BlockManagerInterface;
 use Sonata\PageBundle\Entity\BlockInteractor;
+use Symfony\Bridge\Doctrine\RegistryInterface;
 
 /**
  * BlockInteractorTest class.
@@ -29,9 +32,9 @@ class BlockInteractorTest extends TestCase
      */
     public function testCreateNewContainer()
     {
-        $registry = $this->getMockBuilder('Symfony\Bridge\Doctrine\RegistryInterface')->disableOriginalConstructor()->getMock();
+        $registry = $this->getMockBuilder(RegistryInterface::class)->disableOriginalConstructor()->getMock();
 
-        $blockManager = $this->createMock('Sonata\BlockBundle\Model\BlockManagerInterface');
+        $blockManager = $this->createMock(BlockManagerInterface::class);
         $blockManager->expects($this->any())->method('create')->will($this->returnValue(new Block()));
 
         $blockInteractor = new BlockInteractor($registry, $blockManager);
@@ -43,7 +46,7 @@ class BlockInteractorTest extends TestCase
             $container->setSetting('layout', '<div class="custom-layout">{{ CONTENT }}</div>');
         });
 
-        $this->assertInstanceOf('\Sonata\BlockBundle\Model\BlockInterface', $container);
+        $this->assertInstanceOf(BlockInterface::class, $container);
 
         $settings = $container->getSettings();
 

--- a/tests/Model/PageTest.php
+++ b/tests/Model/PageTest.php
@@ -12,6 +12,9 @@
 namespace Sonata\PageBundle\Tests\Model;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\PageBundle\Model\Block;
+use Sonata\PageBundle\Model\PageInterface;
+use Sonata\PageBundle\Model\SnapshotInterface;
 
 class PageTest extends TestCase
 {
@@ -171,18 +174,18 @@ class PageTest extends TestCase
         $this->assertEquals(2, count($page->getChildren()));
 
         $snapshots = [
-            $this->createMock('Sonata\PageBundle\Model\SnapshotInterface'),
+            $this->createMock(SnapshotInterface::class),
         ];
 
         $page->setSnapshots($snapshots);
         $this->assertEquals(1, count($page->getSnapshots()));
-        $page->addSnapshot($this->createMock('Sonata\PageBundle\Model\SnapshotInterface'));
+        $page->addSnapshot($this->createMock(SnapshotInterface::class));
         $this->assertEquals(2, count($page->getSnapshots()));
 
-        $this->assertInstanceOf('Sonata\PageBundle\Model\SnapshotInterface', $page->getSnapshot());
+        $this->assertInstanceOf(SnapshotInterface::class, $page->getSnapshot());
 
-        $page->setTarget($this->createMock('Sonata\PageBundle\Model\PageInterface'));
-        $this->assertInstanceOf('Sonata\PageBundle\Model\PageInterface', $page->getTarget());
+        $page->setTarget($this->createMock(PageInterface::class));
+        $this->assertInstanceOf(PageInterface::class, $page->getTarget());
         $page->setTarget(null);
         $this->assertNull($page->getTarget());
 
@@ -294,14 +297,14 @@ class PageTest extends TestCase
     {
         $page = new Page();
 
-        $block1 = $this->getMockBuilder('Sonata\PageBundle\Model\Block')->getMock();
+        $block1 = $this->getMockBuilder(Block::class)->getMock();
         $block1->expects($this->any())->method('getType')->will($this->returnValue('sonata.page.block.action'));
 
-        $block2 = $this->getMockBuilder('Sonata\PageBundle\Model\Block')->getMock();
+        $block2 = $this->getMockBuilder(Block::class)->getMock();
         $block2->expects($this->any())->method('getType')->will($this->returnValue('sonata.page.block.container'));
         $block2->expects($this->once())->method('getSetting')->will($this->returnValue('bar'));
 
-        $block3 = $this->getMockBuilder('Sonata\PageBundle\Model\Block')->getMock();
+        $block3 = $this->getMockBuilder(Block::class)->getMock();
         $block3->expects($this->any())->method('getType')->will($this->returnValue('sonata.page.block.container'));
         $block3->expects($this->once())->method('getSetting')->will($this->returnValue('gotcha'));
 
@@ -316,13 +319,13 @@ class PageTest extends TestCase
     {
         $page = new Page();
 
-        $block1 = $this->getMockBuilder('Sonata\PageBundle\Model\Block')->getMock();
+        $block1 = $this->getMockBuilder(Block::class)->getMock();
         $block1->expects($this->once())->method('getType')->will($this->returnValue('sonata.page.block.action'));
 
-        $block2 = $this->getMockBuilder('Sonata\PageBundle\Model\Block')->getMock();
+        $block2 = $this->getMockBuilder(Block::class)->getMock();
         $block2->expects($this->once())->method('getType')->will($this->returnValue('sonata.page.block.container'));
 
-        $block3 = $this->getMockBuilder('Sonata\PageBundle\Model\Block')->getMock();
+        $block3 = $this->getMockBuilder(Block::class)->getMock();
         $block3->expects($this->once())->method('getType')->will($this->returnValue('sonata.page.block.action'));
 
         $page->addBlocks($block1);

--- a/tests/Model/SnapshotPageProxyTest.php
+++ b/tests/Model/SnapshotPageProxyTest.php
@@ -12,15 +12,18 @@
 namespace Sonata\PageBundle\Tests\Model;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\PageBundle\Model\SnapshotInterface;
+use Sonata\PageBundle\Model\SnapshotManagerInterface;
 use Sonata\PageBundle\Model\SnapshotPageProxy;
+use Sonata\PageBundle\Model\TransformerInterface;
 
 class SnapshotPageProxyTest extends TestCase
 {
     public function testInterface()
     {
-        $snapshotManager = $this->createMock('Sonata\PageBundle\Model\SnapshotManagerInterface');
-        $snapshot = $this->createMock('Sonata\PageBundle\Model\SnapshotInterface');
-        $transformer = $this->createMock('Sonata\PageBundle\Model\TransformerInterface');
+        $snapshotManager = $this->createMock(SnapshotManagerInterface::class);
+        $snapshot = $this->createMock(SnapshotInterface::class);
+        $transformer = $this->createMock(TransformerInterface::class);
 
         new SnapshotPageProxy($snapshotManager, $transformer, $snapshot);
     }

--- a/tests/Page/PageServiceManagerTest.php
+++ b/tests/Page/PageServiceManagerTest.php
@@ -12,7 +12,12 @@
 namespace Sonata\PageBundle\Tests\Page;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\PageBundle\Model\PageInterface;
 use Sonata\PageBundle\Page\PageServiceManager;
+use Sonata\PageBundle\Page\Service\PageServiceInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\RouterInterface;
 
 /**
  * Test the page service manager.
@@ -34,7 +39,7 @@ class PageServiceManagerTest extends TestCase
      */
     public function setUp()
     {
-        $this->router = $this->createMock('Symfony\Component\Routing\RouterInterface');
+        $this->router = $this->createMock(RouterInterface::class);
         $this->manager = new PageServiceManager($this->router);
     }
 
@@ -44,7 +49,7 @@ class PageServiceManagerTest extends TestCase
     public function testAdd()
     {
         // GIVEN
-        $service = $this->createMock('Sonata\PageBundle\Page\Service\PageServiceInterface');
+        $service = $this->createMock(PageServiceInterface::class);
 
         // WHEN
         $this->manager->add('default', $service);
@@ -61,10 +66,10 @@ class PageServiceManagerTest extends TestCase
     public function testGetByPage()
     {
         // GIVEN
-        $service = $this->createMock('Sonata\PageBundle\Page\Service\PageServiceInterface');
+        $service = $this->createMock(PageServiceInterface::class);
         $this->manager->add('my-type', $service);
 
-        $page = $this->createMock('Sonata\PageBundle\Model\PageInterface');
+        $page = $this->createMock(PageInterface::class);
         $page->expects($this->once())->method('getType')->will($this->returnValue('my-type'));
 
         // WHEN
@@ -82,8 +87,8 @@ class PageServiceManagerTest extends TestCase
     public function testGetAll()
     {
         // GIVEN
-        $service1 = $this->createMock('Sonata\PageBundle\Page\Service\PageServiceInterface');
-        $service2 = $this->createMock('Sonata\PageBundle\Page\Service\PageServiceInterface');
+        $service1 = $this->createMock(PageServiceInterface::class);
+        $service2 = $this->createMock(PageServiceInterface::class);
         $this->manager->add('service1', $service1);
         $this->manager->add('service2', $service2);
 
@@ -102,7 +107,7 @@ class PageServiceManagerTest extends TestCase
     public function testDefault()
     {
         // GIVEN
-        $default = $this->createMock('Sonata\PageBundle\Page\Service\PageServiceInterface');
+        $default = $this->createMock(PageServiceInterface::class);
         $this->manager->setDefault($default);
 
         // WHEN
@@ -121,15 +126,15 @@ class PageServiceManagerTest extends TestCase
     {
         // GIVEN
         $request = $this
-            ->getMockBuilder('Symfony\Component\HttpFoundation\Request')
+            ->getMockBuilder(Request::class)
             ->disableOriginalClone()
             ->getMock();
-        $response = $this->createMock('Symfony\Component\HttpFoundation\Response');
+        $response = $this->createMock(Response::class);
 
-        $page = $this->createMock('Sonata\PageBundle\Model\PageInterface');
+        $page = $this->createMock(PageInterface::class);
         $page->expects($this->once())->method('getType')->will($this->returnValue('my-type'));
 
-        $service = $this->createMock('Sonata\PageBundle\Page\Service\PageServiceInterface');
+        $service = $this->createMock(PageServiceInterface::class);
         $service->expects($this->once())
             ->method('execute')
             ->with($this->equalTo($page), $this->equalTo($request))

--- a/tests/Page/Service/BasePageServiceTest.php
+++ b/tests/Page/Service/BasePageServiceTest.php
@@ -44,14 +44,14 @@ class BasePageServiceTest extends TestCase
     {
         // GIVEN
         $service = new ConcretePageService('my name');
-        $page = $this->createMock('Sonata\PageBundle\Model\PageInterface');
-        $request = $this->createMock('Symfony\Component\HttpFoundation\Request');
+        $page = $this->createMock(PageInterface::class);
+        $request = $this->createMock(Request::class);
 
         // WHEN
         $response = $service->execute($page, $request);
 
         // THEN
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response, 'Should return a Response object');
+        $this->assertInstanceOf(Response::class, $response, 'Should return a Response object');
     }
 }
 

--- a/tests/Page/Service/DefaultPageServiceTest.php
+++ b/tests/Page/Service/DefaultPageServiceTest.php
@@ -12,7 +12,12 @@
 namespace Sonata\PageBundle\Tests\Page\Service;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\PageBundle\Model\PageInterface;
 use Sonata\PageBundle\Page\Service\DefaultPageService;
+use Sonata\PageBundle\Page\TemplateManagerInterface;
+use Sonata\SeoBundle\Seo\SeoPageInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Test the default page service.
@@ -40,8 +45,8 @@ class DefaultPageServiceTest extends TestCase
     public function setUp()
     {
         $name = 'my name';
-        $this->templateManager = $this->createMock('Sonata\PageBundle\Page\TemplateManagerInterface');
-        $this->seoPage = $this->createMock('Sonata\SeoBundle\Seo\SeoPageInterface');
+        $this->templateManager = $this->createMock(TemplateManagerInterface::class);
+        $this->seoPage = $this->createMock(SeoPageInterface::class);
 
         $this->service = new DefaultPageService($name, $this->templateManager, $this->seoPage);
     }
@@ -54,13 +59,13 @@ class DefaultPageServiceTest extends TestCase
         // GIVEN
 
         // mock a http request
-        $request = $this->createMock('Symfony\Component\HttpFoundation\Request');
+        $request = $this->createMock(Request::class);
 
         // mock http response
-        $response = $this->createMock('Symfony\Component\HttpFoundation\Response');
+        $response = $this->createMock(Response::class);
 
         // mock a page instance
-        $page = $this->createMock('Sonata\PageBundle\Model\PageInterface');
+        $page = $this->createMock(PageInterface::class);
         $page->expects($this->any())->method('getTitle')->will($this->returnValue('page title'));
         $page->expects($this->atLeastOnce())->method('getMetaDescription')->will($this->returnValue('page meta description'));
         $page->expects($this->atLeastOnce())->method('getMetaKeyword')->will($this->returnValue('page meta keywords'));

--- a/tests/Page/TemplateManagerTest.php
+++ b/tests/Page/TemplateManagerTest.php
@@ -12,8 +12,10 @@
 namespace Sonata\PageBundle\Tests\Page;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\PageBundle\Model\Template;
 use Sonata\PageBundle\Page\TemplateManager;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Templating\StreamingEngineInterface;
 
 /**
@@ -28,7 +30,7 @@ class TemplateManagerTest extends TestCase
     {
         // GIVEN
         $template = $this->getMockTemplate('template');
-        $templating = $this->createMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
+        $templating = $this->createMock(EngineInterface::class);
         $manager = new TemplateManager($templating);
 
         // WHEN
@@ -44,7 +46,7 @@ class TemplateManagerTest extends TestCase
     public function testSetAllTemplates()
     {
         // GIVEN
-        $templating = $this->createMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
+        $templating = $this->createMock(EngineInterface::class);
         $manager = new TemplateManager($templating);
 
         $templates = [
@@ -67,7 +69,7 @@ class TemplateManagerTest extends TestCase
     public function testSetDefaultTemplateCode()
     {
         // GIVEN
-        $templating = $this->createMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
+        $templating = $this->createMock(EngineInterface::class);
         $manager = new TemplateManager($templating);
 
         // WHEN
@@ -85,8 +87,8 @@ class TemplateManagerTest extends TestCase
         // GIVEN
         $template = $this->getMockTemplate('template', 'path/to/template');
 
-        $response = $this->createMock('Symfony\Component\HttpFoundation\Response');
-        $templating = $this->createMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
+        $response = $this->createMock(Response::class);
+        $templating = $this->createMock(EngineInterface::class);
         $templating->expects($this->once())->method('renderResponse')->with($this->equalTo('path/to/template'))->will($this->returnValue($response));
 
         $manager = new TemplateManager($templating);
@@ -105,7 +107,7 @@ class TemplateManagerTest extends TestCase
     public function testRenderResponseWithNonExistingCode()
     {
         // GIVEN
-        $templating = $this->createMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
+        $templating = $this->createMock(EngineInterface::class);
         $templating->expects($this->once())->method('renderResponse')->with($this->equalTo('SonataPageBundle::layout.html.twig'));
         $manager = new TemplateManager($templating);
 
@@ -122,8 +124,8 @@ class TemplateManagerTest extends TestCase
     public function testRenderResponseWithoutCode()
     {
         // GIVEN
-        $response = $this->createMock('Symfony\Component\HttpFoundation\Response');
-        $templating = $this->createMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
+        $response = $this->createMock(Response::class);
+        $templating = $this->createMock(EngineInterface::class);
         $templating->expects($this->once())->method('renderResponse')->with($this->equalTo('path/to/default'))->will($this->returnValue($response));
 
         $template = $this->getMockTemplate('template', 'path/to/default');
@@ -146,8 +148,8 @@ class TemplateManagerTest extends TestCase
         // GIVEN
         $template = $this->getMockTemplate('template', 'path/to/template');
 
-        $response = $this->createMock('Symfony\Component\HttpFoundation\Response');
-        $templating = $this->createMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
+        $response = $this->createMock(Response::class);
+        $templating = $this->createMock(EngineInterface::class);
         $templating->expects($this->once())->method('renderResponse')
             ->with(
                 $this->equalTo('path/to/template'),
@@ -177,7 +179,7 @@ class TemplateManagerTest extends TestCase
      */
     protected function getMockTemplate($name, $path = 'path/to/file')
     {
-        $template = $this->getMockbuilder('Sonata\PageBundle\Model\Template')->disableOriginalConstructor()->getMock();
+        $template = $this->getMockbuilder(Template::class)->disableOriginalConstructor()->getMock();
         $template->expects($this->any())->method('getName')->will($this->returnValue($name));
         $template->expects($this->any())->method('getPath')->will($this->returnValue($path));
 

--- a/tests/Request/RequestFactoryTest.php
+++ b/tests/Request/RequestFactoryTest.php
@@ -13,6 +13,7 @@ namespace Sonata\PageBundle\Tests\Request;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\PageBundle\Request\RequestFactory;
+use Sonata\PageBundle\Request\SiteRequest;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Kernel;
 
@@ -38,31 +39,31 @@ class RequestFactoryTest extends TestCase
 
     public function testHostAndCreate()
     {
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Request', RequestFactory::create('host', '/'));
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Request', Request::create('/'));
+        $this->assertInstanceOf(Request::class, RequestFactory::create('host', '/'));
+        $this->assertInstanceOf(Request::class, Request::create('/'));
     }
 
     public function testHostAndCreateFromGlobals()
     {
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Request', RequestFactory::createFromGlobals('host'));
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Request', Request::create('/'));
+        $this->assertInstanceOf(Request::class, RequestFactory::createFromGlobals('host'));
+        $this->assertInstanceOf(Request::class, Request::create('/'));
     }
 
     public function testHostWithPathAndCreate()
     {
-        $this->assertInstanceOf('Sonata\PageBundle\Request\SiteRequest', RequestFactory::create('host_with_path', '/'));
+        $this->assertInstanceOf(SiteRequest::class, RequestFactory::create('host_with_path', '/'));
 
         if ($this->hasFactory) {
-            $this->assertInstanceOf('Sonata\PageBundle\Request\SiteRequest', Request::create('/'));
+            $this->assertInstanceOf(SiteRequest::class, Request::create('/'));
         }
     }
 
     public function testHostWithPathAndCreateFromGlobals()
     {
-        $this->assertInstanceOf('Sonata\PageBundle\Request\SiteRequest', RequestFactory::createFromGlobals('host_with_path'));
+        $this->assertInstanceOf(SiteRequest::class, RequestFactory::createFromGlobals('host_with_path'));
 
         if ($this->hasFactory) {
-            $this->assertInstanceOf('Sonata\PageBundle\Request\SiteRequest', Request::create('/'));
+            $this->assertInstanceOf(SiteRequest::class, Request::create('/'));
         }
     }
 

--- a/tests/Route/RoutePageGeneratorTest.php
+++ b/tests/Route/RoutePageGeneratorTest.php
@@ -13,8 +13,12 @@ namespace Sonata\PageBundle\Tests\Route;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\PageBundle\CmsManager\DecoratorStrategy;
+use Sonata\PageBundle\Entity\PageManager;
+use Sonata\PageBundle\Listener\ExceptionListener;
+use Sonata\PageBundle\Model\SiteInterface;
 use Sonata\PageBundle\Route\RoutePageGenerator;
 use Sonata\PageBundle\Tests\Model\Page;
+use Symfony\Bundle\FrameworkBundle\Routing\Router;
 use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
@@ -106,11 +110,11 @@ class RoutePageGeneratorTest extends TestCase
     /**
      * Returns a mock of a site model.
      *
-     * @return \Sonata\PageBundle\Model\SiteInterface
+     * @return SiteInterface
      */
     protected function getSiteMock()
     {
-        $site = $this->createMock('Sonata\PageBundle\Model\SiteInterface');
+        $site = $this->createMock(SiteInterface::class);
         $site->expects($this->any())->method('getHost')->will($this->returnValue('sonata-project.org'));
         $site->expects($this->any())->method('getId')->will($this->returnValue(1));
 
@@ -120,7 +124,7 @@ class RoutePageGeneratorTest extends TestCase
     /**
      * Returns a mock of Symfony router.
      *
-     * @return \Symfony\Component\Routing\Router
+     * @return Router
      */
     protected function getRouterMock()
     {
@@ -142,7 +146,7 @@ class RoutePageGeneratorTest extends TestCase
             'sonata-project.com'
         ));
 
-        $router = $this->getMockBuilder('Symfony\Component\Routing\Router')
+        $router = $this->getMockBuilder(Router::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -160,7 +164,7 @@ class RoutePageGeneratorTest extends TestCase
     {
         $router = $this->getRouterMock();
 
-        $pageManager = $this->getMockBuilder('Sonata\PageBundle\Entity\PageManager')
+        $pageManager = $this->getMockBuilder(PageManager::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -186,7 +190,7 @@ class RoutePageGeneratorTest extends TestCase
 
         $decoratorStrategy = new DecoratorStrategy([], [], []);
 
-        $exceptionListener = $this->getMockBuilder('Sonata\PageBundle\Listener\ExceptionListener')
+        $exceptionListener = $this->getMockBuilder(ExceptionListener::class)
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/tests/Site/HostByLocaleSiteSelectorTest.php
+++ b/tests/Site/HostByLocaleSiteSelectorTest.php
@@ -11,7 +11,11 @@
 
 namespace Sonata\PageBundle\Tests\Site;
 
+use Sonata\PageBundle\CmsManager\DecoratorStrategyInterface;
+use Sonata\PageBundle\Model\SiteManagerInterface;
 use Sonata\PageBundle\Request\SiteRequest;
+use Sonata\PageBundle\Site\HostByLocaleSiteSelector;
+use Sonata\SeoBundle\Seo\SeoPageInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
@@ -27,11 +31,11 @@ class HostByLocaleSiteSelectorTest extends BaseLocaleSiteSelectorTest
      */
     protected function setUp()
     {
-        $siteManager = $this->createMock('Sonata\PageBundle\Model\SiteManagerInterface');
-        $decoratorStrategy = $this->createMock('Sonata\PageBundle\CmsManager\DecoratorStrategyInterface');
-        $seoPage = $this->createMock('Sonata\SeoBundle\Seo\SeoPageInterface');
+        $siteManager = $this->createMock(SiteManagerInterface::class);
+        $decoratorStrategy = $this->createMock(DecoratorStrategyInterface::class);
+        $seoPage = $this->createMock(SeoPageInterface::class);
 
-        $this->siteSelector = $this->getMockBuilder('Sonata\PageBundle\Site\HostByLocaleSiteSelector')
+        $this->siteSelector = $this->getMockBuilder(HostByLocaleSiteSelector::class)
             ->setConstructorArgs([$siteManager, $decoratorStrategy, $seoPage])
             ->setMethods(['getSites'])
             ->getMock();
@@ -42,7 +46,7 @@ class HostByLocaleSiteSelectorTest extends BaseLocaleSiteSelectorTest
      */
     public function testHandleKernelRequestSelectsEn()
     {
-        $kernel = $this->createMock('Symfony\Component\HttpKernel\HttpKernelInterface');
+        $kernel = $this->createMock(HttpKernelInterface::class);
         $request = SiteRequest::create('http://www.example.com');
 
         // Ensure request locale is null
@@ -72,7 +76,7 @@ class HostByLocaleSiteSelectorTest extends BaseLocaleSiteSelectorTest
      */
     public function testHandleKernelRequestSelectsFr()
     {
-        $kernel = $this->createMock('Symfony\Component\HttpKernel\HttpKernelInterface');
+        $kernel = $this->createMock(HttpKernelInterface::class);
         $request = SiteRequest::create('http://www.example.com', 'GET', [], [], [], [
             'HTTP_ACCEPT_LANGUAGE' => 'fr-FR,fr;q=0.8,en-US;q=0.6,en;q=0.4',
         ]);

--- a/tests/Site/HostPathByLocaleSiteSelectorTest.php
+++ b/tests/Site/HostPathByLocaleSiteSelectorTest.php
@@ -11,7 +11,12 @@
 
 namespace Sonata\PageBundle\Tests\Site;
 
+use Sonata\PageBundle\CmsManager\DecoratorStrategyInterface;
+use Sonata\PageBundle\Model\SiteManagerInterface;
 use Sonata\PageBundle\Request\SiteRequest;
+use Sonata\PageBundle\Site\HostPathByLocaleSiteSelector;
+use Sonata\SeoBundle\Seo\SeoPageInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
@@ -27,11 +32,11 @@ class HostPathByLocaleSiteSelectorTest extends BaseLocaleSiteSelectorTest
      */
     protected function setUp()
     {
-        $siteManager = $this->createMock('Sonata\PageBundle\Model\SiteManagerInterface');
-        $decoratorStrategy = $this->createMock('Sonata\PageBundle\CmsManager\DecoratorStrategyInterface');
-        $seoPage = $this->createMock('Sonata\SeoBundle\Seo\SeoPageInterface');
+        $siteManager = $this->createMock(SiteManagerInterface::class);
+        $decoratorStrategy = $this->createMock(DecoratorStrategyInterface::class);
+        $seoPage = $this->createMock(SeoPageInterface::class);
 
-        $this->siteSelector = $this->getMockBuilder('Sonata\PageBundle\Site\HostPathByLocaleSiteSelector')
+        $this->siteSelector = $this->getMockBuilder(HostPathByLocaleSiteSelector::class)
             ->setConstructorArgs([$siteManager, $decoratorStrategy, $seoPage])
             ->setMethods(['getSites'])
             ->getMock();
@@ -42,7 +47,7 @@ class HostPathByLocaleSiteSelectorTest extends BaseLocaleSiteSelectorTest
      */
     public function testHandleKernelRequestRedirectsToEn()
     {
-        $kernel = $this->createMock('Symfony\Component\HttpKernel\HttpKernelInterface');
+        $kernel = $this->createMock(HttpKernelInterface::class);
         $request = SiteRequest::create('http://www.example.com');
 
         // Ensure request locale is null
@@ -70,7 +75,7 @@ class HostPathByLocaleSiteSelectorTest extends BaseLocaleSiteSelectorTest
         $response = $event->getResponse();
 
         // Ensure the response was a redirect to the default site
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
+        $this->assertInstanceOf(RedirectResponse::class, $response);
 
         // Ensure the redirect url is for "/en"
         $this->assertEquals('/en', $response->getTargetUrl());
@@ -81,7 +86,7 @@ class HostPathByLocaleSiteSelectorTest extends BaseLocaleSiteSelectorTest
      */
     public function testHandleKernelRequestRedirectsToFr()
     {
-        $kernel = $this->createMock('Symfony\Component\HttpKernel\HttpKernelInterface');
+        $kernel = $this->createMock(HttpKernelInterface::class);
         $request = SiteRequest::create('http://www.example.com', 'GET', [], [], [], [
             'HTTP_ACCEPT_LANGUAGE' => 'fr-FR,fr;q=0.8,en-US;q=0.6,en;q=0.4',
         ]);
@@ -111,7 +116,7 @@ class HostPathByLocaleSiteSelectorTest extends BaseLocaleSiteSelectorTest
         $response = $event->getResponse();
 
         // Ensure the response was a redirect to the default site
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
+        $this->assertInstanceOf(RedirectResponse::class, $response);
 
         // Ensure the redirect url is for "/fr"
         $this->assertEquals('/fr', $response->getTargetUrl());

--- a/tests/Site/HostPathSiteSelectorTest.php
+++ b/tests/Site/HostPathSiteSelectorTest.php
@@ -12,9 +12,14 @@
 namespace Sonata\PageBundle\Tests\Site;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Exception\NoValueException;
+use Sonata\PageBundle\CmsManager\DecoratorStrategyInterface;
 use Sonata\PageBundle\Entity\BaseSite;
+use Sonata\PageBundle\Model\SiteManagerInterface;
 use Sonata\PageBundle\Request\SiteRequest;
 use Sonata\PageBundle\Site\HostPathSiteSelector as BaseSiteSelector;
+use Sonata\SeoBundle\Seo\SeoPageInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
@@ -129,7 +134,7 @@ class HostPathSiteSelectorTest extends TestCase
         $response = $event->getResponse();
 
         // Ensure the response was a redirect to the default site
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
+        $this->assertInstanceOf(RedirectResponse::class, $response);
 
         // Ensure the redirect url is for "Site 2"
         $this->assertEquals('//www.example.com/test2', $response->getTargetUrl());
@@ -156,7 +161,7 @@ class HostPathSiteSelectorTest extends TestCase
         $response = $event->getResponse();
 
         // Ensure the response was a redirect to the default site
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
+        $this->assertInstanceOf(RedirectResponse::class, $response);
 
         // Ensure the redirect url is for "Site 2"
         $this->assertEquals('//www.example.com/test2', $response->getTargetUrl());
@@ -183,7 +188,7 @@ class HostPathSiteSelectorTest extends TestCase
         $response = $event->getResponse();
 
         // Ensure the response was a redirect to the default site
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
+        $this->assertInstanceOf(RedirectResponse::class, $response);
 
         // Ensure the redirect url is for "Site 2"
         $this->assertEquals('//www.example.com/test2', $response->getTargetUrl());
@@ -210,7 +215,7 @@ class HostPathSiteSelectorTest extends TestCase
         $response = $event->getResponse();
 
         // Ensure the response was a redirect to the default site
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
+        $this->assertInstanceOf(RedirectResponse::class, $response);
 
         // Ensure the redirect url is for "Site 2"
         $this->assertEquals('//www.example.com/test2', $response->getTargetUrl());
@@ -281,7 +286,7 @@ class HostPathSiteSelectorTest extends TestCase
      */
     protected function performHandleKernelRequestTest($url)
     {
-        $kernel = $this->createMock('Symfony\Component\HttpKernel\HttpKernelInterface');
+        $kernel = $this->createMock(HttpKernelInterface::class);
         $request = SiteRequest::create($url);
 
         // Ensure request locale is null
@@ -289,9 +294,9 @@ class HostPathSiteSelectorTest extends TestCase
 
         $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
 
-        $siteManager = $this->createMock('Sonata\PageBundle\Model\SiteManagerInterface');
-        $decoratorStrategy = $this->createMock('Sonata\PageBundle\CmsManager\DecoratorStrategyInterface');
-        $seoPage = $this->createMock('Sonata\SeoBundle\Seo\SeoPageInterface');
+        $siteManager = $this->createMock(SiteManagerInterface::class);
+        $decoratorStrategy = $this->createMock(DecoratorStrategyInterface::class);
+        $seoPage = $this->createMock(SeoPageInterface::class);
 
         $siteSelector = new HostPathSiteSelector($siteManager, $decoratorStrategy, $seoPage);
 

--- a/tests/Site/HostSiteSelectorTest.php
+++ b/tests/Site/HostSiteSelectorTest.php
@@ -12,8 +12,12 @@
 namespace Sonata\PageBundle\Tests\Site;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Exception\NoValueException;
+use Sonata\PageBundle\CmsManager\DecoratorStrategyInterface;
 use Sonata\PageBundle\Entity\BaseSite;
+use Sonata\PageBundle\Model\SiteManagerInterface;
 use Sonata\PageBundle\Site\HostSiteSelector as BaseSiteSelector;
+use Sonata\SeoBundle\Seo\SeoPageInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
@@ -124,7 +128,7 @@ class HostSiteSelectorTest extends TestCase
      */
     protected function performHandleKernelRequestTest($url)
     {
-        $kernel = $this->createMock('Symfony\Component\HttpKernel\HttpKernelInterface');
+        $kernel = $this->createMock(HttpKernelInterface::class);
         $request = Request::create($url);
 
         // Ensure request locale is null
@@ -132,9 +136,9 @@ class HostSiteSelectorTest extends TestCase
 
         $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
 
-        $siteManager = $this->createMock('Sonata\PageBundle\Model\SiteManagerInterface');
-        $decoratorStrategy = $this->createMock('Sonata\PageBundle\CmsManager\DecoratorStrategyInterface');
-        $seoPage = $this->createMock('Sonata\SeoBundle\Seo\SeoPageInterface');
+        $siteManager = $this->createMock(SiteManagerInterface::class);
+        $decoratorStrategy = $this->createMock(DecoratorStrategyInterface::class);
+        $seoPage = $this->createMock(SeoPageInterface::class);
 
         $siteSelector = new HostSiteSelector($siteManager, $decoratorStrategy, $seoPage);
 

--- a/tests/SonataPageBundleTest.php
+++ b/tests/SonataPageBundleTest.php
@@ -14,6 +14,7 @@ namespace Sonata\PageBundle\Tests;
 use Cocur\Slugify\Slugify;
 use PHPUnit\Framework\TestCase;
 use Sonata\PageBundle\SonataPageBundle;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class Page extends \Sonata\PageBundle\Model\Page
 {
@@ -36,11 +37,11 @@ class SonataPageBundleTest extends TestCase
     public function testBoot($text, $expected)
     {
         $bundle = new SonataPageBundle();
-        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock(ContainerInterface::class);
         $container->expects($this->exactly(1))->method('hasParameter')->will($this->returnValue(true));
         $container->expects($this->exactly(2))->method('getParameter')->will($this->returnCallback(function ($value) {
             if ('sonata.page.page.class' == $value) {
-                return 'Sonata\PageBundle\Tests\Page';
+                return Page::class;
             }
 
             if ('sonata.page.slugify_service' == $value) {

--- a/tests/Twig/Extension/PageExtensionTest.php
+++ b/tests/Twig/Extension/PageExtensionTest.php
@@ -12,26 +12,37 @@
 namespace Sonata\PageBundle\Tests\Twig\Extension;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\BlockBundle\Templating\Helper\BlockHelper;
+use Sonata\PageBundle\CmsManager\CmsManagerSelectorInterface;
+use Sonata\PageBundle\Model\PageBlockInterface;
+use Sonata\PageBundle\Model\PageInterface;
+use Sonata\PageBundle\Model\SiteInterface;
+use Sonata\PageBundle\Site\SiteSelectorInterface;
 use Sonata\PageBundle\Twig\Extension\PageExtension;
+use Symfony\Bridge\Twig\AppVariable;
+use Symfony\Bridge\Twig\Extension\HttpKernelExtension;
+use Symfony\Bundle\FrameworkBundle\Templating\GlobalVariables;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\RouterInterface;
 
 class PageExtensionTest extends TestCase
 {
     public function testAjaxUrl()
     {
-        $cmsManager = $this->createMock('Sonata\PageBundle\CmsManager\CmsManagerSelectorInterface');
-        $siteSelector = $this->createMock('Sonata\PageBundle\Site\SiteSelectorInterface');
-        $router = $this->createMock('Symfony\Component\Routing\RouterInterface');
+        $cmsManager = $this->createMock(CmsManagerSelectorInterface::class);
+        $siteSelector = $this->createMock(SiteSelectorInterface::class);
+        $router = $this->createMock(RouterInterface::class);
         $router->expects($this->once())->method('generate')->will($this->returnValue('/foo/bar'));
-        $blockHelper = $this->getMockBuilder('Sonata\BlockBundle\Templating\Helper\BlockHelper')
+        $blockHelper = $this->getMockBuilder(BlockHelper::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $httpKernelExtension = $this->getMockBuilder('Symfony\Bridge\Twig\Extension\HttpKernelExtension')
+        $httpKernelExtension = $this->getMockBuilder(HttpKernelExtension::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $page = $this->createMock('Sonata\PageBundle\Model\PageInterface');
-        $block = $this->createMock('Sonata\PageBundle\Model\PageBlockInterface');
+        $page = $this->createMock(PageInterface::class);
+        $block = $this->createMock(PageBlockInterface::class);
         $block->expects($this->exactly(2))->method('getPage')->will($this->returnValue($page));
 
         $extension = new PageExtension($cmsManager, $siteSelector, $router, $blockHelper, $httpKernelExtension);
@@ -40,29 +51,29 @@ class PageExtensionTest extends TestCase
 
     public function testController()
     {
-        $cmsManager = $this->createMock('Sonata\PageBundle\CmsManager\CmsManagerSelectorInterface');
-        $site = $this->createMock('Sonata\PageBundle\Model\SiteInterface');
+        $cmsManager = $this->createMock(CmsManagerSelectorInterface::class);
+        $site = $this->createMock(SiteInterface::class);
         $site->method('getRelativePath')->willReturn('/foo/bar');
-        $siteSelector = $this->createMock('Sonata\PageBundle\Site\SiteSelectorInterface');
+        $siteSelector = $this->createMock(SiteSelectorInterface::class);
         $siteSelector->method('retrieve')->willReturn($site);
-        $router = $this->createMock('Symfony\Component\Routing\RouterInterface');
-        $blockHelper = $this->getMockBuilder('Sonata\BlockBundle\Templating\Helper\BlockHelper')
+        $router = $this->createMock(RouterInterface::class);
+        $blockHelper = $this->getMockBuilder(BlockHelper::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $request = $this->createMock('Symfony\Component\HttpFoundation\Request');
+        $request = $this->createMock(Request::class);
         $request->method('getPathInfo')->willReturn('/');
-        $globals = $this->getMockBuilder('Symfony\Bundle\FrameworkBundle\Templating\GlobalVariables')
+        $globals = $this->getMockBuilder(GlobalVariables::class)
             ->disableOriginalConstructor()
             ->getMock();
         $globals->method('getRequest')->willReturn($request);
         $env = $this->createMock('Twig_Environment');
         $env->method('getGlobals')->willReturn(['app' => $globals]);
-        $httpKernelExtension = $this->getMockBuilder('Symfony\Bridge\Twig\Extension\HttpKernelExtension')
+        $httpKernelExtension = $this->getMockBuilder(HttpKernelExtension::class)
             ->disableOriginalConstructor()
             ->getMock();
         $extension = new PageExtension($cmsManager, $siteSelector, $router, $blockHelper, $httpKernelExtension);
         $extension->initRuntime($env);
-        if (!method_exists('Symfony\Bridge\Twig\AppVariable', 'getToken')) {
+        if (!method_exists(AppVariable::class, 'getToken')) {
             $httpKernelExtension->expects($this->once())->method('controller')->with(
                 'foo',
                 ['pathInfo' => '/foo/bar/'],
@@ -74,26 +85,26 @@ class PageExtensionTest extends TestCase
 
     public function testControllerWithoutSite()
     {
-        $cmsManager = $this->createMock('Sonata\PageBundle\CmsManager\CmsManagerSelectorInterface');
-        $siteSelector = $this->createMock('Sonata\PageBundle\Site\SiteSelectorInterface');
-        $router = $this->createMock('Symfony\Component\Routing\RouterInterface');
-        $blockHelper = $this->getMockBuilder('Sonata\BlockBundle\Templating\Helper\BlockHelper')
+        $cmsManager = $this->createMock(CmsManagerSelectorInterface::class);
+        $siteSelector = $this->createMock(SiteSelectorInterface::class);
+        $router = $this->createMock(RouterInterface::class);
+        $blockHelper = $this->getMockBuilder(BlockHelper::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $request = $this->createMock('Symfony\Component\HttpFoundation\Request');
+        $request = $this->createMock(Request::class);
         $request->method('getPathInfo')->willReturn('/');
-        $globals = $this->getMockBuilder('Symfony\Bundle\FrameworkBundle\Templating\GlobalVariables')
+        $globals = $this->getMockBuilder(GlobalVariables::class)
             ->disableOriginalConstructor()
             ->getMock();
         $globals->method('getRequest')->willReturn($request);
         $env = $this->createMock('Twig_Environment');
         $env->method('getGlobals')->willReturn(['app' => $globals]);
-        $httpKernelExtension = $this->getMockBuilder('Symfony\Bridge\Twig\Extension\HttpKernelExtension')
+        $httpKernelExtension = $this->getMockBuilder(HttpKernelExtension::class)
             ->disableOriginalConstructor()
             ->getMock();
         $extension = new PageExtension($cmsManager, $siteSelector, $router, $blockHelper, $httpKernelExtension);
         $extension->initRuntime($env);
-        if (!method_exists('Symfony\Bridge\Twig\AppVariable', 'getToken')) {
+        if (!method_exists(AppVariable::class, 'getToken')) {
             $httpKernelExtension->expects($this->once())->method('controller')->with('bar', [], []);
         }
         $extension->controller('bar');

--- a/tests/Validator/UniqueUrlValidatorTest.php
+++ b/tests/Validator/UniqueUrlValidatorTest.php
@@ -12,9 +12,15 @@
 namespace Sonata\PageBundle\Tests\Validator;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\PageBundle\Model\PageInterface;
+use Sonata\PageBundle\Model\PageManagerInterface;
+use Sonata\PageBundle\Model\SiteInterface;
 use Sonata\PageBundle\Validator\Constraints\UniqueUrl;
 use Sonata\PageBundle\Validator\UniqueUrlValidator;
+use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\Context\ExecutionContext;
+use Symfony\Component\Validator\Validator\ContextualValidatorInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class UniqueUrlValidatorTest extends TestCase
 {
@@ -23,13 +29,13 @@ class UniqueUrlValidatorTest extends TestCase
      */
     public function testValidateWithNoPageFound()
     {
-        $site = $this->createMock('Sonata\PageBundle\Model\SiteInterface');
+        $site = $this->createMock(SiteInterface::class);
 
-        $page = $this->createMock('Sonata\PageBundle\Model\PageInterface');
+        $page = $this->createMock(PageInterface::class);
         $page->expects($this->exactly(2))->method('getSite')->will($this->returnValue($site));
         $page->expects($this->exactly(2))->method('isError')->will($this->returnValue(false));
 
-        $manager = $this->createMock('Sonata\PageBundle\Model\PageManagerInterface');
+        $manager = $this->createMock(PageManagerInterface::class);
         $manager->expects($this->once())->method('fixUrl');
         $manager->expects($this->once())->method('findBy')->will($this->returnValue([$page]));
 
@@ -43,17 +49,17 @@ class UniqueUrlValidatorTest extends TestCase
 
     public function testValidateWithPageFound()
     {
-        $site = $this->createMock('Sonata\PageBundle\Model\SiteInterface');
+        $site = $this->createMock(SiteInterface::class);
 
-        $page = $this->createMock('Sonata\PageBundle\Model\PageInterface');
+        $page = $this->createMock(PageInterface::class);
         $page->expects($this->exactly(2))->method('getSite')->will($this->returnValue($site));
         $page->expects($this->exactly(2))->method('isError')->will($this->returnValue(false));
         $page->expects($this->any())->method('getUrl')->will($this->returnValue('/salut'));
 
-        $pageFound = $this->createMock('Sonata\PageBundle\Model\PageInterface');
+        $pageFound = $this->createMock(PageInterface::class);
         $pageFound->expects($this->any())->method('getUrl')->will($this->returnValue('/salut'));
 
-        $manager = $this->createMock('Sonata\PageBundle\Model\PageManagerInterface');
+        $manager = $this->createMock(PageManagerInterface::class);
         $manager->expects($this->once())->method('fixUrl');
         $manager->expects($this->once())->method('findBy')->will($this->returnValue([$page, $pageFound]));
 
@@ -67,18 +73,18 @@ class UniqueUrlValidatorTest extends TestCase
 
     public function testValidateWithRootUrlAndNoParent()
     {
-        $site = $this->createMock('Sonata\PageBundle\Model\SiteInterface');
+        $site = $this->createMock(SiteInterface::class);
 
-        $page = $this->createMock('Sonata\PageBundle\Model\PageInterface');
+        $page = $this->createMock(PageInterface::class);
         $page->expects($this->exactly(2))->method('getSite')->will($this->returnValue($site));
         $page->expects($this->exactly(2))->method('isError')->will($this->returnValue(false));
         $page->expects($this->exactly(1))->method('getParent')->will($this->returnValue(null));
         $page->expects($this->any())->method('getUrl')->will($this->returnValue('/'));
 
-        $pageFound = $this->createMock('Sonata\PageBundle\Model\PageInterface');
+        $pageFound = $this->createMock(PageInterface::class);
         $pageFound->expects($this->any())->method('getUrl')->will($this->returnValue('/'));
 
-        $manager = $this->createMock('Sonata\PageBundle\Model\PageManagerInterface');
+        $manager = $this->createMock(PageManagerInterface::class);
         $manager->expects($this->once())->method('fixUrl');
         $manager->expects($this->once())->method('findBy')->will($this->returnValue([$page, $pageFound]));
 
@@ -92,15 +98,15 @@ class UniqueUrlValidatorTest extends TestCase
 
     public function testValidateWithPageDynamic()
     {
-        $site = $this->createMock('Sonata\PageBundle\Model\SiteInterface');
+        $site = $this->createMock(SiteInterface::class);
 
-        $page = $this->createMock('Sonata\PageBundle\Model\PageInterface');
+        $page = $this->createMock(PageInterface::class);
         $page->expects($this->once())->method('getSite')->will($this->returnValue($site));
         $page->expects($this->once())->method('isError')->will($this->returnValue(false));
         $page->expects($this->once())->method('isDynamic')->will($this->returnValue(true));
         $page->expects($this->any())->method('getUrl')->will($this->returnValue('/salut'));
 
-        $manager = $this->createMock('Sonata\PageBundle\Model\PageManagerInterface');
+        $manager = $this->createMock(PageManagerInterface::class);
 
         $context = $this->getContext();
 
@@ -112,9 +118,9 @@ class UniqueUrlValidatorTest extends TestCase
 
     private function getContext()
     {
-        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
-        $validator = $this->createMock('Symfony\Component\Validator\Validator\ValidatorInterface');
-        $contextualValidator = $this->createMock('Symfony\Component\Validator\Validator\ContextualValidatorInterface');
+        $translator = $this->createMock(TranslatorInterface::class);
+        $validator = $this->createMock(ValidatorInterface::class);
+        $contextualValidator = $this->createMock(ContextualValidatorInterface::class);
 
         $context = new ExecutionContext($validator, 'root', $translator);
 


### PR DESCRIPTION
I am targeting this branch, because it's BC.

## Changelog

```markdown
### Fixed
 - Replaced FQCN strings with `::class` constants
```