### PR TITLE
Re-allow SF DI>4.4.0 & upgrade di test package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ env:
     - SYMFONY_DEPRECATIONS_HELPER=max[self]=0
     - TARGET=test
     - UPSTREAM_URL=https://github.com/sonata-project/SonataPageBundle.git
-    - PHPUNIT_VERSION=7
+    - PHPUNIT_VERSION=8
 
 matrix:
   fast_finish: true

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "symfony/config": "^3.4 || ^4.2",
         "symfony/console": "^3.4 || ^4.2",
         "symfony/debug": "^3.4 || ^4.2",
-        "symfony/dependency-injection": "^3.4 || ^4.2,<4.4.0",
+        "symfony/dependency-injection": "^3.4 || ^4.2",
         "symfony/form": "^3.4 || ^4.2",
         "symfony/http-foundation": "^3.4.31 || ^4.2",
         "symfony/http-kernel": "^3.4 || ^4.2",
@@ -60,7 +60,7 @@
     "require-dev": {
         "friendsofsymfony/rest-bundle": "^2.1",
         "jms/serializer-bundle": "^1.0 || ^2.0",
-        "matthiasnoback/symfony-dependency-injection-test": "^3.0",
+        "matthiasnoback/symfony-dependency-injection-test": "^4.0",
         "nelmio/api-doc-bundle": "^2.4",
         "symfony/phpunit-bridge": "^4.3"
     },

--- a/tests/Block/PageListBlockServiceTest.php
+++ b/tests/Block/PageListBlockServiceTest.php
@@ -29,7 +29,7 @@ class PageListBlockServiceTest extends AbstractBlockServiceTestCase
      */
     protected $pageManager;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/CmsManager/CmsPageManagerTest.php
+++ b/tests/CmsManager/CmsPageManagerTest.php
@@ -48,7 +48,7 @@ class CmsPageManagerTest extends TestCase
     /**
      * Setup manager object to test.
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->blockInteractor = $this->getMockBlockInteractor();
         $this->pageManager = $this->createMock(PageManagerInterface::class);

--- a/tests/CmsManager/CmsSnapshotManagerTest.php
+++ b/tests/CmsManager/CmsSnapshotManagerTest.php
@@ -54,7 +54,7 @@ class CmsSnapshotManagerTest extends TestCase
     /**
      * Setup manager object to test.
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->blockInteractor = $this->getMockBlockInteractor();
         $this->snapshotManager = $this->createMock(SnapshotManagerInterface::class);

--- a/tests/Command/BaseCommandTest.php
+++ b/tests/Command/BaseCommandTest.php
@@ -31,7 +31,7 @@ class BaseCommandTest extends TestCase
     /**
      * Sets up a new BaseCommand instance.
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->command = $this->getMockBuilder(BaseCommand::class)
             ->disableOriginalConstructor()

--- a/tests/Command/CloneSiteCommandTest.php
+++ b/tests/Command/CloneSiteCommandTest.php
@@ -51,7 +51,7 @@ class CloneSiteCommandTest extends TestCase
      */
     private $blockManager;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->siteManager = $this->prophesize(SiteManagerInterface::class);
         $this->pageManager = $this->prophesize(PageManagerInterface::class);

--- a/tests/Command/CreateBlockContainerCommandTest.php
+++ b/tests/Command/CreateBlockContainerCommandTest.php
@@ -48,7 +48,7 @@ class CreateBlockContainerCommandTest extends TestCase
      */
     protected $container;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->blockInteractor = $this->prophesize(BlockInteractor::class);
 

--- a/tests/Command/CreateSiteCommandTest.php
+++ b/tests/Command/CreateSiteCommandTest.php
@@ -40,7 +40,7 @@ class CreateSiteCommandTest extends TestCase
      */
     private $siteManager;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->siteManager = $this->prophesize(SiteManagerInterface::class);
 

--- a/tests/DependencyInjection/Compiler/CmfRouterAutoRegisterTest.php
+++ b/tests/DependencyInjection/Compiler/CmfRouterAutoRegisterTest.php
@@ -57,7 +57,7 @@ class CmfRouterAutoRegisterTest extends AbstractCompilerPassTestCase
         ];
     }
 
