### PR TITLE
Catch empty locale in exception listener

### DIFF
--- a/src/Listener/ExceptionListener.php
+++ b/src/Listener/ExceptionListener.php
@@ -248,7 +248,7 @@ class ExceptionListener
 
             $cmsManager->setCurrentPage($page);
 
-            if ($page->getSite()->getLocale() !== $event->getRequest()->getLocale()) {
+            if (null !== $page->getSite()->getLocale() && $page->getSite()->getLocale() !== $event->getRequest()->getLocale()) {
                 // Compare locales because Request returns the default one if null.
 
                 // If 404, LocaleListener from HttpKernel component of Symfony is not called.

--- a/tests/Listener/ExceptionListenerTest.php
+++ b/tests/Listener/ExceptionListenerTest.php
@@ -156,11 +156,11 @@ class ExceptionListenerTest extends TestCase
 
         // mock a site
         $site = $this->createMock(SiteInterface::class);
-        $site->expects($this->exactly(2))->method('getLocale')->will($this->returnValue('fr'));
+        $site->expects($this->exactly(3))->method('getLocale')->will($this->returnValue('fr'));
 
         // mock an error page
         $page = $this->createMock(PageInterface::class);
-        $page->expects($this->exactly(2))->method('getSite')->will($this->returnValue($site));
+        $page->expects($this->exactly(3))->method('getSite')->will($this->returnValue($site));
 
         // mock cms manager to return the mock error page and set it as current page
         $this->cmsManager = $this->createMock(CmsManagerInterface::class);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a patch.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Catch empty locale in exception listener
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->

## Subject

The Request object in symfony expects only string, not null values.
