### PR TITLE
Auto-register datepicker form theme

### DIFF
--- a/src/DependencyInjection/SonataPageExtension.php
+++ b/src/DependencyInjection/SonataPageExtension.php
@@ -17,6 +17,7 @@ use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
@@ -24,8 +25,18 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class SonataPageExtension extends Extension
+class SonataPageExtension extends Extension implements PrependExtensionInterface
 {
+    public function prepend(ContainerBuilder $container)
+    {
+        if ($container->hasExtension('twig')) {
+            // add custom form widgets
+            $container->prependExtensionConfig('twig', [
+                'form_themes' => ['@SonataCore/Form/datepicker.html.twig'],
+            ]);
+        }
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/tests/DependencyInjection/SonataPageExtensionTest.php
+++ b/tests/DependencyInjection/SonataPageExtensionTest.php
@@ -13,6 +13,7 @@ namespace Sonata\PageBundle\Tests\DependencyInjection;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 use Sonata\PageBundle\DependencyInjection\SonataPageExtension;
+use Symfony\Bundle\TwigBundle\DependencyInjection\TwigExtension;
 
 /**
  * Tests the SonataPageExtension.
@@ -60,6 +61,21 @@ class SonataPageExtensionTest extends AbstractExtensionTestCase
         ]);
         $this->assertContainerBuilderHasParameter('sonata.page.router_auto_register.enabled', true);
         $this->assertContainerBuilderHasParameter('sonata.page.router_auto_register.priority', 84);
+    }
+
+    public function testDatePickerFormTheme()
+    {
+        $this->container->setParameter('kernel.bundles', []);
+        $this->container->setParameter('kernel.bundles_metadata', []);
+        $this->container->setParameter('kernel.project_dir', __DIR__);
+        $this->container->setParameter('kernel.root_dir', __DIR__);
+        $this->container->registerExtension(new TwigExtension());
+
+        $this->container->compile();
+        $this->assertTrue(in_array(
+            '@SonataCore/Form/datepicker.html.twig',
+            $this->container->getParameter('twig.form.resources')
+        ));
     }
 
     protected function getContainerExtensions()


### PR DESCRIPTION
I am targeting this branch, because this is a patch.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Auto-register datepicker form theme
```

## Subject

If datepicker form theme was not added after installation, `Enabled from` and `Enabled to` fields looks like a regular text fields, and it is almost imposible to fill that fields manualy. To fix this, developer must add this configuration:
```yaml
twig:
    form_themes:
        - '@SonataCore/Form/datepicker.html.twig'
```

This PR will add this configuration for developer automaticaly in SonataPageExtension