### PR TITLE
Force use breadcrumb translation strings for page admins

### DIFF
--- a/src/Admin/BlockAdmin.php
+++ b/src/Admin/BlockAdmin.php
@@ -35,6 +35,8 @@ class BlockAdmin extends BaseBlockAdmin
      */
     protected $blocks;
 
+    protected $classnameLabel = 'Block';
+
     /**
      * {@inheritdoc}
      */

--- a/src/Admin/PageAdmin.php
+++ b/src/Admin/PageAdmin.php
@@ -40,6 +40,8 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
  */
 class PageAdmin extends AbstractAdmin
 {
+    protected $classnameLabel = 'Page';
+
     /**
      * @var PageManagerInterface
      */

--- a/src/Admin/SiteAdmin.php
+++ b/src/Admin/SiteAdmin.php
@@ -29,6 +29,8 @@ use Symfony\Component\Form\Extension\Core\Type\TextareaType;
  */
 class SiteAdmin extends AbstractAdmin
 {
+    protected $classnameLabel = 'Site';
+
     /**
      * @var RoutePageGenerator
      */

--- a/src/Admin/SnapshotAdmin.php
+++ b/src/Admin/SnapshotAdmin.php
@@ -25,6 +25,8 @@ use Sonata\CoreBundle\Form\Type\DateTimePickerType;
  */
 class SnapshotAdmin extends AbstractAdmin
 {
+    protected $classnameLabel = 'Snapshot';
+
     /**
      * @var CacheManagerInterface
      */


### PR DESCRIPTION
I am targeting this branch, because this is a patch.

## Changelog

```markdown
### Changed
- Force use breadcrumb translation strings for page admins
```

## Subject

If a last part of Block/Page/Site/Snapshot class name differs from `Block`, `Page`, `Site` or `Snapshot`, then Admin will try to use non-existing translation strings for breadcrumbs instead of `breadcrumb.link_page_list` or `breadcrumb.link_site_create`, i.e. it will use `breadcrumb.link_sonata_page_page_list for `SonataPagePage` and `breadcrumb.link_sonata_page_site_create` for `SonataPageSite` classes. `$classnameLabel` property for `SharedBlockAdmin` already exists.

With this PR Admin will be forced to use existing translation strings.