### PR TITLE
fix(admin-service-definitions): remove setFormTheme calls

### DIFF
--- a/src/Resources/config/admin.xml
+++ b/src/Resources/config/admin.xml
@@ -69,12 +69,6 @@
             <call method="setContainerBlockTypes">
                 <argument>%sonata.block.container.types%</argument>
             </call>
-            <call method="setFormTheme">
-                <argument type="collection">
-                    <argument>@SonataPage/Form/form_admin_fields.html.twig</argument>
-                    <argument>@SonataDoctrineORMAdmin/Form/form_admin_fields.html.twig</argument>
-                </argument>
-            </call>
         </service>
         <service id="sonata.page.admin.shared_block" class="%sonata.page.admin.shared_block.class%" public="true">
             <tag name="sonata.admin" manager_type="orm" show_in_dashboard="true" group="%sonata.page.admin.groupname%" label_catalogue="%sonata.page.admin.page.translation_domain%" label="shared_block" label_translator_strategy="sonata.admin.label.strategy.underscore" icon="%sonata.page.admin.groupicon%"/>
@@ -92,12 +86,6 @@
             </call>
             <call method="setContainerBlockTypes">
                 <argument>%sonata.block.container.types%</argument>
-            </call>
-            <call method="setFormTheme">
-                <argument type="collection">
-                    <argument>@SonataPage/Form/form_admin_fields.html.twig</argument>
-                    <argument>@SonataDoctrineORMAdmin/Form/form_admin_fields.html.twig</argument>
-                </argument>
             </call>
         </service>
         <service id="sonata.page.admin.snapshot" class="%sonata.page.admin.snapshot.class%" public="true">


### PR DESCRIPTION
## Subject

I am targeting this branch, because this is a bug fix.

Global form template configuration set on the `SonataDoctrineORMAdminBundle` bundle  is currently not applied on the block admin services.

The problem is linked to the `SonataDoctrineORMAdminBundle` `AddTemplatesCompilerPass` compiler pass.

This compiler pass does not add the `setFormTheme()` method call (with the values defined in its bundle configuration) if it's already defined (cf https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/src/DependencyInjection/Compiler/AddTemplatesCompilerPass.php#L37).

The problem is that the method call is always defined since it's hardcoded in the service definitions of this bundle (that's what I'm removing).

Defining this method call in the service definition is useless because the default global form templates configuration on `SonataDoctrineORMAdminBundle` side is exactly the same than the one we have here (cf https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/src/DependencyInjection/Configuration.php#L59).

That means this change is backward compatible for users that did not override the `sonata_doctrine_orm_admin.templates.form` configuration key. For the rest, the good value will now be taken into account. Overidding through `sonata_admin.admin_services.*` configuration continue to behave the same.

## Changelog
```markdown
### Fixed
- Fixed `SonataDoctrineORMAdminBundle` global form template configuration not being taken into account on the block admin services.
```