### PR TITLE
Commands as services

### DIFF
--- a/src/DependencyInjection/SonataPageExtension.php
+++ b/src/DependencyInjection/SonataPageExtension.php
@@ -72,6 +72,7 @@ class SonataPageExtension extends Extension
         $loader->load('http_kernel.xml');
         $loader->load('consumer.xml');
         $loader->load('validators.xml');
+        $loader->load('command.xml');
 
         $this->configureMultisite($container, $config);
         $this->configureCache($container, $config);

--- a/src/Resources/config/command.xml
+++ b/src/Resources/config/command.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="Sonata\PageBundle\Command\CleanupSnapshotsCommand" class="Sonata\PageBundle\Command\CleanupSnapshotsCommand" public="true">
+            <tag name="console.command"/>
+        </service>
+        <service id="Sonata\PageBundle\Command\CloneSiteCommand" class="Sonata\PageBundle\Command\CloneSiteCommand" public="true">
+            <tag name="console.command"/>
+        </service>
+        <service id="Sonata\PageBundle\Command\CreateBlockContainerCommand" class="Sonata\PageBundle\Command\CreateBlockContainerCommand" public="true">
+            <tag name="console.command"/>
+        </service>
+        <service id="Sonata\PageBundle\Command\CreateSiteCommand" class="Sonata\PageBundle\Command\CreateSiteCommand" public="true">
+            <tag name="console.command"/>
+        </service>
+        <service id="Sonata\PageBundle\Command\CreateSnapshotsCommand" class="Sonata\PageBundle\Command\CreateSnapshotsCommand" public="true">
+            <tag name="console.command"/>
+        </service>
+        <service id="Sonata\PageBundle\Command\DumpPageCommand" class="Sonata\PageBundle\Command\DumpPageCommand" public="true">
+            <tag name="console.command"/>
+        </service>
+        <service id="Sonata\PageBundle\Command\MigrateBlockNameSettingCommand" class="Sonata\PageBundle\Command\MigrateBlockNameSettingCommand" public="true">
+            <tag name="console.command"/>
+        </service>
+        <service id="Sonata\PageBundle\Command\MigrateToJsonTypeCommand" class="Sonata\PageBundle\Command\MigrateToJsonTypeCommand" public="true">
+            <tag name="console.command"/>
+        </service>
+        <service id="Sonata\PageBundle\Command\RenderBlockCommand" class="Sonata\PageBundle\Command\RenderBlockCommand" public="true">
+            <tag name="console.command"/>
+        </service>
+        <service id="Sonata\PageBundle\Command\UpdateCoreRoutesCommand" class="Sonata\PageBundle\Command\UpdateCoreRoutesCommand" public="true">
+            <tag name="console.command"/>
+        </service>
+    </services>
+</container>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a BC fix.


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Commands not working on symfony4
```

## Subject

On symfony4 commands are not working as they are not registered as a services, this fixes it.