### PR TITLE
Use doctrine/bundle 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "php": "^7.1",
         "cocur/slugify": "^1.0 || ^2.0 || ^3.0",
         "doctrine/doctrine-bundle": "^1.0 || ^2.0",
+        "doctrine/persistence": "^1.3.3",
         "sonata-project/admin-bundle": "^3.35",
         "sonata-project/block-bundle": "^3.18",
         "sonata-project/cache": "^1.0.2 || ^2.0",

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "symfony/config": "^3.4 || ^4.2",
         "symfony/console": "^3.4 || ^4.2",
         "symfony/debug": "^3.4 || ^4.2",
-        "symfony/dependency-injection": "^3.4 || ^4.2",
+        "symfony/dependency-injection": "^3.4 || ^4.2,<4.4.0",
         "symfony/form": "^3.4 || ^4.2",
         "symfony/http-foundation": "^3.4.31 || ^4.2",
         "symfony/http-kernel": "^3.4 || ^4.2",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.1",
         "cocur/slugify": "^1.0 || ^2.0 || ^3.0",
-        "doctrine/doctrine-bundle": ">=1.12.3 <2.0 || ^2.0",
+        "doctrine/doctrine-bundle": "^1.12.3 || ^2.0",
         "doctrine/persistence": "^1.3.3",
         "sonata-project/admin-bundle": "^3.35",
         "sonata-project/block-bundle": "^3.18",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.1",
         "cocur/slugify": "^1.0 || ^2.0 || ^3.0",
-        "doctrine/doctrine-bundle": "^1.0 || ^2.0",
+        "doctrine/doctrine-bundle": ">=1.12.3 <2.0 || ^2.0",
         "doctrine/persistence": "^1.3.3",
         "sonata-project/admin-bundle": "^3.35",
         "sonata-project/block-bundle": "^3.18",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.1",
         "cocur/slugify": "^1.0 || ^2.0 || ^3.0",
-        "doctrine/doctrine-bundle": "^1.0",
+        "doctrine/doctrine-bundle": "^2.0",
         "sonata-project/admin-bundle": "^3.35",
         "sonata-project/block-bundle": "^3.18",
         "sonata-project/cache": "^1.0.2 || ^2.0",
@@ -39,7 +39,7 @@
         "symfony/config": "^3.4 || ^4.2",
         "symfony/console": "^3.4 || ^4.2",
         "symfony/debug": "^3.4 || ^4.2",
-        "symfony/dependency-injection": "^3.4 || ^4.2,<4.4.0",
+        "symfony/dependency-injection": "^3.4 || ^4.2",
         "symfony/form": "^3.4 || ^4.2",
         "symfony/http-foundation": "^3.4.31 || ^4.2",
         "symfony/http-kernel": "^3.4 || ^4.2",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.1",
         "cocur/slugify": "^1.0 || ^2.0 || ^3.0",
-        "doctrine/doctrine-bundle": "^2.0",
+        "doctrine/doctrine-bundle": "^1.0 || ^2.0",
         "sonata-project/admin-bundle": "^3.35",
         "sonata-project/block-bundle": "^3.18",
         "sonata-project/cache": "^1.0.2 || ^2.0",

--- a/src/Entity/BlockInteractor.php
+++ b/src/Entity/BlockInteractor.php
@@ -14,10 +14,10 @@ declare(strict_types=1);
 namespace Sonata\PageBundle\Entity;
 
 use Doctrine\ORM\EntityManager;
+use Doctrine\Persistence\ManagerRegistry;
 use Sonata\BlockBundle\Model\BlockManagerInterface;
 use Sonata\PageBundle\Model\BlockInteractorInterface;
 use Sonata\PageBundle\Model\PageInterface;
-use Symfony\Bridge\Doctrine\RegistryInterface;
 
 /**
  * This class interacts with blocks.
@@ -32,7 +32,7 @@ class BlockInteractor implements BlockInteractorInterface
     protected $pageBlocksLoaded = [];
 
     /**
-     * @var RegistryInterface
+     * @var ManagerRegistry
      */
     protected $registry;
 
