### PR TITLE
bugfix: create new container position corrected

### DIFF
--- a/assets/src/js/composer.js
+++ b/assets/src/js/composer.js
@@ -354,7 +354,7 @@
                     $parentFormControl.parent().parent().hide();
                 } else if (self.isFormControlTypeByName(formControlName, 'position')) {
                     $positionFormControl = $formControl;
-                    $positionFormControl.val($containerChildren.find('> *').length);
+                    $positionFormControl.val($containerChildren.find('> *').length - 1);
                     $positionFormControl.closest('.form-group').hide();
                 }
             });

--- a/src/Resources/public/sonata-page.back.js
+++ b/src/Resources/public/sonata-page.back.js
@@ -362,7 +362,7 @@
                     $parentFormControl.parent().parent().hide();
                 } else if (self.isFormControlTypeByName(formControlName, 'position')) {
                     $positionFormControl = $formControl;
-                    $positionFormControl.val($containerChildren.find('> *').length);
+                    $positionFormControl.val($containerChildren.find('> *').length - 1);
                     $positionFormControl.closest('.form-group').hide();
                 }
             });


### PR DESCRIPTION
I am targeting this branch, because it's a bugfix.

## Changelog

```markdown
### Fixed
- Add new block to container position starts with 0.
```
## Subject

When adding a new block in a container it uses the length of all children (including itself) which leads to an offset of 1. If you use the drag & drop sorting the count is one less as it starts with 0. This is usually not a big problem as you just have a gap in the positions but the sorting still works fine, but if you depend on the position in the template or controller this can lead to unexpected behavior. 

I.E. you want to give the first child in a container an extra class. If you just add the items (without sorting) the position starts at 1. If you use the drag & drop sort feature the position starts at 0.