### PR TITLE
Show blocks with blockMetadata only

### DIFF
--- a/src/Resources/views/PageAdmin/compose_container_show.html.twig
+++ b/src/Resources/views/PageAdmin/compose_container_show.html.twig
@@ -8,10 +8,8 @@
     <div class="page-composer__block-type-selector">
         <label>{{ 'composer.block.add.type'|trans({}, 'SonataPageBundle') }}</label>
         <select class="page-composer__block-type-selector__select" style="width: auto">
-            {% for blockServiceId, blockService in blockServices %}
-                {% if blockService.blockMetadata is defined %}
-                    <option value="{{ blockServiceId }}">{{ blockService.blockMetadata.title|trans({}, blockService.blockMetadata.domain|default('SonataBlockBundle')) }}</option>
-                {% endif %}
+            {% for blockServiceId, blockService in blockServices if blockService.blockMetadata is defined %}
+                <option value="{{ blockServiceId }}">{{ blockService.blockMetadata.title|trans({}, blockService.blockMetadata.domain|default('SonataBlockBundle')) }}</option>
             {% endfor %}
         </select>
         <a class="btn btn-action btn-small page-composer__block-type-selector__confirm"

--- a/src/Resources/views/PageAdmin/compose_container_show.html.twig
+++ b/src/Resources/views/PageAdmin/compose_container_show.html.twig
@@ -9,7 +9,9 @@
         <label>{{ 'composer.block.add.type'|trans({}, 'SonataPageBundle') }}</label>
         <select class="page-composer__block-type-selector__select" style="width: auto">
             {% for blockServiceId, blockService in blockServices %}
-                <option value="{{ blockServiceId }}">{{ blockService.blockMetadata.title|trans({}, blockService.blockMetadata.domain|default('SonataBlockBundle')) }}</option>
+                {% if blockService.blockMetadata is defined %}
+                    <option value="{{ blockServiceId }}">{{ blockService.blockMetadata.title|trans({}, blockService.blockMetadata.domain|default('SonataBlockBundle')) }}</option>
+                {% endif %}
             {% endfor %}
         </select>
         <a class="btn btn-action btn-small page-composer__block-type-selector__confirm"


### PR DESCRIPTION
I am targeting this branch, because this is a patch.

## Changelog

```markdown
### Fixed
- Only blocks with getBlockMetadata method will be shown in "add block of type" menu of Page Composer
```

## Subject

If a block is added to `sonata_block.blocks` without contexts, and if a block is **not** implementing `Sonata\BlockBundle\Block\Service\AdminBlockServiceInterface`, and if `sonata_block.default_contexts: [sonata_page_bundle]`, then there will be a error in `PageAdmin\compose_container_show.html.twig` template in Page Composer:

> Neither the property "blockMetadata" nor one of the methods "blockMetadata()", "getblockMetadata()"/"isblockMetadata()"/"hasblockMetadata()" or "__call()" exist and have public access in class "Sonata\AdminBundle\Block\AdminSearchBlockService".