### PR TITLE
Use page title in breadcrumb

### DIFF
--- a/src/Block/BreadcrumbBlockService.php
+++ b/src/Block/BreadcrumbBlockService.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\PageBundle\Block;
 
 use Knp\Menu\FactoryInterface;
+use Knp\Menu\ItemInterface;
 use Knp\Menu\Provider\MenuProviderInterface;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\PageBundle\CmsManager\CmsManagerSelectorInterface;
@@ -78,21 +79,11 @@ class BreadcrumbBlockService extends BaseBreadcrumbMenuBlockService
                 continue;
             }
 
-            $menu->addChild($parent->getName(), [
-                'route' => 'page_slug',
-                'routeParameters' => [
-                    'path' => $parent->getUrl(),
-                ],
-            ]);
+            $this->createMenuItem($menu, $parent);
         }
 
         if (!$page->isError()) {
-            $menu->addChild($page->getName(), [
-                'route' => 'page_slug',
-                'routeParameters' => [
-                    'path' => $page->getUrl(),
-                ],
-            ]);
+            $this->createMenuItem($menu, $page);
         }
 
         return $menu;
@@ -108,5 +99,19 @@ class BreadcrumbBlockService extends BaseBreadcrumbMenuBlockService
         $cms = $this->cmsSelector->retrieve();
 
         return $cms->getCurrentPage();
+    }
+
+    /**
+     * @param ItemInterface $menu
+     * @param PageInterface $page
+     */
+    private function createMenuItem(ItemInterface $menu, PageInterface $page): void
+    {
+        $menu->addChild($page->getName(), [
+            'route' => 'page_slug',
+            'routeParameters' => [
+                'path' => $page->getUrl(),
+            ],
+        ]);
     }
 }

--- a/src/Block/BreadcrumbBlockService.php
+++ b/src/Block/BreadcrumbBlockService.php
@@ -101,17 +101,23 @@ class BreadcrumbBlockService extends BaseBreadcrumbMenuBlockService
         return $cms->getCurrentPage();
     }
 
-    /**
-     * @param ItemInterface $menu
-     * @param PageInterface $page
-     */
     private function createMenuItem(ItemInterface $menu, PageInterface $page): void
     {
-        $menu->addChild($page->getName(), [
+        $label = $page->getTitle();
+        $extras = [];
+
+        if (null === $label) {
+            $label = $page->getName();
+
+            $extras['translation_domain'] = 'SonataPageBundle';
+        }
+
+        $menu->addChild($label, [
             'route' => 'page_slug',
             'routeParameters' => [
                 'path' => $page->getUrl(),
             ],
+            'extras' => $extras,
         ]);
     }
 }

--- a/src/Model/PageInterface.php
+++ b/src/Model/PageInterface.php
@@ -248,7 +248,7 @@ interface PageInterface
     /**
      * Get children.
      *
-     * @return ArrayCollection|array
+     * @return ArrayCollection|PageInterface[]
      */
     public function getChildren();
 
@@ -262,7 +262,7 @@ interface PageInterface
     /**
      * Get blocks.
      *
-     * @return ArrayCollection|array
+     * @return ArrayCollection|PageBlockInterface[]
      */
     public function getBlocks();
 
@@ -389,12 +389,12 @@ interface PageInterface
     public function getHeaders();
 
     /**
-     * @param array $parents
+     * @param PageInterface[] $parents
      */
     public function setParents(array $parents);
 
     /**
-     * @return array
+     * @return PageInterface[]
      */
     public function getParents();
 

--- a/src/Resources/translations/SonataPageBundle.de.xliff
+++ b/src/Resources/translations/SonataPageBundle.de.xliff
@@ -922,6 +922,14 @@
                 <source>form.label_icon</source>
                 <target>Icon</target>
             </trans-unit>
+            <trans-unit id="sonata_page_exceptions_list">
+                <source>sonata_page_exceptions_list</source>
+                <target>Exceptions</target>
+            </trans-unit>
+            <trans-unit id="sonata_page_exceptions_edit">
+                <source>sonata_page_exceptions_edit</source>
+                <target>Exception bearbeiten</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Resources/translations/SonataPageBundle.en.xliff
+++ b/src/Resources/translations/SonataPageBundle.en.xliff
@@ -923,6 +923,14 @@
                 <source>form.label_icon</source>
                 <target>Icon</target>
             </trans-unit>
+            <trans-unit id="sonata_page_exceptions_list">
+                <source>sonata_page_exceptions_list</source>
+                <target>Exceptions</target>
+            </trans-unit>
+            <trans-unit id="sonata_page_exceptions_edit">
+                <source>sonata_page_exceptions_edit</source>
+                <target>Edit exception</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Resources/views/Page/breadcrumb.html.twig
+++ b/src/Resources/views/Page/breadcrumb.html.twig
@@ -8,15 +8,24 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 
 #}
+{%- macro label(page) -%}
+    {% if page.title %}
+        {{ page.title }}
+    {% else %}
+        {{ page.name|trans({}, 'SonataPageBundle') }}
+    {% endif %}
+{%- endmacro -%}
+
+{% import _self as helper %}
 
 {% if breadcrumbs %}
     <ul {% for attrname, attrvalue in options.container_attr %}{{ attrname }}="{{ attrvalue }}" {% endfor %}>
         {% for breadcrumb in breadcrumbs %}
             <li {% for attrname, attrvalue in options.elements_attr %}{{ attrname }}="{{ attrvalue }}" {% endfor %}>
                 {% if not breadcrumb.isdynamic %}
-                    <a href="{{ path(breadcrumb) }}" title="{{ breadcrumb.title ? : breadcrumb.name }}">{{ breadcrumb.title ? : breadcrumb.name }}</a>{{ options.separator|raw }}
+                    <a href="{{ path(breadcrumb) }}" title="{{ label(breadcrumb) }}">{{ label(breadcrumb) }}</a>{{ options.separator|raw }}
                 {% else %}
-                    {{ breadcrumb.title ? : breadcrumb.name }}{{ options.separator|raw }}
+                    {{ label(breadcrumb) }}{{ options.separator|raw }}
                 {% endif %}
             </li>
         {% endfor %}
@@ -25,9 +34,9 @@ file that was distributed with this source code.
         {% set li_attrs = options.elements_attr|merge({'class': li_attrs_class}) %}
         <li {% for attrname, attrvalue in li_attrs %}{{ attrname }}="{{ attrvalue }}" {% endfor %}>
             {% if not page.isdynamic %}
-                <a href="{{ path(page) }}" title="{{ page.title ? : page.name }}">{{ page.title ? : page.name }}</a>{{ options.last_separator|raw }}
+                <a href="{{ path(page) }}" title="{{ helper.label(page) }}">{{ helper.label(page) }}</a>{{ options.last_separator|raw }}
             {% else %}
-                {{ page.title ? : page.name }}{{ options.last_separator|raw }}
+                {{ helper.label(page) }}{{ options.last_separator|raw }}
             {% endif %}
         </li>
     </ul>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
The breadcrumb was using the (technical) page name if no special SEO title was defined. The page title is now used if it is defined, otherwise the translated page name is used.

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a bugfix.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataPageBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Translate page name in breadcrumb if no title is defined

### Fixed
- Use page title in breadcrumbs
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
