### PR TITLE
Fix deprecations for addChild

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "cocur/slugify": "^1.0 || ^2.0 || ^3.0",
-        "sonata-project/admin-bundle": "^3.31",
+        "sonata-project/admin-bundle": "^3.35",
         "sonata-project/block-bundle": "^3.11",
         "sonata-project/cache": "^1.0.2",
         "sonata-project/cache-bundle": "^2.4",

--- a/src/Resources/config/admin.xml
+++ b/src/Resources/config/admin.xml
@@ -30,9 +30,11 @@
             <argument>%sonata.page.admin.page.controller%</argument>
             <call method="addChild">
                 <argument type="service" id="sonata.page.admin.block"/>
+                <argument>page</argument>
             </call>
             <call method="addChild">
                 <argument type="service" id="sonata.page.admin.snapshot"/>
+                <argument>page</argument>
             </call>
             <call method="setPageManager">
                 <argument type="service" id="sonata.page.manager.page"/>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCommentBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- fixes `addChild` deprecations
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->

## Subject

After merging https://github.com/sonata-project/SonataAdminBundle/pull/5058 all the bundles that used `addChild` are now throwing deprecations, this fixes it.