### PR TITLE
Require sonata-project/doctrine-orm-admin-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "sonata-project/core-bundle": "^3.9",
         "sonata-project/datagrid-bundle": "^2.3",
         "sonata-project/doctrine-extensions": "^1.0",
+        "sonata-project/doctrine-orm-admin-bundle": "^3.5",
         "sonata-project/easy-extends-bundle": "^2.5",
         "sonata-project/notification-bundle": "^3.3",
         "sonata-project/seo-bundle": "^2.5",
@@ -52,19 +53,14 @@
     },
     "conflict": {
         "friendsofsymfony/rest-bundle": "<2.1 || >=3.0",
-        "jms/serializer": "<0.13",
-        "sonata-project/doctrine-orm-admin-bundle": "<3.0 || >=4.0"
+        "jms/serializer": "<0.13"
     },
     "require-dev": {
         "friendsofsymfony/rest-bundle": "^2.1",
         "jms/serializer-bundle": "^1.0 || ^2.0",
         "matthiasnoback/symfony-dependency-injection-test": "^1.1",
         "nelmio/api-doc-bundle": "^2.4",
-        "sonata-project/doctrine-orm-admin-bundle": "^3.4",
         "symfony/phpunit-bridge": "^4.0"
-    },
-    "suggest": {
-        "sonata-project/doctrine-orm-admin-bundle": "^2.2"
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
I am targeting this branch, because this a patch.

See https://github.com/sonata-project/dev-kit/issues/409

## Subject

SonataPageBundle supports only DoctrineORM. This PR will allow to install fully functional AdminBundle with DoctrineORM support after `composer require sonata-project/page-bundle`. And it will be still possible to create a recipe for Flex if this PR won't be accepted, these changes are optional