### PR TITLE
Fix missing import

### DIFF
--- a/src/DependencyInjection/SonataPageExtension.php
+++ b/src/DependencyInjection/SonataPageExtension.php
@@ -12,6 +12,7 @@
 namespace Sonata\PageBundle\DependencyInjection;
 
 use Sonata\EasyExtendsBundle\Mapper\DoctrineCollector;
+use Sonata\PageBundle\Model\Template;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;


### PR DESCRIPTION
I am targeting this branch, because it's a bug fix.

## Changelog

```markdown
### Fixed
- Fixed missing import
```

## Subject

Thanks @core23 

P.S I checked other PRs that I made with FQCN - everything is fine), but found some missing imports for phpdoc, that have been missing for quite a time.