### PR TITLE
Added button styles

### DIFF
--- a/src/Resources/views/Page/create.html.twig
+++ b/src/Resources/views/Page/create.html.twig
@@ -10,7 +10,7 @@ file that was distributed with this source code.
 #}
 {% extends "@SonataPage/layout.html.twig" %}
 
-{% block title %}{{ "title_page_not_found"|trans({}, 'SonataPageBundle')}}{% endblock %}
+{% block title %}{{ "title_page_not_found"|trans({}, 'SonataPageBundle') }}{% endblock %}
 
 {% block content %}
     <div>
@@ -18,7 +18,10 @@ file that was distributed with this source code.
 
         {% if creatable %}
             <p>
-                <a href="{{ sonata_admin.url('sonata.page.admin.page', 'create', {'url': pathInfo, 'siteId': site.id}) }}">
+                <a href="{{ sonata_admin.url('sonata.page.admin.page', 'create', {'url': pathInfo, 'siteId': site.id}) }}"
+                   class="btn btn-primary"
+                >
+                    <i class="fa fa-plus" aria-hidden="true"></i>
                     {{ "create_page"|trans({'pathInfo': pathInfo}, 'SonataPageBundle') }}
                 </a>
             </p>
@@ -26,6 +29,6 @@ file that was distributed with this source code.
             <p>
                 {{ "message_page_does_not_exist"|trans({'pathInfo': pathInfo}, 'SonataPageBundle') }}
             </p>
-        {% endif%}
+        {% endif %}
     </div>
-{% endblock%}
+{% endblock %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a patch.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
 - Added styling to page create button
```
Before
<img width="389" alt="bildschirmfoto 2018-02-06 um 20 44 30" src="https://user-images.githubusercontent.com/3440437/35880584-9c5283b0-0b7e-11e8-9794-a60f00ec36bd.PNG">

After
<img width="400" alt="bildschirmfoto 2018-02-06 um 20 44 52" src="https://user-images.githubusercontent.com/3440437/35880583-9c387d26-0b7e-11e8-8efb-3965eb633c75.PNG">
