### PR TITLE
Add show.label_type missing translation for fr and en

### DIFF
--- a/src/Resources/translations/SonataPageBundle.en.xliff
+++ b/src/Resources/translations/SonataPageBundle.en.xliff
@@ -939,6 +939,10 @@
                 <source>sonata.page.block.container</source>
                 <target>Container</target>
             </trans-unit>
+            <trans-unit id="show.label_type">
+                <source>show.label_type</source>
+                <target>Type</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Resources/translations/SonataPageBundle.fr.xliff
+++ b/src/Resources/translations/SonataPageBundle.fr.xliff
@@ -924,6 +924,10 @@
                 <source>form.label_icon</source>
                 <target>Icône</target>
             </trans-unit>
+            <trans-unit id="show.label_type">
+                <source>show.label_type</source>
+                <target>Type</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
## Subject

PageAdmin adds the "type" field by default. The default translation key for this field is "show.label_type". It does not exist in this bundle translation domain.

I am targeting this branch, because it is a bug fix.

## Changelog

```markdown
### Added
- Added the "show.label_type" translation for the "fr" and "en" locales.
```