### PR TITLE
[CacheBundle] Add missing typehint for v3 support

### DIFF
--- a/src/Cache/BlockEsiCache.php
+++ b/src/Cache/BlockEsiCache.php
@@ -99,8 +99,12 @@ class BlockEsiCache extends VarnishCache
         return new CacheElement($keys, new Response($content));
     }
 
-    public function set(array $keys, $data, $ttl = CacheElement::DAY, array $contextualKeys = []): CacheElementInterface
-    {
+    public function set(
+        array $keys,
+        $data,
+        int $ttl = CacheElement::DAY,
+        array $contextualKeys = []
+    ): CacheElementInterface {
         $this->validateKeys($keys);
 
         return new CacheElement($keys, $data, $ttl, $contextualKeys);

--- a/src/Cache/BlockSsiCache.php
+++ b/src/Cache/BlockSsiCache.php
@@ -81,8 +81,12 @@ class BlockSsiCache extends SsiCache
         return new CacheElement($keys, new Response($content));
     }
 
-    public function set(array $keys, $data, $ttl = CacheElement::DAY, array $contextualKeys = []): CacheElementInterface
-    {
+    public function set(
+        array $keys,
+        $data,
+        int $ttl = CacheElement::DAY,
+        array $contextualKeys = []
+    ): CacheElementInterface {
         $this->validateKeys($keys);
 
         return new CacheElement($keys, $data, $ttl, $contextualKeys);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Add missing argument type declaration missed in https://github.com/sonata-project/SonataPageBundle/pull/1054.
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it's a BC break.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