@@ -42,10 +42,10 @@ class BlockInteractor implements BlockInteractorInterface
     protected $blockManager;
 
     /**
-     * @param RegistryInterface     $registry     Doctrine registry
+     * @param ManagerRegistry       $registry     Doctrine registry
      * @param BlockManagerInterface $blockManager Block manager
      */
-    public function __construct(RegistryInterface $registry, BlockManagerInterface $blockManager)
+    public function __construct(ManagerRegistry $registry, BlockManagerInterface $blockManager)
     {
         $this->blockManager = $blockManager;
         $this->registry = $registry;

--- a/src/Entity/Transformer.php
+++ b/src/Entity/Transformer.php
@@ -15,6 +15,7 @@ namespace Sonata\PageBundle\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\BlockBundle\Model\BlockManagerInterface;
 use Sonata\PageBundle\Model\PageInterface;
@@ -23,7 +24,6 @@ use Sonata\PageBundle\Model\SnapshotInterface;
 use Sonata\PageBundle\Model\SnapshotManagerInterface;
 use Sonata\PageBundle\Model\SnapshotPageProxy;
 use Sonata\PageBundle\Model\TransformerInterface;
-use Symfony\Bridge\Doctrine\RegistryInterface;
 
 /**
  * This class transform a SnapshotInterface into PageInterface.
@@ -51,11 +51,11 @@ class Transformer implements TransformerInterface
     protected $children = [];
 
     /**
-     * @var RegistryInterface
+     * @var ManagerRegistry
      */
     protected $registry;
 
-    public function __construct(SnapshotManagerInterface $snapshotManager, PageManagerInterface $pageManager, BlockManagerInterface $blockManager, RegistryInterface $registry)
+    public function __construct(SnapshotManagerInterface $snapshotManager, PageManagerInterface $pageManager, BlockManagerInterface $blockManager, ManagerRegistry $registry)
     {
         $this->snapshotManager = $snapshotManager;
         $this->pageManager = $pageManager;

--- a/tests/Model/BlockInteractorTest.php
+++ b/tests/Model/BlockInteractorTest.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace Sonata\PageBundle\Tests\Model;
 
+use Doctrine\Common\Persistence\ManagerRegistry;
 use PHPUnit\Framework\TestCase;
 use Sonata\BlockBundle\Model\Block;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\BlockBundle\Model\BlockManagerInterface;
 use Sonata\PageBundle\Entity\BlockInteractor;
-use Symfony\Bridge\Doctrine\RegistryInterface;
 
 /**
  * @author Vincent Composieux <composieux@ekino.com>
@@ -30,7 +30,7 @@ class BlockInteractorTest extends TestCase
      */
     public function testCreateNewContainer()
     {
-        $registry = $this->createMock(RegistryInterface::class);
+        $registry = $this->createMock(ManagerRegistry::class);
 
         $blockManager = $this->createMock(BlockManagerInterface::class);
         $blockManager->expects($this->any())->method('create')->willReturn(new Block());


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Use doctrine/doctrine-bundle 2.x

The recent update of doctrine/doctrine-bundle removed RegistryInterface : https://github.com/doctrine/DoctrineBundle/blob/master/UPGRADE-2.0.md

> Registry no longer implements Symfony\Bridge\Doctrine\RegistryInterface. 

It was breaking Sonata PageBundle and @greg0ire had to force this bundle compatibility to doctrine/doctrine-bundle 1

This pull request allow the usage of doctrine/doctrine-bundle 2.x.

I am targeting this branch, because even if it changes the signature of two classes' constructors, it also forces doctrine/doctrine-bundle to ^2.0. ~Also, the linked issue of symfony/dependency-injection (cdd30d7e1ecad6fabc5c207b83983686c3131ead) doesn't seem to be an issue with this change~ errata: it still seems to be an issue as the tests don't pass, even if I have no visible trouble in my application. I reverted this change.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1094 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataPageBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- BlockInteractor constructor's argument $registry is now an instance of Doctrine\Persistence\ManagerRegistry
- Transformer constructor's argument $registry is now an instance of Doctrine\Persistence\ManagerRegistry
- Requires doctrine/doctrine-bundle ^1.12.3 or ^2.0 and doctrine/persistence ^1.3.3
```
