### PR TITLE
Deprecate no-confirmation option in command

### DIFF
--- a/src/Command/CreateSiteCommand.php
+++ b/src/Command/CreateSiteCommand.php
@@ -107,7 +107,16 @@ INFO
 
         $confirmation = true;
 
-        if (!$input->getOption('no-confirmation')) {
+        if (!$input->hasOption('no-confirmation')) {
+            $input->setOption('no-interaction', true === $input->getOption('no-confirmation'));
+
+            @trigger_error(
+                'The "no-confirmation" option is deprecated since sonata-project/page-bundle 3.x and will be removed in version 4.0.',
+                E_USER_DEPRECATED
+            );
+        }
+
+        if (!$input->hasOption('no-interaction')) {
             $question = new ConfirmationQuestion('Confirm site creation (Y/N)', false, '/^(y)/i');
             $confirmation = $helper->ask($input, $output, $question);
         }

--- a/tests/Command/CreateSiteCommandTest.php
+++ b/tests/Command/CreateSiteCommandTest.php
@@ -79,6 +79,31 @@ class CreateSiteCommandTest extends TestCase
         $this->assertRegExp('@Site created !@', $commandTester->getDisplay());
     }
 
+    public function testExecuteWithNoInteraction()
+    {
+        $site = new Site();
+
+        $this->siteManager->create()->willReturn($site);
+        $this->siteManager->save($site)->shouldBeCalled();
+
+        $command = $this->application->find('sonata:page:create-site');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([
+            'command' => $command->getName(),
+            '--name' => 'foo',
+            '--host' => 'foo',
+            '--relativePath' => 'foo',
+            '--enabled' => true,
+            '--enabledFrom' => 'now',
+            '--enabledTo' => 'now',
+            '--default' => true,
+            '--locale' => 'foo',
+            '--no-interaction',
+        ]);
+
+        $this->assertRegExp('@Site created !@', $commandTester->getDisplay());
+    }
+
     public function testExecuteWithoutNoConfirmation()
     {
         $site = new Site();


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataPageBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecate `no-confirmation` option in favor of common `no-interaction` option in command
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
