### PR TITLE
Added support for latest sonata cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "cocur/slugify": "^1.0 || ^2.0 || ^3.0",
         "sonata-project/admin-bundle": "^3.35",
         "sonata-project/block-bundle": "^3.11",
-        "sonata-project/cache": "^1.0.2",
+        "sonata-project/cache": "^1.0.2 || ^2.0",
         "sonata-project/cache-bundle": "^2.4",
         "sonata-project/core-bundle": "^3.9",
         "sonata-project/datagrid-bundle": "^2.3",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this feature is BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added support for latest `sonata-project/cache`
```