-    protected function registerCompilerPass(ContainerBuilder $container)
+    protected function registerCompilerPass(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new CmfRouterCompilerPass());
     }

--- a/tests/DependencyInjection/SonataPageExtensionTest.php
+++ b/tests/DependencyInjection/SonataPageExtensionTest.php
@@ -79,12 +79,12 @@ class SonataPageExtensionTest extends AbstractExtensionTestCase
         ));
     }
 
-    protected function getContainerExtensions()
+    protected function getContainerExtensions(): array
     {
         return [new SonataPageExtension()];
     }
 
-    protected function getMinimalConfiguration()
+    protected function getMinimalConfiguration(): array
     {
         return [
             'multisite' => 'host',

--- a/tests/Form/Type/PageSelectorTypeTest.php
+++ b/tests/Form/Type/PageSelectorTypeTest.php
@@ -27,7 +27,7 @@ class PageSelectorTypeTest extends TestCase
 
     protected $site;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $pages = [];
 

--- a/tests/Form/Type/TemplateChoiceTypeTest.php
+++ b/tests/Form/Type/TemplateChoiceTypeTest.php
@@ -35,7 +35,7 @@ class TemplateChoiceTypeTest extends TestCase
     /**
      * setup each unit test.
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->manager = $this->createMock(TemplateManagerInterface::class);
         $this->type = new TemplateChoiceType($this->manager);

--- a/tests/Listener/ExceptionListenerTest.php
+++ b/tests/Listener/ExceptionListenerTest.php
@@ -76,7 +76,7 @@ class ExceptionListenerTest extends TestCase
     /**
      * setup unit test.
      */
-    public function setUp()
+    protected function setUp(): void
     {
         // mock dependencies
         $this->siteSelector = $this->createMock(SiteSelectorInterface::class);

--- a/tests/Listener/ResponseListenerTest.php
+++ b/tests/Listener/ResponseListenerTest.php
@@ -57,7 +57,7 @@ class ResponseListenerTest extends TestCase
     /**
      * setup unit test.
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->decoratorStrategy = $this->createMock(DecoratorStrategyInterface::class);
         $this->pageServiceManager = $this->createMock(PageServiceManagerInterface::class);

--- a/tests/Page/PageServiceManagerTest.php
+++ b/tests/Page/PageServiceManagerTest.php
@@ -33,7 +33,7 @@ class PageServiceManagerTest extends TestCase
      */
     protected $manager;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->router = $this->createMock(RouterInterface::class);
         $this->manager = new PageServiceManager($this->router);

--- a/tests/Page/Service/DefaultPageServiceTest.php
+++ b/tests/Page/Service/DefaultPageServiceTest.php
@@ -38,7 +38,7 @@ class DefaultPageServiceTest extends TestCase
      */
     protected $seoPage;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $name = 'my name';
         $this->templateManager = $this->createMock(TemplateManagerInterface::class);

--- a/tests/Request/RequestFactoryTest.php
+++ b/tests/Request/RequestFactoryTest.php
@@ -20,12 +20,12 @@ use Symfony\Component\HttpFoundation\Request;
 
 class RequestFactoryTest extends TestCase
 {
-    public function setup()
+    protected function setUp(): void
     {
         Request::setFactory(null);
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         Request::setFactory(null);
     }

--- a/tests/Resources/XliffTest.php
+++ b/tests/Resources/XliffTest.php
@@ -13,15 +13,75 @@ declare(strict_types=1);
 
 namespace Sonata\PageBundle\Tests\Resources;
 
-use Sonata\CoreBundle\Test\XliffValidatorTestCase;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Translation\Exception\InvalidResourceException;
+use Symfony\Component\Translation\Loader\XliffFileLoader;
 
-class XliffTest extends XliffValidatorTestCase
+class XliffTest extends TestCase
 {
+    /**
+     * @var XliffFileLoader
+     */
+    protected $loader;
+
+    /**
+     * @var string[]
+     */
+    protected $errors = [];
+
+    protected function setUp(): void
+    {
+        $this->loader = new XliffFileLoader();
+    }
+
+    /**
+     * @dataProvider getXliffPaths
+     */
+    public function testXliff($path)
+    {
+        $this->validatePath($path);
+
+        if (\count($this->errors) > 0) {
+            $this->fail(sprintf('Unable to parse xliff files: %s', implode(', ', $this->errors)));
+        }
+
+        $this->assertCount(
+            0,
+            $this->errors,
+            sprintf('Unable to parse xliff files: %s', implode(', ', $this->errors))
+        );
+    }
+
     /**
      * @return array List all path to validate xliff
      */
     public function getXliffPaths()
     {
         return [[__DIR__.'/../../Resources/translations']];
+    }
+
+    /**
+     * @param string $file The path to the xliff file
+     */
+    protected function validateXliff($file)
+    {
+        try {
+            $this->loader->load($file, 'en');
+            $this->assertTrue(true, sprintf('Successful loading file: %s', $file));
+        } catch (InvalidResourceException $e) {
+            $this->errors[] = sprintf('%s => %s', $file, $e->getMessage());
+        }
+    }
+
+    /**
+     * @param string $path The path to lookup for Xliff file
+     */
+    protected function validatePath($path)
+    {
+        $files = glob(sprintf('%s/*.xliff', $path));
+
+        foreach ($files as $file) {
+            $this->validateXliff($file);
+        }
     }
 }

--- a/tests/Route/CmsPageRouterTest.php
+++ b/tests/Route/CmsPageRouterTest.php
@@ -52,7 +52,7 @@ class CmsPageRouterTest extends TestCase
     /**
      * Setup test object with its dependencies.
      */
-    public function setup()
+    protected function setUp(): void
     {
         $this->cmsSelector = $this->createMock(CmsManagerSelectorInterface::class);
         $this->siteSelector = $this->createMock(SiteSelectorInterface::class);

--- a/tests/Route/RoutePageGeneratorTest.php
+++ b/tests/Route/RoutePageGeneratorTest.php
@@ -38,7 +38,7 @@ class RoutePageGeneratorTest extends TestCase
     /**
      * Set up dependencies.
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->routePageGenerator = $this->getRoutePageGenerator();
     }

--- a/tests/Site/BaseLocaleSiteSelectorTest.php
+++ b/tests/Site/BaseLocaleSiteSelectorTest.php
@@ -27,7 +27,7 @@ abstract class BaseLocaleSiteSelectorTest extends TestCase
      */
     protected $siteSelector;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         throw new \RuntimeException('You must define a setUp method to initialize the site selector.');
     }
@@ -35,7 +35,7 @@ abstract class BaseLocaleSiteSelectorTest extends TestCase
     /**
      * Cleanups the site selector.
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         unset($this->siteSelector);
     }

--- a/tests/Site/HostByLocaleSiteSelectorTest.php
+++ b/tests/Site/HostByLocaleSiteSelectorTest.php
@@ -26,7 +26,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
  */
 class HostByLocaleSiteSelectorTest extends BaseLocaleSiteSelectorTest
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         $siteManager = $this->createMock(SiteManagerInterface::class);
         $decoratorStrategy = $this->createMock(DecoratorStrategyInterface::class);

--- a/tests/Site/HostPathByLocaleSiteSelectorTest.php
+++ b/tests/Site/HostPathByLocaleSiteSelectorTest.php
@@ -27,7 +27,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
  */
 class HostPathByLocaleSiteSelectorTest extends BaseLocaleSiteSelectorTest
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         $siteManager = $this->createMock(SiteManagerInterface::class);
         $decoratorStrategy = $this->createMock(DecoratorStrategyInterface::class);


### PR DESCRIPTION
## Subject
I am targeting this branch, because it does not contain BC break i guess.

to understand this: 
- https://github.com/symfony/dependency-injection/commit/ddb02286fb427dc6aba02cabc150f21b40aeb349
- https://github.com/SymfonyTest/SymfonyDependencyInjectionTest/commit/3431fc928541fa676a88cf59adb4bc45dbcc6764

## Changelog

```markdown
### Changed
- Re-allow SF DI>4.4.0
- Upgrade matthiasnoback/symfony-dependency-injection-test to ^4.0
```