### PR TITLE
Require doctrine/doctrine-bundle 1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     "require": {
         "php": "^7.1",
         "cocur/slugify": "^1.0 || ^2.0 || ^3.0",
+        "doctrine/doctrine-bundle": "^1.0",
         "sonata-project/admin-bundle": "^3.35",
         "sonata-project/block-bundle": "^3.18",
         "sonata-project/cache": "^1.0.2 || ^2.0",

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "symfony/config": "^3.4 || ^4.2",
         "symfony/console": "^3.4 || ^4.2",
         "symfony/debug": "^3.4 || ^4.2",
-        "symfony/dependency-injection": "^3.4 || ^4.2",
+        "symfony/dependency-injection": "^3.4 || ^4.2,<4.4.0",
         "symfony/form": "^3.4 || ^4.2",
         "symfony/http-foundation": "^3.4.31 || ^4.2",
         "symfony/http-kernel": "^3.4 || ^4.2",


### PR DESCRIPTION
## Subject

We rely on a `doctrine` service defined in that bundle, which means we
have a dependency on the bundle that cannot be seen by just examining
php code like composer-require-checker does.
The error might be quite easy to fix, but the constraint I added should
stay, and be broadened to include version 2 when the time comes

See:
- https://github.com/doctrine/DoctrineBundle/blob/d1f8a28fb45b6ff0b59f88df393575a4f89c3b66/Resources/config/dbal.xml#L67
- https://github.com/sonata-project/SonataPageBundle/blob/3.x/src/Resources/config/orm.xml#L25

Refs #1094, which should be properly fixed in another PR that adds
support for version 2.

I am targeting this branch, because this is BC.


## Changelog


```markdown
### Fixed
- crash when upgrading to `doctrine/doctrine-bundle` 2
```