### PR TITLE
fix(decorator-strategy): check headers values as strings

### DIFF
--- a/src/CmsManager/DecoratorStrategy.php
+++ b/src/CmsManager/DecoratorStrategy.php
@@ -57,12 +57,14 @@ class DecoratorStrategy implements DecoratorStrategyInterface
             return false;
         }
 
-        if (true === $response->headers->get('x-sonata-page-not-decorable', false)) {
+        // TODO: drop support for `true` value when bumping symfony/http-foundation dependency to >= 3.4.31
+        if (\in_array($response->headers->get('x-sonata-page-not-decorable', '0'), [true, '1'], true)) {
             return false;
         }
 
+        // TODO: drop support for `true` value when bumping symfony/http-foundation dependency to >= 3.4.31
         // the main controller explicitly force the the page to be decorate
-        if (true === $response->headers->get('x-sonata-page-decorable', false)) {
+        if (\in_array($response->headers->get('x-sonata-page-decorable', '0'), [true, '1'], true)) {
             return true;
         }
 

--- a/tests/CmsManager/DecoratorStrategyTest.php
+++ b/tests/CmsManager/DecoratorStrategyTest.php
@@ -15,13 +15,14 @@ namespace Sonata\PageBundle\Tests\Page;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\PageBundle\CmsManager\DecoratorStrategy;
-use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class DecoratorStrategyTest extends TestCase
 {
+    // TODO: drop support for headers' boolean values when bumping symfony/http-foundation dependency to >= 3.4.31
     public function testIsDecorable()
     {
         $response = new Response('dummy');
@@ -31,7 +32,7 @@ class DecoratorStrategyTest extends TestCase
 
         $this->assertFalse($strategy->isDecorable($request, HttpKernelInterface::SUB_REQUEST, $response));
 
-        $response->headers = new ParameterBag();
+        $response->headers = new ResponseHeaderBag();
         $response->headers->set('Content-Type', 'foo/test');
 
         $this->assertFalse($strategy->isDecorable($request, HttpKernelInterface::MASTER_REQUEST, $response));
@@ -47,11 +48,22 @@ class DecoratorStrategyTest extends TestCase
 
         $request->headers->set('x-requested-with', null);
 
+        $response->headers->set('x-sonata-page-decorable', true);
+        $this->assertTrue($strategy->isDecorable($request, HttpKernelInterface::MASTER_REQUEST, $response));
+
+        $response->headers->set('x-sonata-page-not-decorable', true);
+        $this->assertFalse($strategy->isDecorable($request, HttpKernelInterface::MASTER_REQUEST, $response));
+
+        $response->headers->set('x-sonata-page-not-decorable', '1');
+        $this->assertFalse($strategy->isDecorable($request, HttpKernelInterface::MASTER_REQUEST, $response));
+
+        $response->headers->remove('x-sonata-page-not-decorable');
+
         $response->headers->set('x-sonata-page-decorable', false);
         $this->assertFalse($strategy->isDecorable($request, HttpKernelInterface::MASTER_REQUEST, $response));
 
         $request->headers->set('x-requested-with', 'XMLHttpRequest');
-        $response->headers->set('x-sonata-page-decorable', true);
+        $response->headers->set('x-sonata-page-decorable', '1');
         $this->assertTrue($strategy->isDecorable($request, HttpKernelInterface::MASTER_REQUEST, $response));
     }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it's a bug fix.

This project does not properly compare HttpFoundation headers values. The returned value can be a string, an array of strings or null. The following commit : https://github.com/symfony/symfony/commit/ef5ead00059fc321e7fda20c2dfdd4440585be26#diff-5f886132f28113d74a1a219e967e88fcR124 recently enforced the returned values (by casting them to strings). Thus, the strict comparisons against booleans does not work anymore.

The bug was not detected by the CI because the wrong bag is used for headers in the unit test. I updated it and I also added assertions for the non tested header `x-sonata-page-not-decorable`.

I think it's better to handle both cases (bool & string) to not force a `symfony/http-foundation` bump.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataPageBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed `DecoratorStrategy` compatibility with `symfony/http-foundation` >= 3.4.31
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
