### PR TITLE
 Add internal as default context for sonata.page.block.container 

### DIFF
--- a/src/Resources/config/block.xml
+++ b/src/Resources/config/block.xml
@@ -10,7 +10,7 @@
     </parameters>
     <services>
         <service id="sonata.page.block.container" class="%sonata.page.block.container.class%">
-            <tag name="sonata.block"/>
+            <tag name="sonata.block" context="internal"/>
             <argument>sonata.page.block.container</argument>
             <argument type="service" id="sonata.templating"/>
         </service>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is technically a BC break, because it removes technically blocks from the page composer, but no one should ever used it.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataPageBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Add `internal` as default context for technical blocks
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
