### PR TITLE
#590 duplicate root route when it in config

### DIFF
--- a/src/Route/RoutePageGenerator.php
+++ b/src/Route/RoutePageGenerator.php
@@ -91,16 +91,7 @@ class RoutePageGenerator
 
         // no root url for the given website, create one
         if (!$root) {
-            $root = $this->pageManager->create([
-                'routeName' => PageInterface::PAGE_ROUTE_CMS_NAME,
-                'name' => 'Homepage',
-                'url' => '/',
-                'site' => $site,
-                'requestMethod' => $requirements['_method'] ??
-                    'GET|POST|HEAD|DELETE|PUT',
-                'slug' => '/',
-            ]);
-
+            $root = $this->createRootPage($site);
             $this->pageManager->save($root);
         }
 
@@ -247,5 +238,38 @@ MSG
         if ($output instanceof OutputInterface) {
             $output->writeln($message);
         }
+    }
+
+    /**
+     * Generate root page (parent for another generated page).
+     * If root path available in config - create from config
+     * Else - generate it statically.
+     */
+    private function createRootPage(SiteInterface $site): PageInterface
+    {
+        foreach ($this->router->getRouteCollection()->all() as $name => $route) {
+            if ('/' === $route->getPath()) {
+                $requirements = $route->getRequirements();
+                $name = trim($name);
+
+                return $this->pageManager->create([
+                    'routeName' => $name,
+                    'name' => $name,
+                    'url' => $route->getPath(),
+                    'site' => $site,
+                    'requestMethod' => $requirements['_method'] ?? 'GET|POST|HEAD|DELETE|PUT',
+                    'slug' => '/',
+                ]);
+            }
+        }
+
+        return $this->pageManager->create([
+            'routeName' => PageInterface::PAGE_ROUTE_CMS_NAME,
+            'name' => 'Homepage',
+            'url' => '/',
+            'site' => $site,
+            'requestMethod' => 'GET|POST|HEAD|DELETE|PUT',
+            'slug' => '/',
+        ]);
     }
 }


### PR DESCRIPTION
I am targeting this branch, because its patch.

Closes #590
Code is not my idea, thank @grimpows

## Changelog

Updated RoutePageGenerator. Now, homepage creates statically, and it stay as root page for another config pages by default. If  we will create in config page with root path ("/") - they same as other will child page (it means it will available by two slashes path ("example.com//"). 
This patch, before creating homepage looks in config page and search any page with root path. If it will found - we will use that config page as root.
So, after patch, possible configure bundle for homepage in routing file.

### Fixed

Creating homepage from router config (check if page available in config - we will not create default Homepage.

### Security

I checked this on my project. Looks good. Checked generating new routes and update previously routes.
Please double check this code.