### PR TITLE
Remove cocur/slugify dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
     ],
     "require": {
         "php": "^7.1",
-        "cocur/slugify": "^1.0 || ^2.0 || ^3.0",
         "doctrine/doctrine-bundle": "^1.12.3 || ^2.0",
         "doctrine/persistence": "^1.3.3",
         "sonata-project/admin-bundle": "^3.35",


### PR DESCRIPTION
## Subject

I wanted to allow cocur/slugify ^4.0 but I actually didn't find any usage in the
code so I guess we can remove the dependency entirely.

I am targeting this branch, because this change is backward compatible.

## Changelog
```markdown
### Removed
- Removed "cocur/slugify" dependency
```