### PR TITLE
Hide debug information in prod environment

### DIFF
--- a/src/Listener/ExceptionListener.php
+++ b/src/Listener/ExceptionListener.php
@@ -188,6 +188,10 @@ class ExceptionListener
      */
     private function handleInternalError(GetResponseForExceptionEvent $event)
     {
+        if (false === $this->debug) {
+            return;
+        }
+
         $content = $this->templating->render('@SonataPage/internal_error.html.twig', [
             'exception' => $event->getException(),
         ]);

--- a/src/Listener/ExceptionListener.php
+++ b/src/Listener/ExceptionListener.php
@@ -189,6 +189,10 @@ class ExceptionListener
     private function handleInternalError(GetResponseForExceptionEvent $event)
     {
         if (false === $this->debug) {
+            $this->logger->error($event->getException()->getMessage(), [
+                'exception' => $event->getException(),
+            ]);
+
             return;
         }
 

--- a/tests/Listener/ExceptionListenerTest.php
+++ b/tests/Listener/ExceptionListenerTest.php
@@ -106,16 +106,11 @@ class ExceptionListenerTest extends TestCase
         $exception = $this->createMock(InternalErrorException::class);
         $event = $this->getMockEvent($exception);
 
-        // mock templating to expect a twig rendering
-        $this->templating->expects($this->once())->method('render')
-             ->with($this->equalTo('@SonataPage/internal_error.html.twig'));
+        $this->logger->expects($this->once())
+            ->method('error');
 
         // WHEN
         $this->listener->onKernelException($event);
-
-        // THEN
-        $this->assertInstanceOf(Response::class, $event->getResponse(), 'Should return a response in event');
-        $this->assertEquals(500, $event->getResponse()->getStatusCode(), 'Should return 500 status code');
     }
 
     /**


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1001

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Security
- Hide debug information in prod environment
```

## Subject

You should not show any debug information, the reason why there is an internal error, in a prod environment.
