### PR TITLE
Add missing translation for admin menu

### DIFF
--- a/src/Resources/translations/SonataAdminBundle.de.xlf
+++ b/src/Resources/translations/SonataAdminBundle.de.xlf
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="de" datatype="plaintext" original="file.ext">
+    <header>
+      <tool tool-id="symfony" tool-name="Symfony"/>
+    </header>
+    <body>
+      <trans-unit id="sonata_page">
+        <source>sonata_page</source>
+        <target>Seiten</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Resources/translations/SonataAdminBundle.en.xlf
+++ b/src/Resources/translations/SonataAdminBundle.en.xlf
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" datatype="plaintext" original="file.ext">
+    <header>
+      <tool tool-id="symfony" tool-name="Symfony"/>
+    </header>
+    <body>
+      <trans-unit id="sonata_page">
+        <source>sonata_page</source>
+        <target>Pages</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

This key is defined here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/src/Resources/config/admin.xml#L4 and used at the admin sidebar.
If you don't define a custom translation domain (at the AdminBundle config), the fallback domain is `SonataAdminBundle`

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/4.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a patch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataUserBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Add missing translation for admin menu
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
