### PR TITLE
Remove default value for parent association mappings

### DIFF
--- a/src/Admin/BlockAdmin.php
+++ b/src/Admin/BlockAdmin.php
@@ -31,11 +31,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class BlockAdmin extends BaseBlockAdmin
 {
     /**
-     * {@inheritdoc}
-     */
-    protected $parentAssociationMapping = 'page';
-
-    /**
      * @var array
      */
     protected $blocks;

--- a/src/Admin/SnapshotAdmin.php
+++ b/src/Admin/SnapshotAdmin.php
@@ -33,11 +33,6 @@ class SnapshotAdmin extends AbstractAdmin
     /**
      * {@inheritdoc}
      */
-    protected $parentAssociationMapping = 'page';
-
-    /**
-     * {@inheritdoc}
-     */
     protected $accessMapping = [
         'batchToggleEnabled' => 'EDIT',
     ];


### PR DESCRIPTION
I am targeting this branch, because this is a bug fix.

See https://github.com/sonata-project/SonataPageBundle/pull/983 and https://github.com/sonata-project/SonataAdminBundle/pull/5058

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Removed default value for parent association mappings
```

## Subject

I am not sure if this is a BC break or not, but without this PR PageBundle is broken.

Now, an exception `Warning: Illegal string offset 'sonata.page.admin.page'` is occured when `Sonata\AdminBundle\Admin\addParentAssociationMapping` tries to set a value, but there is a default string instead of array.