### PR TITLE
Make page names more readable when using generator

### DIFF
--- a/src/Route/RoutePageGenerator.php
+++ b/src/Route/RoutePageGenerator.php
@@ -98,6 +98,7 @@ class RoutePageGenerator
         // Iterate over declared routes from the routing mechanism
         foreach ($this->router->getRouteCollection()->all() as $name => $route) {
             $name = trim($name);
+            $displayName = $this->displayName($name);
 
             $knowRoutes[] = $name;
 
@@ -136,7 +137,7 @@ class RoutePageGenerator
 
                 $page = $this->pageManager->create([
                     'routeName' => $name,
-                    'name' => $name,
+                    'name' => $displayName,
                     'url' => $route->getPath(),
                     'site' => $site,
                     'requestMethod' => $requirements['_method'] ??
@@ -166,6 +167,7 @@ class RoutePageGenerator
         // Iterate over error pages
         foreach ($this->exceptionListener->getHttpErrorCodes() as $name) {
             $name = trim((string) $name);
+            $displayName = $this->displayName($name);
 
             $knowRoutes[] = $name;
 
@@ -177,7 +179,7 @@ class RoutePageGenerator
             if (!$page) {
                 $params = [
                     'routeName' => $name,
-                    'name' => $name,
+                    'name' => $displayName,
                     'decorate' => false,
                     'site' => $site,
                 ];
@@ -253,10 +255,11 @@ MSG
             if ('/' === $route->getPath()) {
                 $requirements = $route->getRequirements();
                 $name = trim($name);
+                $displayName = $this->displayName($name);
 
                 return $this->pageManager->create([
                     'routeName' => $name,
-                    'name' => $name,
+                    'name' => $displayName,
                     'url' => $route->getPath(),
                     'site' => $site,
                     'requestMethod' => $requirements['_method'] ?? 'GET|POST|HEAD|DELETE|PUT',
@@ -273,5 +276,10 @@ MSG
             'requestMethod' => 'GET|POST|HEAD|DELETE|PUT',
             'slug' => '/',
         ]);
+    }
+
+    private function displayName(string $name): string
+    {
+        return ucwords(trim(str_replace('_', ' ', $name)));
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

When calling `sonata:page:update-core-route`, generated page names will not use the route name as default anymore. A meaningful page title will guessed by replacing the underscore with words.

E.g. the generated page for the route `sonata_news_view` will get `Sonata News View` as default page name. 

The name is only displayed on the admin backend and it will only affect newly generated pages, so this is BC.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->



## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataPageBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Removed underscores in page names when calling `sonata:page:update-core-route`
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
