### PR TITLE
Changed default templates for system pages

### DIFF
--- a/src/Resources/views/Exceptions/list.html.twig
+++ b/src/Resources/views/Exceptions/list.html.twig
@@ -8,8 +8,6 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 
 #}
-{% extends "::base.html.twig" %}
-
 {% block title %}{{ 'title_list_exceptions'|trans({}, 'SonataPageBundle')}}{% endblock %}
 
 {% block body %}

--- a/src/Resources/views/Page/create.html.twig
+++ b/src/Resources/views/Page/create.html.twig
@@ -8,7 +8,7 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 
 #}
-{% extends "@SonataPage/layout.html.twig" %}
+{% extends sonata_page.defaultTemplate %}
 
 {% block title %}{{ "title_page_not_found"|trans({}, 'SonataPageBundle')}}{% endblock %}
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a patch.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
 - Remove default template from exception list
 - Use default template in page create template

```


## Subject

The old address won't work in with newer twig versions.
