### PR TITLE
Put page listener behind firewall listener

### DIFF
--- a/src/Resources/config/page.xml
+++ b/src/Resources/config/page.xml
@@ -55,7 +55,7 @@
             <argument>%sonata.page.skip_redirection%</argument>
         </service>
         <service id="sonata.page.request_listener" class="%sonata.page.request_listener.class%">
-            <tag name="kernel.event_listener" event="kernel.request" method="onCoreRequest" priority="30"/>
+            <tag name="kernel.event_listener" event="kernel.request" method="onCoreRequest" priority="4"/>
             <argument type="service" id="sonata.page.cms_manager_selector"/>
             <argument type="service" id="sonata.page.site.selector"/>
             <argument type="service" id="sonata.page.decorator_strategy"/>


### PR DESCRIPTION
I am targeting this branch, because using remember_me functionality will break the page on the first hit (when not logged in).

## Changelog
```markdown
### Fixed
- Lowered page request listener to make sure it's triggered behind the firewall listener
```

## Subject

When using the remember_me functionality, a user can visit the website as an anonymous user. The Firewall Request Listerer will log in the user based on the remember_me cookie. Because the page listener forced itself infront of the firewall listener, it would load the page as a snapshot, which creates a problem later on, because the user is then logged in.
The result of this is an error page saying `No page instance available for the url, run the sonata:page:update-core-routes and sonata:page:create-snapshots commands`, which is solved then by a simple refresh. Something we don't want for our enduser.

The priority was last changed in: https://github.com/sonata-project/SonataPageBundle/commit/8f963ef4e95112cfac7f929ef518c47d137ebd86

I've now put it to "4", so it's still ahead of the regular "0" listeners, but behind the firewall, which has priority "8"
