### PR TITLE
Added admin icons

### DIFF
--- a/src/Resources/config/admin.xml
+++ b/src/Resources/config/admin.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <parameters>
+        <parameter key="sonata.page.admin.groupname">sonata_page</parameter>
+        <parameter key="sonata.page.admin.groupicon"><![CDATA[<i class='fa fa-sitemap'></i>]]></parameter>
         <!-- PAGE -->
         <parameter key="sonata.page.admin.page.class">Sonata\PageBundle\Admin\PageAdmin</parameter>
         <parameter key="sonata.page.admin.page.controller">SonataPageBundle:PageAdmin</parameter>
@@ -24,7 +26,7 @@
     </parameters>
     <services>
         <service id="sonata.page.admin.page" class="%sonata.page.admin.page.class%" public="true">
-            <tag name="sonata.admin" manager_type="orm" group="sonata_page" label_catalogue="%sonata.page.admin.page.translation_domain%" label="page" label_translator_strategy="sonata.admin.label.strategy.underscore"/>
+            <tag name="sonata.admin" manager_type="orm" group="%sonata.page.admin.groupname%" label_catalogue="%sonata.page.admin.page.translation_domain%" label="page" label_translator_strategy="sonata.admin.label.strategy.underscore" icon="%sonata.page.admin.groupicon%"/>
             <argument/>
             <argument>%sonata.page.admin.page.entity%</argument>
             <argument>%sonata.page.admin.page.controller%</argument>
@@ -50,7 +52,7 @@
             </call>
         </service>
         <service id="sonata.page.admin.block" class="%sonata.page.admin.block.class%" public="true">
-            <tag name="sonata.admin" manager_type="orm" show_in_dashboard="false" group="sonata_page" label_catalogue="%sonata.page.admin.page.translation_domain%" label="block" label_translator_strategy="sonata.admin.label.strategy.underscore"/>
+            <tag name="sonata.admin" manager_type="orm" show_in_dashboard="false" group="%sonata.page.admin.groupname%" label_catalogue="%sonata.page.admin.page.translation_domain%" label="block" label_translator_strategy="sonata.admin.label.strategy.underscore" icon="%sonata.page.admin.groupicon%"/>
             <argument/>
             <argument>%sonata.page.admin.block.entity%</argument>
             <argument>%sonata.page.admin.block.controller%</argument>
@@ -75,7 +77,7 @@
             </call>
         </service>
         <service id="sonata.page.admin.shared_block" class="%sonata.page.admin.shared_block.class%" public="true">
-            <tag name="sonata.admin" manager_type="orm" show_in_dashboard="true" group="sonata_page" label_catalogue="%sonata.page.admin.page.translation_domain%" label="shared_block" label_translator_strategy="sonata.admin.label.strategy.underscore"/>
+            <tag name="sonata.admin" manager_type="orm" show_in_dashboard="true" group="%sonata.page.admin.groupname%" label_catalogue="%sonata.page.admin.page.translation_domain%" label="shared_block" label_translator_strategy="sonata.admin.label.strategy.underscore" icon="%sonata.page.admin.groupicon%"/>
             <argument/>
             <argument>%sonata.page.admin.block.entity%</argument>
             <argument>%sonata.page.admin.shared_block.controller%</argument>
@@ -99,7 +101,7 @@
             </call>
         </service>
         <service id="sonata.page.admin.snapshot" class="%sonata.page.admin.snapshot.class%" public="true">
-            <tag name="sonata.admin" manager_type="orm" group="sonata_page" label_catalogue="%sonata.page.admin.snapshot.translation_domain%" label="snapshot" show_in_dashboard="false" label_translator_strategy="sonata.admin.label.strategy.underscore"/>
+            <tag name="sonata.admin" manager_type="orm" group="%sonata.page.admin.groupname%" label_catalogue="%sonata.page.admin.snapshot.translation_domain%" label="snapshot" show_in_dashboard="false" label_translator_strategy="sonata.admin.label.strategy.underscore" icon="%sonata.page.admin.groupicon%"/>
             <argument/>
             <argument>%sonata.page.admin.snapshot.entity%</argument>
             <argument>%sonata.page.admin.snapshot.controller%</argument>
@@ -111,7 +113,7 @@
             </call>
         </service>
         <service id="sonata.page.admin.site" class="%sonata.page.admin.site.class%" public="true">
-            <tag name="sonata.admin" manager_type="orm" group="sonata_page" label_catalogue="%sonata.page.admin.site.translation_domain%" label="site" label_translator_strategy="sonata.admin.label.strategy.underscore"/>
+            <tag name="sonata.admin" manager_type="orm" group="%sonata.page.admin.groupname%" label_catalogue="%sonata.page.admin.site.translation_domain%" label="site" label_translator_strategy="sonata.admin.label.strategy.underscore" icon="%sonata.page.admin.groupicon%"/>
             <argument/>
             <argument>%sonata.page.admin.site.entity%</argument>
             <argument>%sonata.page.admin.site.controller%</argument>

--- a/src/Resources/translations/SonataPageBundle.de.xliff
+++ b/src/Resources/translations/SonataPageBundle.de.xliff
@@ -720,7 +720,7 @@
             </trans-unit>
             <trans-unit id="179" resname="shared_block">
                 <source>shared_block</source>
-                <target>shared_block</target>
+                <target>Gemeinsame Blöcke</target>
             </trans-unit>
             <trans-unit id="180" resname="breadcrumb.link_shared_block_batch">
                 <source>breadcrumb.link_shared_block_batch</source>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added group icon to admin pages
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->

