### PR TITLE
Removed duplicate title from page composer

### DIFF
--- a/src/Resources/views/PageAdmin/compose.html.twig
+++ b/src/Resources/views/PageAdmin/compose.html.twig
@@ -9,24 +9,22 @@ file that was distributed with this source code.
 
 #}
 
-{% extends '@SonataAdmin/CRUD/action.html.twig' %}
+{% extends 'SonataAdminBundle:CRUD:action.html.twig' %}
 
 {% block title %}
     {{ "title_edit"|trans({'%name%': admin.toString(object)|truncate(15) }, 'SonataAdminBundle') }}
 {% endblock %}
 
 {% block navbar_title %}
-    {{ block('title') }}
+    {{ 'page.compose_page'|trans({}, 'SonataPageBundle') }} "{{ page.name }}" <small>[{{ 'page.compose_template_label'|trans({}, 'SonataPageBundle') }}: <b>{{ template.name }}</b>]</small>
 {% endblock %}
 
 {% block body_attributes %}class="sonata-bc skin-black fixed page-composer-page sonata-ba-no-side-menu"{% endblock %}
 
 {% block content %}
     <div class="page-composer">
-        <h2>{{ 'page.compose_page'|trans({}, 'SonataPageBundle') }} "{{ page.name }}" <small>[{{ 'page.compose_template_label'|trans({}, 'SonataPageBundle') }}: <b>{{ template.name }}</b>]</small></h2>
-
         {% if containers|length == 0 %}
-            {% include '@SonataPage/PageAdmin/compose_hint.html.twig' %}
+            {% include 'SonataPageBundle:PageAdmin:compose_hint.html.twig' %}
         {% else %}
             <div class="row row-fluid">
                 <div class="col-md-4 span4">


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a patch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown 
### Removed
 - Removed duplicate title from page composer
```

## Subject

Before
<img width="525" alt="bildschirmfoto 2018-02-06 um 21 02 36" src="https://user-images.githubusercontent.com/3440437/35881573-849d91d0-0b81-11e8-8b41-566d5e8472e2.PNG">

After
<img width="594" alt="bildschirmfoto 2018-02-06 um 21 05 02" src="https://user-images.githubusercontent.com/3440437/35881570-84720df8-0b81-11e8-8bda-aa049887b2cf.PNG">
