### PR TITLE
Added more options to blocks

### DIFF
--- a/src/Block/ChildrenPagesBlockService.php
+++ b/src/Block/ChildrenPagesBlockService.php
@@ -96,6 +96,14 @@ class ChildrenPagesBlockService extends AbstractAdminBlockService
                   'required' => false,
                     'label' => 'form.label_title',
                 ]],
+                ['translation_domain', TextType::class, [
+                    'label' => 'form.label_translation_domain',
+                    'required' => false,
+                ]],
+                ['icon', TextType::class, [
+                    'label' => 'form.label_icon',
+                    'required' => false,
+                ]],
                 ['current', CheckboxType::class, [
                   'required' => false,
                   'label' => 'form.label_current',
@@ -132,8 +140,10 @@ class ChildrenPagesBlockService extends AbstractAdminBlockService
         $resolver->setDefaults([
             'current' => true,
             'pageId' => null,
-            'title' => '',
-            'class' => '',
+            'title' => null,
+            'translation_domain' => null,
+            'icon' => null,
+            'class' => null,
             'template' => '@SonataPage/Block/block_core_children_pages.html.twig',
         ]);
     }

--- a/src/Block/PageListBlockService.php
+++ b/src/Block/PageListBlockService.php
@@ -55,6 +55,18 @@ class PageListBlockService extends AbstractAdminBlockService
                     'label' => 'form.label_title',
                     'required' => false,
                 ]],
+                ['translation_domain', TextType::class, [
+                    'label' => 'form.label_translation_domain',
+                    'required' => false,
+                ]],
+                ['icon', TextType::class, [
+                    'label' => 'form.label_icon',
+                    'required' => false,
+                ]],
+                ['class', TextType::class, [
+                    'label' => 'form.label_class',
+                    'required' => false,
+                ]],
                 ['mode', ChoiceType::class, [
                     'label' => 'form.label_mode',
                     'choices' => [
@@ -97,7 +109,10 @@ class PageListBlockService extends AbstractAdminBlockService
     {
         $resolver->setDefaults([
             'mode' => 'public',
-            'title' => 'List Pages',
+            'title' => null,
+            'translation_domain' => null,
+            'icon' => 'fa fa-globe',
+            'class' => null,
             'template' => '@SonataPage/Block/block_pagelist.html.twig',
         ]);
     }

--- a/src/Resources/translations/SonataPageBundle.de.xliff
+++ b/src/Resources/translations/SonataPageBundle.de.xliff
@@ -914,6 +914,14 @@
                 <source>pages.label_no_site_selected</source>
                 <target>Keine Seiten ausgewählt</target>
             </trans-unit>
+            <trans-unit id="form.label_translation_domain">
+                <source>form.label_translation_domain</source>
+                <target>Übersetzungsdatei</target>
+            </trans-unit>
+            <trans-unit id="form.label_icon">
+                <source>form.label_icon</source>
+                <target>Icon</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Resources/translations/SonataPageBundle.en.xliff
+++ b/src/Resources/translations/SonataPageBundle.en.xliff
@@ -915,6 +915,14 @@
                 <source>pages.label_no_site_selected</source>
                 <target>No site selected</target>
             </trans-unit>
+            <trans-unit id="form.label_translation_domain">
+                <source>form.label_translation_domain</source>
+                <target>Translation domain</target>
+            </trans-unit>
+            <trans-unit id="form.label_icon">
+                <source>form.label_icon</source>
+                <target>Icon</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Resources/translations/SonataPageBundle.fr.xliff
+++ b/src/Resources/translations/SonataPageBundle.fr.xliff
@@ -916,6 +916,14 @@
                 <source>pages.label_no_site_selected</source>
                 <target>pages.label_no_site_selected</target>
             </trans-unit>
+            <trans-unit id="form.label_translation_domain">
+                <source>form.label_translation_domain</source>
+                <target>Domaine de traduction</target>
+            </trans-unit>
+            <trans-unit id="form.label_icon">
+                <source>form.label_icon</source>
+                <target>Icône</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Resources/views/Block/block_core_children_pages.html.twig
+++ b/src/Resources/views/Block/block_core_children_pages.html.twig
@@ -13,7 +13,18 @@ file that was distributed with this source code.
 
 {% block block %}
     <div class="sonata-page-menu-container {{ settings.class }}">
-        {% if settings.title %}<h3>{{ settings.title }}</h3>{% endif %}
+        {% if settings.title is not empty %}
+            <h4>
+                {% if settings.icon %}
+                    <i class="{{ settings.icon }}" aria-hidden="true"></i>
+                {% endif %}
+                {% if settings.translation_domain %}
+                    {{ settings.title|trans({}, settings.translation_domain) }}
+                {% else %}
+                    {{ settings.title }}
+                {% endif %}
+            </h4>
+        {% endif %}
 
         <ul class="sonata-page-menu-chilren-list">
             {% if page %}

--- a/src/Resources/views/Block/block_core_children_pages.html.twig
+++ b/src/Resources/views/Block/block_core_children_pages.html.twig
@@ -12,7 +12,7 @@ file that was distributed with this source code.
 {% extends sonata_block.templates.block_base %}
 
 {% block block %}
-    <div class="sonata-page-menu-container {{ settings.class }}">
+    <div class="{{ settings.class }}">
         {% if settings.title is not empty %}
             <h4>
                 {% if settings.icon %}
@@ -26,10 +26,10 @@ file that was distributed with this source code.
             </h4>
         {% endif %}
 
-        <ul class="sonata-page-menu-chilren-list">
+        <ul>
             {% if page %}
                 {% for child in page.children %}
-                    <li class="sonata-page-menu-children-element"><a href="{{ path(child) }}" title="{{ child.name|escape }}">{{ child.name }}</a></li>
+                    <li><a href="{{ path(child) }}" title="{{ child.name|escape }}">{{ child.name }}</a></li>
                 {% endfor %}
             {% endif %}
         </ul>

--- a/src/Resources/views/Block/block_pagelist.html.twig
+++ b/src/Resources/views/Block/block_pagelist.html.twig
@@ -1,10 +1,19 @@
 {% extends sonata_block.templates.block_base %}
 
 {% block block %}
-    <div class="panel panel-default panel-page-list">
+    <div class="panel panel-default {{ settings.class }}">
         {% if settings.title is not empty %}
             <div class="panel-heading">
-                <h4 class="panel-title"><i class="fa fa-globe"></i> {{ settings.title }}</h4>
+                <h4 class="panel-title">
+                    {% if settings.icon %}
+                        <i class="{{ settings.icon }}" aria-hidden="true"></i>
+                    {% endif %}
+                    {% if settings.translation_domain %}
+                        {{ settings.title|trans({}, settings.translation_domain) }}
+                    {% else %}
+                        {{ settings.title }}
+                    {% endif %}
+                </h4>
             </div>
         {% endif %}
 

--- a/tests/Block/PageListBlockServiceTest.php
+++ b/tests/Block/PageListBlockServiceTest.php
@@ -41,7 +41,10 @@ class PageListBlockServiceTest extends AbstractBlockServiceTestCase
 
         $this->assertSettings([
             'mode' => 'public',
-            'title' => 'List Pages',
+            'title' => null,
+            'translation_domain' => null,
+            'icon' => 'fa fa-globe',
+            'class' => null,
             'template' => '@SonataPage/Block/block_pagelist.html.twig',
         ], $blockContext);
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this feature is BC (if you ignore the html changes).

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
 - added block title translation domain option
 - added block icon option
 - added block class option

### Removed
 - Removed default title from blocks
 - Removed old `sonata-` classes from templates
```

