### PR TITLE
Fix page actions for symfony 4

### DIFF
--- a/src/Controller/PageController.php
+++ b/src/Controller/PageController.php
@@ -35,8 +35,18 @@ class PageController extends Controller
      * @throws AccessDeniedException
      *
      * @return Response
+     *
+     * NEXT_MAJOR: Remove this method
      */
     public function exceptionsListAction()
+    {
+        return $this->exceptionsList();
+    }
+
+    /**
+     * @throws AccessDeniedException
+     */
+    public function exceptionsList(): Response
     {
         if (!$this->getCmsManagerSelector()->isEditor()) {
             throw new AccessDeniedException();
@@ -53,8 +63,18 @@ class PageController extends Controller
      * @throws InternalErrorException|AccessDeniedException
      *
      * @return Response
+     *
+     * NEXT_MAJOR: Remove this method
      */
     public function exceptionEditAction($code)
+    {
+        return $this->exceptionEdit($code);
+    }
+
+    /**
+     * @throws InternalErrorException|AccessDeniedException
+     */
+    public function exceptionEdit(string $code): Response
     {
         $cms = $this->getCmsManager();
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
We reference the actions without the `Action` suffix inside the routing files: https://github.com/sonata-project/SonataPageBundle/blob/3.x/src/Resources/config/routing/exceptions.xml#L4-L7

This was okay for old symfony version, but it breaks in symfony 4

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataPageBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fix page actions for symfony 4
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
