### PR TITLE
Use class names for form field types

### DIFF
--- a/src/Block/ChildrenPagesBlockService.php
+++ b/src/Block/ChildrenPagesBlockService.php
@@ -15,9 +15,13 @@ use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Block\Service\AbstractAdminBlockService;
 use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
 use Sonata\PageBundle\CmsManager\CmsManagerSelectorInterface;
 use Sonata\PageBundle\Exception\PageNotFoundException;
+use Sonata\PageBundle\Form\Type\PageSelectorType;
 use Sonata\PageBundle\Site\SiteSelectorInterface;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Templating\EngineInterface;
@@ -86,24 +90,24 @@ class ChildrenPagesBlockService extends AbstractAdminBlockService
      */
     public function buildEditForm(FormMapper $formMapper, BlockInterface $block)
     {
-        $formMapper->add('settings', 'sonata_type_immutable_array', [
+        $formMapper->add('settings', ImmutableArrayType::class, [
             'keys' => [
-                ['title', 'text', [
+                ['title', TextType::class, [
                   'required' => false,
                     'label' => 'form.label_title',
                 ]],
-                ['current', 'checkbox', [
+                ['current', CheckboxType::class, [
                   'required' => false,
                   'label' => 'form.label_current',
                 ]],
-                ['pageId', 'sonata_page_selector', [
+                ['pageId', PageSelectorType::class, [
                     'model_manager' => $formMapper->getAdmin()->getModelManager(),
                     'class' => $formMapper->getAdmin()->getClass(),
                     'site' => $block->getPage()->getSite(),
                     'required' => false,
                     'label' => 'form.label_page',
                 ]],
-                ['class', 'text', [
+                ['class', TextType::class, [
                   'required' => false,
                   'label' => 'form.label_class',
                 ]],

--- a/src/Block/PageListBlockService.php
+++ b/src/Block/PageListBlockService.php
@@ -15,6 +15,7 @@ use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Block\Service\AbstractAdminBlockService;
 use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
 use Sonata\CoreBundle\Model\Metadata;
 use Sonata\PageBundle\Model\Page;
 use Sonata\PageBundle\Model\PageManagerInterface;
@@ -48,7 +49,7 @@ class PageListBlockService extends AbstractAdminBlockService
      */
     public function buildEditForm(FormMapper $formMapper, BlockInterface $block)
     {
-        $formMapper->add('settings', 'sonata_type_immutable_array', [
+        $formMapper->add('settings', ImmutableArrayType::class, [
             'keys' => [
                 ['title', TextType::class, [
                     'label' => 'form.label_title',

--- a/src/Block/SharedBlockBlockService.php
+++ b/src/Block/SharedBlockBlockService.php
@@ -13,10 +13,12 @@ namespace Sonata\PageBundle\Block;
 
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Form\Type\ModelListType;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Block\Service\AbstractAdminBlockService;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\BlockBundle\Model\BlockManagerInterface;
+use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
 use Sonata\CoreBundle\Validator\ErrorElement;
 use Sonata\PageBundle\Admin\SharedBlockAdmin;
 use Sonata\PageBundle\Model\Block;
@@ -104,7 +106,7 @@ class SharedBlockBlockService extends AbstractAdminBlockService
             $this->load($block);
         }
 
-        $formMapper->add('settings', 'sonata_type_immutable_array', [
+        $formMapper->add('settings', ImmutableArrayType::class, [
             'keys' => [
                 [$this->getBlockBuilder($formMapper), null, []],
             ],
@@ -191,7 +193,7 @@ class SharedBlockBlockService extends AbstractAdminBlockService
                 'type' => ClassMetadataInfo::MANY_TO_ONE,
             ]);
 
-        return $formMapper->create('blockId', 'sonata_type_model_list', [
+        return $formMapper->create('blockId', ModelListType::class, [
                 'sonata_field_description' => $fieldDescription,
                 'class' => $this->getSharedBlockAdmin()->getClass(),
                 'model_manager' => $this->getSharedBlockAdmin()->getModelManager(),


### PR DESCRIPTION
I am targeting this branch, because form components are broken with SF3.4.
## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Replaced service names for field types by classnames.
```

## Subject

<!-- Describe your Pull Request content here -->
When adding blocks to pages, errors were thrown because type fields are handled as class names but service names are given.