### PR TITLE
Add support for mssql in the SnapshotManager to clean up snapshots

### DIFF
--- a/src/Entity/SnapshotManager.php
+++ b/src/Entity/SnapshotManager.php
@@ -288,6 +288,30 @@ class SnapshotManager extends BaseEntityManager implements SnapshotManagerInterf
                 $keep
             ));
         }
+        
+        if ('mssql' === $platform) {
+            return $this->getConnection()->exec(sprintf(
+                'DELETE FROM %s
+                WHERE
+                    page_id = %d
+                    AND id NOT IN (
+                        SELECT id
+                        FROM (
+                            SELECT TOP %d id, publication_date_end
+                            FROM %s
+                            WHERE
+                                page_id = %d
+                            ORDER BY
+                                publication_date_end DESC
+                        ) AS table_alias
+                )',
+                $tableName,
+                $page->getId(),
+                $keep,
+                $tableName,
+                $page->getId()
+            ));
+        }
 
         throw new \RuntimeException(sprintf('The %s database platform has not been tested yet. Please report us if it works and feel free to create a pull request to handle it ;-)', $platform));
     }

--- a/src/Entity/SnapshotManager.php
+++ b/src/Entity/SnapshotManager.php
@@ -288,7 +288,7 @@ class SnapshotManager extends BaseEntityManager implements SnapshotManagerInterf
                 $keep
             ));
         }
-        
+
         if ('mssql' === $platform) {
             return $this->getConnection()->exec(sprintf(
                 'DELETE FROM %s


### PR DESCRIPTION
I am targeting this branch, because it's a new feature that is backwards compatible.

## Changelog

```markdown
### Added
- Add support for mssql in `SnapshotManager` to clean up snapshots
```

## Subject

Cleaning up snapshots aren't currently supported on MSSQL databases. This PR adds support for MSSQL when cleaning up snapshots.
