### PR TITLE
Drop support for Symfony < 4.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,20 +36,20 @@
         "sonata-project/notification-bundle": "^3.3",
         "sonata-project/seo-bundle": "^2.5",
         "symfony-cmf/routing-bundle": "^1.1 || ^2.0",
-        "symfony/config": "^3.4 || ^4.2",
-        "symfony/console": "^3.4 || ^4.2",
-        "symfony/debug": "^3.4 || ^4.2",
-        "symfony/dependency-injection": "^3.4 || ^4.2",
-        "symfony/form": "^3.4 || ^4.2",
-        "symfony/http-foundation": "^3.4.35 || ^4.2.12",
-        "symfony/http-kernel": "^3.4 || ^4.2",
-        "symfony/options-resolver": "^3.4 || ^4.2",
-        "symfony/process": "^3.4 || ^4.2",
-        "symfony/routing": "^3.4 || ^4.2",
-        "symfony/security-core": "^3.4 || ^4.2",
-        "symfony/security-http": "^3.4 || ^4.2",
-        "symfony/templating": "^3.4 || ^4.2",
-        "symfony/validator": "^3.4 || ^4.2",
+        "symfony/config": "^4.3",
+        "symfony/console": "^4.3",
+        "symfony/debug": "^4.3",
+        "symfony/dependency-injection": "^4.3",
+        "symfony/form": "^4.3",
+        "symfony/http-foundation": "^4.3.8",
+        "symfony/http-kernel": "^4.3",
+        "symfony/options-resolver": "^4.3",
+        "symfony/process": "^4.3",
+        "symfony/routing": "^4.3",
+        "symfony/security-core": "^4.3",
+        "symfony/security-http": "^4.3",
+        "symfony/templating": "^4.3",
+        "symfony/validator": "^4.3",
         "twig/twig": "^2.10"
     },
     "conflict": {
@@ -61,7 +61,7 @@
         "jms/serializer-bundle": "^1.0 || ^2.0",
         "matthiasnoback/symfony-dependency-injection-test": "^4.0",
         "nelmio/api-doc-bundle": "^2.4",
-        "symfony/phpunit-bridge": "^4.3"
+        "symfony/phpunit-bridge": "^5.0"
     },
     "config": {
         "sort-packages": true

--- a/docs/reference/installation.rst
+++ b/docs/reference/installation.rst
@@ -4,7 +4,7 @@ Installation
 Prerequisites
 -------------
 
-PHP 7.1 and Symfony >=3.4 or >= 4.2 are needed to make this bundle work, there are
+PHP 7.1 and Symfony >=4.3 are needed to make this bundle work, there are
 also some Sonata dependencies that need to be installed and configured beforehand:
 
     - SonataAdminBundle_

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -32,12 +32,7 @@ class Configuration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder('sonata_block');
 
-        // Keep compatibility with symfony/config < 4.2
-        if (!method_exists($treeBuilder, 'getRootNode')) {
-            $node = $treeBuilder->root('sonata_page');
-        } else {
-            $node = $treeBuilder->getRootNode();
-        }
+        $node = $treeBuilder->getRootNode();
 
         $node = $node->children();
 

--- a/src/Model/Snapshot.php
+++ b/src/Model/Snapshot.php
@@ -56,7 +56,7 @@ abstract class Snapshot implements SnapshotInterface
     protected $url;
 
     /**
-     * @var
+     * @var bool
      */
     protected $enabled;
 

--- a/tests/Admin/BaseBlockAdminTest.php
+++ b/tests/Admin/BaseBlockAdminTest.php
@@ -24,7 +24,7 @@ use Sonata\PageBundle\Model\PageInterface;
 
 class BaseBlockAdminTest extends TestCase
 {
-    public function testSettingAsEditedOnPreBatchDeleteAction()
+    public function testSettingAsEditedOnPreBatchDeleteAction(): void
     {
         $page = $this->createMock(PageInterface::class);
         $page->expects($this->once())->method('setEdited')->with(true);
@@ -47,7 +47,7 @@ class BaseBlockAdminTest extends TestCase
      *
      * @group legacy
      */
-    public function testSettingAsEditedOnPreRemove()
+    public function testSettingAsEditedOnPreRemove(): void
     {
         $page = $this->createMock(PageInterface::class);
         $page->expects($this->once())->method('setEdited')->with(true);
@@ -56,7 +56,7 @@ class BaseBlockAdminTest extends TestCase
         $block->expects($this->once())->method('getPage')->willReturn($page);
 
         $blockService = $this->createMock(AbstractAdminBlockService::class);
-        $blockService->expects($this->any())->method('preRemove')->with($block);
+        $blockService->method('preRemove')->with($block);
 
         $blockServiceManager = $this->createMock(BlockServiceManagerInterface::class);
         $blockServiceManager

--- a/tests/Admin/Extension/CreateSnapshotAdminExtensionTest.php
+++ b/tests/Admin/Extension/CreateSnapshotAdminExtensionTest.php
@@ -22,7 +22,7 @@ use Sonata\PageBundle\Model\PageInterface;
 
 class CreateSnapshotAdminExtensionTest extends TestCase
 {
-    public function testPostUpdateOnPage()
+    public function testPostUpdateOnPage(): void
     {
         $page = $this->createMock(PageInterface::class);
         $page->expects($this->once())->method('getId')->willReturn(42);
@@ -39,7 +39,7 @@ class CreateSnapshotAdminExtensionTest extends TestCase
         $extension->postUpdate($admin, $page);
     }
 
-    public function testPostPersistOnPage()
+    public function testPostPersistOnPage(): void
     {
         $page = $this->createMock(PageInterface::class);
         $page->expects($this->once())->method('getId')->willReturn(42);
@@ -56,7 +56,7 @@ class CreateSnapshotAdminExtensionTest extends TestCase
         $extension->postPersist($admin, $page);
     }
 
-    public function testPostUpdateOnBlock()
+    public function testPostUpdateOnBlock(): void
     {
         $page = $this->createMock(PageInterface::class);
         $page->expects($this->once())->method('getId')->willReturn(42);
@@ -76,7 +76,7 @@ class CreateSnapshotAdminExtensionTest extends TestCase
         $extension->postUpdate($admin, $block);
     }
 
-    public function testPostPersistOnBlock()
+    public function testPostPersistOnBlock(): void
     {
         $page = $this->createMock(PageInterface::class);
         $page->expects($this->once())->method('getId')->willReturn(42);

--- a/tests/Admin/PageAdminTest.php
+++ b/tests/Admin/PageAdminTest.php
@@ -26,7 +26,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class PageAdminTest extends TestCase
 {
-    public function testTabMenuHasLinksWithSubSite()
+    public function testTabMenuHasLinksWithSubSite(): void
     {
         $request = new Request(['id' => 42]);
         $admin = new PageAdmin(

--- a/tests/Block/BlockContextManagerTest.php
+++ b/tests/Block/BlockContextManagerTest.php
@@ -26,7 +26,7 @@ use Sonata\PageBundle\Block\BlockContextManager;
  */
 class BlockContextManagerTest extends TestCase
 {
-    public function testGetWithValidData()
+    public function testGetWithValidData(): void
     {
         $service = $this->createMock(AbstractBlockService::class);
 

--- a/tests/Block/ContainerBlockServiceTest.php
+++ b/tests/Block/ContainerBlockServiceTest.php
@@ -27,7 +27,7 @@ class ContainerBlockServiceTest extends AbstractBlockServiceTestCase
     /**
      * test the block execute() method.
      */
-    public function testExecute()
+    public function testExecute(): void
     {
         $service = new ContainerBlockService('core.container', $this->templating);
 
@@ -56,7 +56,7 @@ class ContainerBlockServiceTest extends AbstractBlockServiceTestCase
     /**
      * test the container layout.
      */
-    public function testLayout()
+    public function testLayout(): void
     {
         $service = new ContainerBlockService('core.container', $this->templating);
 
@@ -84,7 +84,7 @@ class ContainerBlockServiceTest extends AbstractBlockServiceTestCase
     /**
      * test the block's form builders.
      */
-    public function testFormBuilder()
+    public function testFormBuilder(): void
     {
         $service = new ContainerBlockService('core.container', $this->templating);
 

--- a/tests/Block/PageListBlockServiceTest.php
+++ b/tests/Block/PageListBlockServiceTest.php
@@ -36,7 +36,7 @@ class PageListBlockServiceTest extends AbstractBlockServiceTestCase
         $this->pageManager = $this->createMock(PageManagerInterface::class);
     }
 
-    public function testDefaultSettings()
+    public function testDefaultSettings(): void
     {
         $blockService = new PageListBlockService('block.service', $this->templating, $this->pageManager);
         $blockContext = $this->getBlockContext($blockService);
@@ -51,7 +51,7 @@ class PageListBlockServiceTest extends AbstractBlockServiceTestCase
         ], $blockContext);
     }
 
-    public function testExecute()
+    public function testExecute(): void
     {
         $page1 = $this->createMock(PageInterface::class);
         $page2 = $this->createMock(PageInterface::class);

--- a/tests/Cache/BlockEsiCacheTest.php
+++ b/tests/Cache/BlockEsiCacheTest.php
@@ -25,7 +25,7 @@ class BlockEsiCacheTest extends TestCase
     /**
      * @dataProvider getExceptionCacheKeys
      */
-    public function testExceptions($keys)
+    public function testExceptions($keys): void
     {
         $this->expectException(\RuntimeException::class);
 
@@ -40,7 +40,7 @@ class BlockEsiCacheTest extends TestCase
         $cache->get($keys, 'data');
     }
 
-    public static function getExceptionCacheKeys()
+    public static function getExceptionCacheKeys(): array
     {
         return [
             [[]],
@@ -53,11 +53,10 @@ class BlockEsiCacheTest extends TestCase
         ];
     }
 
-    public function testInitCache()
+    public function testInitCache(): void
     {
         $router = $this->createMock(RouterInterface::class);
         $router
-            ->expects($this->any())
             ->method('generate')
             ->willReturn('https://sonata-project.org/cache/XXX/page/esi/page/5/4?updated_at=as');
 

--- a/tests/Cache/BlockJsCacheTest.php
+++ b/tests/Cache/BlockJsCacheTest.php
@@ -26,7 +26,7 @@ class BlockJsCacheTest extends TestCase
     /**
      * @dataProvider getExceptionCacheKeys
      */
-    public function testExceptions($keys)
+    public function testExceptions($keys): void
     {
         $this->expectException(\RuntimeException::class);
 
@@ -41,7 +41,7 @@ class BlockJsCacheTest extends TestCase
         $cache->get($keys, 'data');
     }
 
-    public static function getExceptionCacheKeys()
+    public static function getExceptionCacheKeys(): array
     {
         return [
             [[]],
@@ -54,7 +54,7 @@ class BlockJsCacheTest extends TestCase
         ];
     }
 
-    public function testInitCache()
+    public function testInitCache(): void
     {
         $router = $this->createMock(RouterInterface::class);
         $router

--- a/tests/Cache/BlockSsiCacheTest.php
+++ b/tests/Cache/BlockSsiCacheTest.php
@@ -25,7 +25,7 @@ class BlockSsiCacheTest extends TestCase
     /**
      * @dataProvider      getExceptionCacheKeys
      */
-    public function testExceptions($keys)
+    public function testExceptions($keys): void
     {
         $this->expectException(\RuntimeException::class);
 
@@ -39,7 +39,7 @@ class BlockSsiCacheTest extends TestCase
         $cache->get($keys, 'data');
     }
 
-    public static function getExceptionCacheKeys()
+    public static function getExceptionCacheKeys(): array
     {
         return [
             [[]],
@@ -52,11 +52,10 @@ class BlockSsiCacheTest extends TestCase
         ];
     }
 
-    public function testInitCache()
+    public function testInitCache(): void
     {
         $router = $this->createMock(RouterInterface::class);
         $router
-            ->expects($this->any())
             ->method('generate')
             ->willReturn('/cache/page/esi/XXXXX/page/5/4?updated_at=as');
 

--- a/tests/CmsManager/CmsPageManagerTest.php
+++ b/tests/CmsManager/CmsPageManagerTest.php
@@ -58,7 +58,7 @@ class CmsPageManagerTest extends TestCase
     /**
      * Test finding an existing container in a page.
      */
-    public function testFindExistingContainer()
+    public function testFindExistingContainer(): void
     {
         $block = new CmsBlock();
         $block->setSettings(['code' => 'findme']);
@@ -78,7 +78,7 @@ class CmsPageManagerTest extends TestCase
     /**
      * Test finding an non-existing container in a page does create a new block.
      */
-    public function testFindNonExistingContainerCreatesNewBlock()
+    public function testFindNonExistingContainerCreatesNewBlock(): void
     {
         $page = new Page();
 
@@ -91,12 +91,12 @@ class CmsPageManagerTest extends TestCase
     /**
      * Test get Page method with url return Page.
      */
-    public function testGetPageWithUrl()
+    public function testGetPageWithUrl(): void
     {
         $pageManager = $this->createMock(PageManagerInterface::class);
 
-        $pageManager->expects($this->any())->method('findOneBy')->willReturn(new Page());
-        $this->blockInteractor->expects($this->any())->method('loadPageBlocks')->willReturn([]);
+        $pageManager->method('findOneBy')->willReturn(new Page());
+        $this->blockInteractor->method('loadPageBlocks')->willReturn([]);
 
         $manager = $this->createManager($pageManager, $this->blockInteractor);
 
@@ -109,21 +109,21 @@ class CmsPageManagerTest extends TestCase
     /**
      * Test get Page method with url throw Exception.
      */
-    public function testGetPageWithUrlException()
+    public function testGetPageWithUrlException(): void
     {
         $this->expectException(PageNotFoundException::class);
         $this->expectExceptionMessage('Unable to find the page : url = /test');
 
         $pageManager = $this->createMock(PageManagerInterface::class);
 
-        $this->blockInteractor->expects($this->any())->method('loadPageBlocks')->willReturn([]);
+        $this->blockInteractor->method('loadPageBlocks')->willReturn([]);
 
         $manager = $this->createManager($pageManager, $this->blockInteractor);
 
         $page = '/test';
         $site = new Site();
 
-        $pageManager->expects($this->any())->method('findOneBy')->willReturn(null);
+        $pageManager->method('findOneBy')->willReturn(null);
         $manager = $this->createManager($pageManager, $this->blockInteractor);
 
         $manager->getPage($site, $page);
@@ -132,12 +132,12 @@ class CmsPageManagerTest extends TestCase
     /**
      * Test get Page method with url return Page.
      */
-    public function testGetPageWithRouteName()
+    public function testGetPageWithRouteName(): void
     {
         $pageManager = $this->createMock(PageManagerInterface::class);
 
-        $pageManager->expects($this->any())->method('findOneBy')->willReturn(new Page());
-        $this->blockInteractor->expects($this->any())->method('loadPageBlocks')->willReturn([]);
+        $pageManager->method('findOneBy')->willReturn(new Page());
+        $this->blockInteractor->method('loadPageBlocks')->willReturn([]);
 
         $manager = $this->createManager($pageManager, $this->blockInteractor);
 
@@ -150,21 +150,21 @@ class CmsPageManagerTest extends TestCase
     /**
      * Test get Page method with url throw Exception.
      */
-    public function testGetPageWithRouteNameException()
+    public function testGetPageWithRouteNameException(): void
     {
         $this->expectException(PageNotFoundException::class);
         $this->expectExceptionMessage('Unable to find the page : url = /test');
 
         $pageManager = $this->createMock(PageManagerInterface::class);
 
-        $this->blockInteractor->expects($this->any())->method('loadPageBlocks')->willReturn([]);
+        $this->blockInteractor->method('loadPageBlocks')->willReturn([]);
 
         $manager = $this->createManager($pageManager, $this->blockInteractor);
 
         $page = '/test';
         $site = new Site();
 
-        $pageManager->expects($this->any())->method('findOneBy')->willReturn(null);
+        $pageManager->method('findOneBy')->willReturn(null);
         $manager = $this->createManager($pageManager, $this->blockInteractor);
 
         $manager->getPage($site, $page);
@@ -173,12 +173,12 @@ class CmsPageManagerTest extends TestCase
     /**
      * Test get Page method with url return Page.
      */
-    public function testGetPageWithId()
+    public function testGetPageWithId(): void
     {
         $pageManager = $this->createMock(PageManagerInterface::class);
 
-        $pageManager->expects($this->any())->method('findOneBy')->willReturn(new Page());
-        $this->blockInteractor->expects($this->any())->method('loadPageBlocks')->willReturn([]);
+        $pageManager->method('findOneBy')->willReturn(new Page());
+        $this->blockInteractor->method('loadPageBlocks')->willReturn([]);
 
         $manager = $this->createManager($pageManager, $this->blockInteractor);
 
@@ -191,21 +191,21 @@ class CmsPageManagerTest extends TestCase
     /**
      * Test get Page method with url throw Exception.
      */
-    public function testGetPageWithIdException()
+    public function testGetPageWithIdException(): void
     {
         $this->expectException(PageNotFoundException::class);
         $this->expectExceptionMessage('Unable to find the page : id = 1');
 
         $pageManager = $this->createMock(PageManagerInterface::class);
 
-        $this->blockInteractor->expects($this->any())->method('loadPageBlocks')->willReturn([]);
+        $this->blockInteractor->method('loadPageBlocks')->willReturn([]);
 
         $manager = $this->createManager($pageManager, $this->blockInteractor);
 
         $page = 1;
         $site = new Site();
 
-        $pageManager->expects($this->any())->method('findOneBy')->willReturn(null);
+        $pageManager->method('findOneBy')->willReturn(null);
         $manager = $this->createManager($pageManager, $this->blockInteractor);
 
         $manager->getPage($site, $page);
@@ -214,12 +214,12 @@ class CmsPageManagerTest extends TestCase
     /**
      * Test get Page method with url return Page.
      */
-    public function testGetPageWithoutParam()
+    public function testGetPageWithoutParam(): void
     {
         $pageManager = $this->createMock(PageManagerInterface::class);
 
-        $pageManager->expects($this->any())->method('findOneBy')->willReturn(new Page());
-        $this->blockInteractor->expects($this->any())->method('loadPageBlocks')->willReturn([]);
+        $pageManager->method('findOneBy')->willReturn(new Page());
+        $this->blockInteractor->method('loadPageBlocks')->willReturn([]);
 
         $manager = $this->createManager($pageManager, $this->blockInteractor);
         $manager->setCurrentPage(new Page());
@@ -232,21 +232,21 @@ class CmsPageManagerTest extends TestCase
     /**
      * Test get Page method with url throw Exception.
      */
-    public function testGetPageWithoutParamException()
+    public function testGetPageWithoutParamException(): void
     {
         $this->expectException(PageNotFoundException::class);
         $this->expectExceptionMessage('Unable to retrieve the page');
 
         $pageManager = $this->createMock(PageManagerInterface::class);
 
-        $this->blockInteractor->expects($this->any())->method('loadPageBlocks')->willReturn([]);
+        $this->blockInteractor->method('loadPageBlocks')->willReturn([]);
 
         $manager = $this->createManager($pageManager, $this->blockInteractor);
 
         $page = null;
         $site = new Site();
 
-        $pageManager->expects($this->any())->method('findOneBy')->willReturn(null);
+        $pageManager->method('findOneBy')->willReturn(null);
         $manager = $this->createManager($pageManager, $this->blockInteractor);
 
         $manager->getPage($site, $page);
@@ -254,10 +254,8 @@ class CmsPageManagerTest extends TestCase
 
     /**
      * Returns a mock block interactor.
-     *
-     * @return \Sonata\PageBundle\Model\BlockInteractorInterface
      */
-    protected function getMockBlockInteractor()
+    protected function getMockBlockInteractor(): BlockInteractorInterface
     {
         $callback = static function ($options) {
             $block = new CmsBlock();
@@ -267,12 +265,12 @@ class CmsPageManagerTest extends TestCase
         };
 
         $mock = $this->createMock(BlockInteractorInterface::class);
-        $mock->expects($this->any())->method('createNewContainer')->willReturnCallback($callback);
+        $mock->method('createNewContainer')->willReturnCallback($callback);
 
         return $mock;
     }
 
-    private function createManager($pageManager, $blockInteractor)
+    private function createManager($pageManager, $blockInteractor): CmsPageManager
     {
         return new CmsPageManager($pageManager, $blockInteractor);
     }

--- a/tests/CmsManager/CmsSnapshotManagerTest.php
+++ b/tests/CmsManager/CmsSnapshotManagerTest.php
@@ -65,7 +65,7 @@ class CmsSnapshotManagerTest extends TestCase
     /**
      * Test finding an existing container in a page.
      */
-    public function testFindExistingContainer()
+    public function testFindExistingContainer(): void
     {
         $block = new SnapshotBlock();
         $block->setSettings(['code' => 'findme']);
@@ -85,7 +85,7 @@ class CmsSnapshotManagerTest extends TestCase
     /**
      * Test finding an non-existing container in a page does NOT create a new block.
      */
-    public function testFindNonExistingContainerCreatesNoNewBlock()
+    public function testFindNonExistingContainerCreatesNoNewBlock(): void
     {
         $page = new Page();
 
@@ -94,7 +94,7 @@ class CmsSnapshotManagerTest extends TestCase
         $this->assertNull($container, 'should not create a new container block');
     }
 
-    public function testGetPageWithUnknownPage()
+    public function testGetPageWithUnknownPage(): void
     {
         $this->expectException(PageNotFoundException::class);
 
@@ -107,19 +107,19 @@ class CmsSnapshotManagerTest extends TestCase
         $snapshotManager->getPage($site, 1);
     }
 
-    public function testGetPageWithId()
+    public function testGetPageWithId(): void
     {
         $cBlock = $this->createMock(BlockInterface::class);
-        $cBlock->expects($this->any())->method('hasChildren')->willReturn(false);
-        $cBlock->expects($this->any())->method('getId')->willReturn(2);
+        $cBlock->method('hasChildren')->willReturn(false);
+        $cBlock->method('getId')->willReturn(2);
 
         $pBlock = $this->createMock(BlockInterface::class);
-        $pBlock->expects($this->any())->method('getChildren')->willReturn([$cBlock]);
-        $pBlock->expects($this->any())->method('hasChildren')->willReturn(true);
-        $pBlock->expects($this->any())->method('getId')->willReturn(1);
+        $pBlock->method('getChildren')->willReturn([$cBlock]);
+        $pBlock->method('hasChildren')->willReturn(true);
+        $pBlock->method('getId')->willReturn(1);
 
         $page = $this->createMock(PageInterface::class);
-        $page->expects($this->any())->method('getBlocks')->willReturnCallback(static function () use ($pBlock) {
+        $page->method('getBlocks')->willReturnCallback(static function () use ($pBlock) {
             static $count;
 
             ++$count;
@@ -158,10 +158,8 @@ class CmsSnapshotManagerTest extends TestCase
 
     /**
      * Returns a mock block interactor.
-     *
-     * @return BlockInteractorInterface
      */
-    protected function getMockBlockInteractor()
+    protected function getMockBlockInteractor(): BlockInteractorInterface
     {
         $callback = static function ($options) {
             $block = new SnapshotBlock();
@@ -172,7 +170,6 @@ class CmsSnapshotManagerTest extends TestCase
 
         $blockInteractor = $this->createMock(BlockInteractorInterface::class);
         $blockInteractor
-            ->expects($this->any())
             ->method('createNewContainer')
             ->willReturnCallback($callback);
 

--- a/tests/CmsManager/DecoratorStrategyTest.php
+++ b/tests/CmsManager/DecoratorStrategyTest.php
@@ -22,7 +22,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class DecoratorStrategyTest extends TestCase
 {
-    public function testIsDecorable()
+    public function testIsDecorable(): void
     {
         $response = new Response('dummy');
         $request = Request::create('/myurl');
@@ -57,28 +57,28 @@ class DecoratorStrategyTest extends TestCase
         $this->assertTrue($strategy->isDecorable($request, HttpKernelInterface::MASTER_REQUEST, $response));
     }
 
-    public function testIgnoreRouteNameMatch()
+    public function testIgnoreRouteNameMatch(): void
     {
         $strategy = new DecoratorStrategy(['test'], [], []);
 
         $this->assertFalse($strategy->isRouteNameDecorable('test'));
     }
 
-    public function testIgnoreRouteNamePatternsMatch()
+    public function testIgnoreRouteNamePatternsMatch(): void
     {
         $strategy = new DecoratorStrategy([], ['test[0-2]{1}'], []);
 
         $this->assertFalse($strategy->isRouteNameDecorable('test2'));
     }
 
-    public function testIgnoreUriPatternsMatch()
+    public function testIgnoreUriPatternsMatch(): void
     {
         $strategy = new DecoratorStrategy([], [], ['(.*)']);
 
         $this->assertFalse($strategy->isRouteUriDecorable('ok'));
     }
 
-    public function testIgnoreUriPatternsNotMatch()
+    public function testIgnoreUriPatternsNotMatch(): void
     {
         $strategy = new DecoratorStrategy([], [], ['ok']);
 

--- a/tests/Command/BaseCommandTest.php
+++ b/tests/Command/BaseCommandTest.php
@@ -42,7 +42,7 @@ class BaseCommandTest extends TestCase
     /**
      * Tests the getSites() method with different parameters.
      */
-    public function testGetSites()
+    public function testGetSites(): void
     {
         // Given
         $method = new \ReflectionMethod($this->command, 'getSites');
@@ -54,7 +54,7 @@ class BaseCommandTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->command->expects($this->any())->method('getSiteManager')->willReturn($siteManager);
+        $this->command->method('getSiteManager')->willReturn($siteManager);
 
         // Test --site=all value
         $input->expects($this->at(0))->method('getOption')->with('site')->willReturn(['all']);

--- a/tests/Command/CloneSiteCommandTest.php
+++ b/tests/Command/CloneSiteCommandTest.php
@@ -69,7 +69,7 @@ class CloneSiteCommandTest extends TestCase
         $this->application->add($command);
     }
 
-    public function testExecute()
+    public function testExecute(): void
     {
         $sourceSite = $this->prophesize(SiteInterface::class);
         $destSite = $this->prophesize(SiteInterface::class);
@@ -155,7 +155,7 @@ class CloneSiteCommandTest extends TestCase
         $this->assertRegExp('@done!@', $commandTester->getDisplay());
     }
 
-    public function testExecuteNoSourceId()
+    public function testExecuteNoSourceId(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Please provide a "--source-id=SITE_ID" option.');
@@ -173,7 +173,7 @@ class CloneSiteCommandTest extends TestCase
         $this->assertRegExp('@Writing cache file ...\s+done!@', $commandTester->getDisplay());
     }
 
-    public function testExecuteNoDestId()
+    public function testExecuteNoDestId(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Please provide a "--dest-id=SITE_ID" option.');
@@ -191,7 +191,7 @@ class CloneSiteCommandTest extends TestCase
         $this->assertRegExp('@Writing cache file ...\s+done!@', $commandTester->getDisplay());
     }
 
-    public function testExecuteNoPrefix()
+    public function testExecuteNoPrefix(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Please provide a "--prefix=PREFIX" option.');

--- a/tests/Command/CreateBlockContainerCommandTest.php
+++ b/tests/Command/CreateBlockContainerCommandTest.php
@@ -65,7 +65,7 @@ class CreateBlockContainerCommandTest extends TestCase
     /**
      * Tests that Block is added into Page's blocks field.
      */
-    public function testCreateBlock()
+    public function testCreateBlock(): void
     {
         $block = $this->prophesize(PageBlockInterface::class);
         $this->blockInteractor->createNewContainer(Argument::any())->willReturn($block->reveal());

--- a/tests/Command/CreateSiteCommandTest.php
+++ b/tests/Command/CreateSiteCommandTest.php
@@ -54,7 +54,7 @@ class CreateSiteCommandTest extends TestCase
         $this->application->add($command);
     }
 
-    public function testExecuteWithNoConfirmation()
+    public function testExecuteWithNoConfirmation(): void
     {
         $site = new Site();
 
@@ -79,7 +79,7 @@ class CreateSiteCommandTest extends TestCase
         $this->assertRegExp('@Site created !@', $commandTester->getDisplay());
     }
 
-    public function testExecuteWithoutNoConfirmation()
+    public function testExecuteWithoutNoConfirmation(): void
     {
         $site = new Site();
 

--- a/tests/Controller/Api/AjaxControllerTest.php
+++ b/tests/Controller/Api/AjaxControllerTest.php
@@ -30,7 +30,7 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class AjaxControllerTest extends TestCase
 {
-    public function testWithInvalidBlock()
+    public function testWithInvalidBlock(): void
     {
         $this->expectException(BlockNotFoundException::class);
 
@@ -50,7 +50,7 @@ class AjaxControllerTest extends TestCase
         $controller->execute($request, 10, 12);
     }
 
-    public function testRenderer()
+    public function testRenderer(): void
     {
         $block = $this->createMock(BlockInterface::class);
 

--- a/tests/Controller/Api/BlockControllerTest.php
+++ b/tests/Controller/Api/BlockControllerTest.php
@@ -28,14 +28,14 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  */
 class BlockControllerTest extends TestCase
 {
-    public function testGetBlockAction()
+    public function testGetBlockAction(): void
     {
         $block = $this->createMock(BlockInterface::class);
 
         $this->assertSame($block, $this->createBlockController($block)->getBlockAction(1));
     }
 
-    public function testGetBlockActionNotFoundException()
+    public function testGetBlockActionNotFoundException(): void
     {
         $this->expectException(NotFoundHttpException::class);
         $this->expectExceptionMessage('Block (42) not found');
@@ -43,7 +43,7 @@ class BlockControllerTest extends TestCase
         $this->createBlockController()->getBlockAction(42);
     }
 
-    public function testPutBlockAction()
+    public function testPutBlockAction(): void
     {
         $block = $this->createMock(BlockInterface::class);
 
@@ -63,7 +63,7 @@ class BlockControllerTest extends TestCase
         $this->assertInstanceOf(BlockInterface::class, $block);
     }
 
-    public function testPutBlockInvalidAction()
+    public function testPutBlockInvalidAction(): void
     {
         $block = $this->createMock(BlockInterface::class);
 
@@ -82,7 +82,7 @@ class BlockControllerTest extends TestCase
         $this->assertInstanceOf(FormInterface::class, $view);
     }
 
-    public function testDeleteBlockAction()
+    public function testDeleteBlockAction(): void
     {
         $block = $this->createMock(BlockInterface::class);
 
@@ -94,7 +94,7 @@ class BlockControllerTest extends TestCase
         $this->assertSame(['deleted' => true], $view);
     }
 
-    public function testDeleteBlockInvalidAction()
+    public function testDeleteBlockInvalidAction(): void
     {
         $this->expectException(NotFoundHttpException::class);
 
@@ -104,10 +104,7 @@ class BlockControllerTest extends TestCase
         $this->createBlockController(null, $blockManager)->deleteBlockAction(1);
     }
 
-    /**
-     * @return BlockController
-     */
-    public function createBlockController($block = null, $blockManager = null, $formFactory = null)
+    public function createBlockController($block = null, $blockManager = null, $formFactory = null): BlockController
     {
         if (null === $blockManager) {
             $blockManager = $this->createMock(BlockManagerInterface::class);

--- a/tests/Controller/Api/PageControllerTest.php
+++ b/tests/Controller/Api/PageControllerTest.php
@@ -37,7 +37,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  */
 class PageControllerTest extends TestCase
 {
-    public function testGetPagesAction()
+    public function testGetPagesAction(): void
     {
         $pager = $this->createMock(Pager::class);
 
@@ -54,14 +54,14 @@ class PageControllerTest extends TestCase
         $this->assertSame($pager, $this->createPageController(null, null, $pageManager)->getPagesAction($paramFetcher));
     }
 
-    public function testGetPageAction()
+    public function testGetPageAction(): void
     {
         $page = $this->createMock(PageInterface::class);
 
         $this->assertSame($page, $this->createPageController($page)->getPageAction(1));
     }
 
-    public function testGetPageActionNotFoundException()
+    public function testGetPageActionNotFoundException(): void
     {
         $this->expectException(NotFoundHttpException::class);
         $this->expectExceptionMessage('Page (42) not found');
@@ -69,7 +69,7 @@ class PageControllerTest extends TestCase
         $this->createPageController()->getPageAction(42);
     }
 
-    public function testGetPageBlocksAction()
+    public function testGetPageBlocksAction(): void
     {
         $page = $this->createMock(PageInterface::class);
         $block = $this->createMock(PageBlockInterface::class);
@@ -79,7 +79,7 @@ class PageControllerTest extends TestCase
         $this->assertSame([$block], $this->createPageController($page)->getPageBlocksAction(1));
     }
 
-    public function testPostPageAction()
+    public function testPostPageAction(): void
     {
         $page = $this->createMock(PageInterface::class);
 
@@ -100,7 +100,7 @@ class PageControllerTest extends TestCase
         $this->assertInstanceOf(View::class, $view);
     }
 
-    public function testPostPageInvalidAction()
+    public function testPostPageInvalidAction(): void
     {
         $page = $this->createMock(PageInterface::class);
 
@@ -120,7 +120,7 @@ class PageControllerTest extends TestCase
         $this->assertInstanceOf(FormInterface::class, $view);
     }
 
-    public function testPutPageAction()
+    public function testPutPageAction(): void
     {
         $page = $this->createMock(PageInterface::class);
 
@@ -141,7 +141,7 @@ class PageControllerTest extends TestCase
         $this->assertInstanceOf(View::class, $view);
     }
 
-    public function testPutPageInvalidAction()
+    public function testPutPageInvalidAction(): void
     {
         $page = $this->createMock(PageInterface::class);
 
@@ -161,7 +161,7 @@ class PageControllerTest extends TestCase
         $this->assertInstanceOf(FormInterface::class, $view);
     }
 
-    public function testDeletePageAction()
+    public function testDeletePageAction(): void
     {
         $page = $this->createMock(PageInterface::class);
 
@@ -173,7 +173,7 @@ class PageControllerTest extends TestCase
         $this->assertSame(['deleted' => true], $view);
     }
 
-    public function testDeletePageInvalidAction()
+    public function testDeletePageInvalidAction(): void
     {
         $this->expectException(NotFoundHttpException::class);
 
@@ -183,7 +183,7 @@ class PageControllerTest extends TestCase
         $this->createPageController(null, null, $pageManager)->deletePageAction(1);
     }
 
-    public function testPostPageBlockAction()
+    public function testPostPageBlockAction(): void
     {
         $block = $this->createMock(Block::class);
         $block->expects($this->once())->method('setPage');
@@ -210,7 +210,7 @@ class PageControllerTest extends TestCase
         $this->assertInstanceOf(Block::class, $block);
     }
 
-    public function testPostPageBlockInvalidAction()
+    public function testPostPageBlockInvalidAction(): void
     {
         $block = $this->createMock(Block::class);
 
@@ -234,7 +234,7 @@ class PageControllerTest extends TestCase
         $this->assertInstanceOf(FormInterface::class, $view);
     }
 
-    public function testPostPageSnapshotAction()
+    public function testPostPageSnapshotAction(): void
     {
         $page = $this->createMock(PageInterface::class);
 
@@ -247,7 +247,7 @@ class PageControllerTest extends TestCase
         $this->assertSame(['queued' => true], $view);
     }
 
-    public function testPostPagesSnapshotsAction()
+    public function testPostPagesSnapshotsAction(): void
     {
         $site = $this->createMock(SiteInterface::class);
 
@@ -263,9 +263,6 @@ class PageControllerTest extends TestCase
         $this->assertSame(['queued' => true], $view);
     }
 
-    /**
-     * @return PageController
-     */
     public function createPageController(
         $page = null,
         $siteManager = null,
@@ -273,7 +270,7 @@ class PageControllerTest extends TestCase
         $blockManager = null,
         $formFactory = null,
         $backend = null
-    ) {
+    ): PageController {
         if (null === $siteManager) {
             $siteManager = $this->createMock(SiteManagerInterface::class);
         }

--- a/tests/Controller/Api/SiteControllerTest.php
+++ b/tests/Controller/Api/SiteControllerTest.php
@@ -30,7 +30,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  */
 class SiteControllerTest extends TestCase
 {
-    public function testGetSitesAction()
+    public function testGetSitesAction(): void
     {
         $siteManager = $this->createMock(SiteManagerInterface::class);
         $siteManager->expects($this->once())->method('getPager')->willReturn([]);
@@ -45,14 +45,14 @@ class SiteControllerTest extends TestCase
         $this->assertSame([], $this->createSiteController(null, $siteManager)->getSitesAction($paramFetcher));
     }
 
-    public function testGetSiteAction()
+    public function testGetSiteAction(): void
     {
         $site = $this->createMock(SiteInterface::class);
 
         $this->assertSame($site, $this->createSiteController($site)->getSiteAction(1));
     }
 
-    public function testGetSiteActionNotFoundException()
+    public function testGetSiteActionNotFoundException(): void
     {
         $this->expectException(NotFoundHttpException::class);
         $this->expectExceptionMessage('Site (1) not found');
@@ -60,7 +60,7 @@ class SiteControllerTest extends TestCase
         $this->createSiteController()->getSiteAction(1);
     }
 
-    public function testPostSiteAction()
+    public function testPostSiteAction(): void
     {
         $site = $this->createMock(SiteInterface::class);
 
@@ -80,7 +80,7 @@ class SiteControllerTest extends TestCase
         $this->assertInstanceOf(View::class, $view);
     }
 
-    public function testPostSiteInvalidAction()
+    public function testPostSiteInvalidAction(): void
     {
         $site = $this->createMock(SiteInterface::class);
 
@@ -99,7 +99,7 @@ class SiteControllerTest extends TestCase
         $this->assertInstanceOf(FormInterface::class, $view);
     }
 
-    public function testPutSiteAction()
+    public function testPutSiteAction(): void
     {
         $site = $this->createMock(SiteInterface::class);
 
@@ -119,7 +119,7 @@ class SiteControllerTest extends TestCase
         $this->assertInstanceOf(View::class, $view);
     }
 
-    public function testPutSiteInvalidAction()
+    public function testPutSiteInvalidAction(): void
     {
         $site = $this->createMock(SiteInterface::class);
 
@@ -138,7 +138,7 @@ class SiteControllerTest extends TestCase
         $this->assertInstanceOf(FormInterface::class, $view);
     }
 
-    public function testDeleteSiteAction()
+    public function testDeleteSiteAction(): void
     {
         $site = $this->createMock(SiteInterface::class);
 
@@ -150,7 +150,7 @@ class SiteControllerTest extends TestCase
         $this->assertSame(['deleted' => true], $view);
     }
 
-    public function testDeleteSiteInvalidAction()
+    public function testDeleteSiteInvalidAction(): void
     {
         $this->expectException(NotFoundHttpException::class);
 

--- a/tests/Controller/Api/SnapshotControllerTest.php
+++ b/tests/Controller/Api/SnapshotControllerTest.php
@@ -25,7 +25,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  */
 class SnapshotControllerTest extends TestCase
 {
-    public function testGetSnapshotsAction()
+    public function testGetSnapshotsAction(): void
     {
         $snapshotManager = $this->createMock(SnapshotManagerInterface::class);
         $snapshotManager->expects($this->once())->method('getPager')->willReturn([]);
@@ -41,7 +41,7 @@ class SnapshotControllerTest extends TestCase
             ->getSnapshotsAction($paramFetcher));
     }
 
-    public function testGetSnapshotAction()
+    public function testGetSnapshotAction(): void
     {
         $snapshot = $this->createMock(SnapshotInterface::class);
 
@@ -49,7 +49,7 @@ class SnapshotControllerTest extends TestCase
             ->getSnapshotAction(1));
     }
 
-    public function testGetSnapshotActionNotFoundException()
+    public function testGetSnapshotActionNotFoundException(): void
     {
         $this->expectException(NotFoundHttpException::class);
         $this->expectExceptionMessage('Snapshot (1) not found');
@@ -57,7 +57,7 @@ class SnapshotControllerTest extends TestCase
         $this->createSnapshotController()->getSnapshotAction(1);
     }
 
-    public function testDeleteSnapshotAction()
+    public function testDeleteSnapshotAction(): void
     {
         $snapshot = $this->createMock(SnapshotInterface::class);
 
@@ -70,7 +70,7 @@ class SnapshotControllerTest extends TestCase
         $this->assertSame(['deleted' => true], $view);
     }
 
-    public function testDeletePageInvalidAction()
+    public function testDeletePageInvalidAction(): void
     {
         $this->expectException(NotFoundHttpException::class);
 
@@ -81,10 +81,7 @@ class SnapshotControllerTest extends TestCase
             ->deleteSnapshotAction(1);
     }
 
-    /**
-     * @return SnapshotController
-     */
-    public function createSnapshotController($snapshot = null, $snapshotManager = null)
+    public function createSnapshotController($snapshot = null, $snapshotManager = null): SnapshotController
     {
         if (null === $snapshotManager) {
             $snapshotManager = $this->createMock(SnapshotManagerInterface::class);

--- a/tests/DependencyInjection/Compiler/CmfRouterAutoRegisterTest.php
+++ b/tests/DependencyInjection/Compiler/CmfRouterAutoRegisterTest.php
@@ -24,7 +24,7 @@ class CmfRouterAutoRegisterTest extends AbstractCompilerPassTestCase
     /**
      * @dataProvider providerRoutedAutoRegister
      */
-    public function testRouterAutoRegister($enabled, $priority)
+    public function testRouterAutoRegister($enabled, $priority): void
     {
         $this->container->setParameter('sonata.page.router_auto_register.enabled', $enabled);
         $this->container->setParameter('sonata.page.router_auto_register.priority', $priority);
@@ -33,12 +33,12 @@ class CmfRouterAutoRegisterTest extends AbstractCompilerPassTestCase
 
         $router = $this->container->getDefinition('cmf_routing.router');
         foreach ($router->getMethodCalls() as $methodCall) {
-            list($method, $arguments) = $methodCall;
+            [$method, $arguments] = $methodCall;
 
             if ('add' !== $method) {
                 continue;
             }
-            list($reference, $weight) = $arguments;
+            [$reference, $weight] = $arguments;
             if ($reference instanceof Reference && 'sonata.page.router' === $reference->__toString()) {
                 if ($enabled) {
                     $this->assertSame($priority, $weight);
@@ -49,7 +49,7 @@ class CmfRouterAutoRegisterTest extends AbstractCompilerPassTestCase
         }
     }
 
-    public function providerRoutedAutoRegister()
+    public function providerRoutedAutoRegister(): array
     {
         return [
             'enabled router' => [true, 42],

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\Config\Definition\Processor;
 
 class ConfigurationTest extends TestCase
 {
-    public function testPageWithMatrix()
+    public function testPageWithMatrix(): void
     {
         $processor = new Processor();
 
@@ -162,14 +162,13 @@ class ConfigurationTest extends TestCase
                     'block' => 'Application\\Sonata\\PageBundle\\Entity\\Block',
                     'site' => 'Application\\Sonata\\PageBundle\\Entity\\Site',
             ],
-            'slugify_service' => 'sonata.core.slugify.native',
             'direct_publication' => false,
         ];
 
         $this->assertSame($expected, $config);
     }
 
-    public function testPageWithoutMatrix()
+    public function testPageWithoutMatrix(): void
     {
         $processor = new Processor();
 

--- a/tests/DependencyInjection/SonataPageExtensionTest.php
+++ b/tests/DependencyInjection/SonataPageExtensionTest.php
@@ -22,14 +22,14 @@ use Symfony\Bundle\TwigBundle\DependencyInjection\TwigExtension;
  */
 class SonataPageExtensionTest extends AbstractExtensionTestCase
 {
-    public function testRequestContextServiceIsDefined()
+    public function testRequestContextServiceIsDefined(): void
     {
         $this->container->setParameter('kernel.bundles', []);
         $this->load();
         $this->assertContainerBuilderHasService('sonata.page.router.request_context');
     }
 
-    public function testApiServicesAreDefinedWhenSpecificBundlesArePresent()
+    public function testApiServicesAreDefinedWhenSpecificBundlesArePresent(): void
     {
         $this->container->setParameter('kernel.bundles', [
             'FOSRestBundle' => 42,
@@ -39,7 +39,7 @@ class SonataPageExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasService('sonata.page.serializer.handler.page');
     }
 
-    public function testAdminServicesAreDefinedWhenAdminBundlesIsPresent()
+    public function testAdminServicesAreDefinedWhenAdminBundlesIsPresent(): void
     {
         $this->container->setParameter('kernel.bundles', [
             'SonataAdminBundle' => 42,
@@ -48,7 +48,7 @@ class SonataPageExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasService('sonata.page.admin.page');
     }
 
-    public function testRouterAutoRegister()
+    public function testRouterAutoRegister(): void
     {
         $this->container->setParameter('kernel.bundles', [
             'CmfRouterBundle' => 42,
@@ -63,7 +63,7 @@ class SonataPageExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasParameter('sonata.page.router_auto_register.priority', 84);
     }
 
-    public function testDatePickerFormTheme()
+    public function testDatePickerFormTheme(): void
     {
         $this->container->setParameter('kernel.bundles', []);
         $this->container->setParameter('kernel.bundles_metadata', []);
@@ -73,11 +73,10 @@ class SonataPageExtensionTest extends AbstractExtensionTestCase
         $this->container->registerExtension(new TwigExtension());
 
         $this->container->compile();
-        $this->assertTrue(\in_array(
+        $this->assertContains(
             '@SonataCore/Form/datepicker.html.twig',
-            $this->container->getParameter('twig.form.resources'),
-            true
-        ));
+            $this->container->getParameter('twig.form.resources')
+        );
     }
 
     protected function getContainerExtensions(): array

--- a/tests/Entity/BlockManagerTest.php
+++ b/tests/Entity/BlockManagerTest.php
@@ -25,7 +25,7 @@ use Sonata\PageBundle\Entity\BlockManager;
 
 class BlockManagerTest extends TestCase
 {
-    public function testGetPager()
+    public function testGetPager(): void
     {
         $self = $this;
         $this
@@ -37,29 +37,29 @@ class BlockManagerTest extends TestCase
             ->getPager(['root' => true], 1);
     }
 
-    protected function getBlockManager($qbCallback)
+    protected function getBlockManager($qbCallback): BlockManager
     {
         $query = $this->getMockForAbstractClass(AbstractQuery::class, [], '', false, true, true, ['execute']);
-        $query->expects($this->any())->method('execute')->willReturn(true);
+        $query->method('execute')->willReturn(true);
 
         $qb = $this->getMockBuilder(QueryBuilder::class)
             ->setConstructorArgs([$this->createMock(EntityManager::class)])
             ->getMock();
 
-        $qb->expects($this->any())->method('getRootAliases')->willReturn([]);
-        $qb->expects($this->any())->method('select')->willReturn($qb);
-        $qb->expects($this->any())->method('getQuery')->willReturn($query);
+        $qb->method('getRootAliases')->willReturn([]);
+        $qb->method('select')->willReturn($qb);
+        $qb->method('getQuery')->willReturn($query);
 
         $qbCallback($qb);
 
         $repository = $this->createMock(EntityRepository::class);
-        $repository->expects($this->any())->method('createQueryBuilder')->willReturn($qb);
+        $repository->method('createQueryBuilder')->willReturn($qb);
 
         $em = $this->createMock(EntityManagerInterface::class);
-        $em->expects($this->any())->method('getRepository')->willReturn($repository);
+        $em->method('getRepository')->willReturn($repository);
 
         $registry = $this->createMock(ManagerRegistry::class);
-        $registry->expects($this->any())->method('getManagerForClass')->willReturn($em);
+        $registry->method('getManagerForClass')->willReturn($em);
 
         return new BlockManager(BasePage::class, $registry);
     }

--- a/tests/Entity/PageManagerTest.php
+++ b/tests/Entity/PageManagerTest.php
@@ -27,7 +27,7 @@ use Sonata\PageBundle\Tests\Model\Page;
 
 class PageManagerTest extends TestCase
 {
-    public function testFixUrl()
+    public function testFixUrl(): void
     {
         $manager = new PageManager(
             'Foo\Bar',
@@ -71,7 +71,7 @@ class PageManagerTest extends TestCase
         $this->assertSame('/', $page1->getUrl());
     }
 
-    public function testWithSlashAtTheEnd()
+    public function testWithSlashAtTheEnd(): void
     {
         $manager = new PageManager(
             'Foo\Bar',
@@ -98,7 +98,7 @@ class PageManagerTest extends TestCase
         $this->assertSame('/bundles/foobar', $child->getUrl());
     }
 
-    public function testCreateWithGlobalDefaults()
+    public function testCreateWithGlobalDefaults(): void
     {
         $manager = new PageManager(
             Page::class,
@@ -113,7 +113,7 @@ class PageManagerTest extends TestCase
         $this->assertFalse($page->getDecorate());
     }
 
-    public function testGetPager()
+    public function testGetPager(): void
     {
         $self = $this;
         $this
@@ -128,21 +128,20 @@ class PageManagerTest extends TestCase
             ->getPager([], 1);
     }
 
-    public function testGetPagerWithInvalidSort()
+    public function testGetPagerWithInvalidSort(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage(
             'Invalid sort field \'invalid\' in \'Sonata\\PageBundle\\Entity\\BasePage\' class'
         );
 
-        $self = $this;
         $this
-            ->getPageManager(static function ($qb) use ($self) {
+            ->getPageManager(static function ($qb) {
             })
             ->getPager([], 1, 10, ['invalid' => 'ASC']);
     }
 
-    public function testGetPagerWithMultipleSort()
+    public function testGetPagerWithMultipleSort(): void
     {
         $self = $this;
         $this
@@ -166,7 +165,7 @@ class PageManagerTest extends TestCase
             ]);
     }
 
-    public function testGetPagerWithRootPages()
+    public function testGetPagerWithRootPages(): void
     {
         $self = $this;
         $this
@@ -176,7 +175,7 @@ class PageManagerTest extends TestCase
             ->getPager(['root' => true], 1);
     }
 
-    public function testGetPagerWithNonRootPages()
+    public function testGetPagerWithNonRootPages(): void
     {
         $self = $this;
         $this
@@ -186,7 +185,7 @@ class PageManagerTest extends TestCase
             ->getPager(['root' => false], 1);
     }
 
-    public function testGetPagerWithEnabledPages()
+    public function testGetPagerWithEnabledPages(): void
     {
         $self = $this;
         $this
@@ -197,7 +196,7 @@ class PageManagerTest extends TestCase
             ->getPager(['enabled' => true], 1);
     }
 
-    public function testGetPagerWithDisabledPages()
+    public function testGetPagerWithDisabledPages(): void
     {
         $self = $this;
         $this
@@ -208,7 +207,7 @@ class PageManagerTest extends TestCase
             ->getPager(['enabled' => false], 1);
     }
 
-    public function testGetPagerWithEditedPages()
+    public function testGetPagerWithEditedPages(): void
     {
         $self = $this;
         $this
@@ -219,7 +218,7 @@ class PageManagerTest extends TestCase
             ->getPager(['edited' => true], 1);
     }
 
-    public function testGetPagerWithNonEditedPages()
+    public function testGetPagerWithNonEditedPages(): void
     {
         $self = $this;
         $this
@@ -230,7 +229,7 @@ class PageManagerTest extends TestCase
             ->getPager(['edited' => false], 1);
     }
 
-    public function testGetPagerWithParentChildPages()
+    public function testGetPagerWithParentChildPages(): void
     {
         $self = $this;
         $this
@@ -245,7 +244,7 @@ class PageManagerTest extends TestCase
             ->getPager(['parent' => 13], 1);
     }
 
-    public function testGetPagerWithSitePages()
+    public function testGetPagerWithSitePages(): void
     {
         $self = $this;
         $this
@@ -260,36 +259,36 @@ class PageManagerTest extends TestCase
             ->getPager(['site' => 13], 1);
     }
 
-    protected function getPageManager($qbCallback)
+    protected function getPageManager($qbCallback): PageManager
     {
         $query = $this->getMockForAbstractClass(AbstractQuery::class, [], '', false, true, true, ['execute']);
-        $query->expects($this->any())->method('execute')->willReturn(true);
+        $query->method('execute')->willReturn(true);
 
         $qb = $this->getMockBuilder(QueryBuilder::class)
             ->setConstructorArgs([$this->createMock(EntityManager::class)])
             ->getMock();
 
-        $qb->expects($this->any())->method('getRootAliases')->willReturn([]);
-        $qb->expects($this->any())->method('select')->willReturn($qb);
-        $qb->expects($this->any())->method('getQuery')->willReturn($query);
+        $qb->method('getRootAliases')->willReturn([]);
+        $qb->method('select')->willReturn($qb);
+        $qb->method('getQuery')->willReturn($query);
 
         $qbCallback($qb);
 
         $repository = $this->createMock(EntityRepository::class);
-        $repository->expects($this->any())->method('createQueryBuilder')->willReturn($qb);
+        $repository->method('createQueryBuilder')->willReturn($qb);
 
         $metadata = $this->createMock(ClassMetadata::class);
-        $metadata->expects($this->any())->method('getFieldNames')->willReturn([
+        $metadata->method('getFieldNames')->willReturn([
             'name',
             'routeName',
         ]);
 
         $em = $this->createMock(EntityManagerInterface::class);
-        $em->expects($this->any())->method('getRepository')->willReturn($repository);
-        $em->expects($this->any())->method('getClassMetadata')->willReturn($metadata);
+        $em->method('getRepository')->willReturn($repository);
+        $em->method('getClassMetadata')->willReturn($metadata);
 
         $registry = $this->createMock(ManagerRegistry::class);
-        $registry->expects($this->any())->method('getManagerForClass')->willReturn($em);
+        $registry->method('getManagerForClass')->willReturn($em);
 
         return new PageManager(BasePage::class, $registry);
     }

--- a/tests/Entity/SiteManagerTest.php
+++ b/tests/Entity/SiteManagerTest.php
@@ -26,7 +26,7 @@ use Sonata\PageBundle\Entity\SiteManager;
 
 class SiteManagerTest extends TestCase
 {
-    public function testGetPager()
+    public function testGetPager(): void
     {
         $self = $this;
         $this
@@ -41,21 +41,20 @@ class SiteManagerTest extends TestCase
             ->getPager([], 1);
     }
 
-    public function testGetPagerWithInvalidSort()
+    public function testGetPagerWithInvalidSort(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage(
             'Invalid sort field \'invalid\' in \'Sonata\\PageBundle\\Entity\\BaseSite\' class'
         );
 
-        $self = $this;
         $this
-            ->getSiteManager(static function ($qb) use ($self) {
+            ->getSiteManager(static function ($qb) {
             })
             ->getPager([], 1, 10, ['invalid' => 'ASC']);
     }
 
-    public function testGetPagerWithMultipleSort()
+    public function testGetPagerWithMultipleSort(): void
     {
         $self = $this;
         $this
@@ -80,7 +79,7 @@ class SiteManagerTest extends TestCase
             ]);
     }
 
-    public function testGetPagerWithEnabledSites()
+    public function testGetPagerWithEnabledSites(): void
     {
         $self = $this;
         $this
@@ -91,7 +90,7 @@ class SiteManagerTest extends TestCase
             ->getPager(['enabled' => true], 1);
     }
 
-    public function testGetPagerWithDisabledSites()
+    public function testGetPagerWithDisabledSites(): void
     {
         $self = $this;
         $this
@@ -102,7 +101,7 @@ class SiteManagerTest extends TestCase
             ->getPager(['enabled' => false], 1);
     }
 
-    public function testGetPagerWithDefaultSites()
+    public function testGetPagerWithDefaultSites(): void
     {
         $self = $this;
         $this
@@ -113,7 +112,7 @@ class SiteManagerTest extends TestCase
             ->getPager(['is_default' => true], 1);
     }
 
-    public function testGetPagerWithNonDefaultSites()
+    public function testGetPagerWithNonDefaultSites(): void
     {
         $self = $this;
         $this
@@ -124,36 +123,36 @@ class SiteManagerTest extends TestCase
             ->getPager(['is_default' => false], 1);
     }
 
-    protected function getSiteManager($qbCallback)
+    protected function getSiteManager($qbCallback): SiteManager
     {
         $query = $this->getMockForAbstractClass(AbstractQuery::class, [], '', false, true, true, ['execute']);
-        $query->expects($this->any())->method('execute')->willReturn(true);
+        $query->method('execute')->willReturn(true);
 
         $qb = $this->getMockBuilder(QueryBuilder::class)
             ->setConstructorArgs([$this->createMock(EntityManager::class)])
             ->getMock();
 
-        $qb->expects($this->any())->method('getRootAliases')->willReturn([]);
-        $qb->expects($this->any())->method('select')->willReturn($qb);
-        $qb->expects($this->any())->method('getQuery')->willReturn($query);
+        $qb->method('getRootAliases')->willReturn([]);
+        $qb->method('select')->willReturn($qb);
+        $qb->method('getQuery')->willReturn($query);
 
         $qbCallback($qb);
 
         $repository = $this->createMock(EntityRepository::class);
-        $repository->expects($this->any())->method('createQueryBuilder')->willReturn($qb);
+        $repository->method('createQueryBuilder')->willReturn($qb);
 
         $metadata = $this->createMock(ClassMetadata::class);
-        $metadata->expects($this->any())->method('getFieldNames')->willReturn([
+        $metadata->method('getFieldNames')->willReturn([
             'name',
             'host',
         ]);
 
         $em = $this->createMock(EntityManagerInterface::class);
-        $em->expects($this->any())->method('getRepository')->willReturn($repository);
-        $em->expects($this->any())->method('getClassMetadata')->willReturn($metadata);
+        $em->method('getRepository')->willReturn($repository);
+        $em->method('getClassMetadata')->willReturn($metadata);
 
         $registry = $this->createMock(ManagerRegistry::class);
-        $registry->expects($this->any())->method('getManagerForClass')->willReturn($em);
+        $registry->method('getManagerForClass')->willReturn($em);
 
         return new SiteManager(BaseSite::class, $registry);
     }

--- a/tests/Entity/Snapshot.php
+++ b/tests/Entity/Snapshot.php
@@ -25,7 +25,7 @@ class Snapshot extends BaseSnapshot
     /**
      * @return int $id
      */
-    public function getId()
+    public function getId(): int
     {
         return $this->id;
     }

--- a/tests/Entity/SnapshotManagerTest.php
+++ b/tests/Entity/SnapshotManagerTest.php
@@ -31,7 +31,7 @@ use Sonata\PageBundle\Model\TransformerInterface;
 
 class SnapshotManagerTest extends TestCase
 {
-    public function testSetTemplates()
+    public function testSetTemplates(): void
     {
         $manager = $this->getMockBuilder(SnapshotManager::class)
             // we need to set at least one method, which does not need to exist!
@@ -51,7 +51,7 @@ class SnapshotManagerTest extends TestCase
         $this->assertSame(['foo' => 'bar'], $manager->getTemplates());
     }
 
-    public function testGetTemplates()
+    public function testGetTemplates(): void
     {
         $manager = $this->getMockBuilder(SnapshotManager::class)
             ->setMethods([
@@ -69,7 +69,7 @@ class SnapshotManagerTest extends TestCase
         $this->assertSame(['foo' => 'bar'], $manager->getTemplates());
     }
 
-    public function testGetTemplate()
+    public function testGetTemplate(): void
     {
         $manager = $this->getMockBuilder(SnapshotManager::class)
             ->setMethods([
@@ -87,7 +87,7 @@ class SnapshotManagerTest extends TestCase
         $this->assertSame('bar', $manager->getTemplate('foo'));
     }
 
-    public function testGetTemplatesException()
+    public function testGetTemplatesException(): void
     {
         $manager = $this->getMockBuilder(SnapshotManager::class)
             ->setMethods([
@@ -103,7 +103,7 @@ class SnapshotManagerTest extends TestCase
         $manager->getTemplate('foo');
     }
 
-    public function testGetPager()
+    public function testGetPager(): void
     {
         $self = $this;
         $this
@@ -114,7 +114,7 @@ class SnapshotManagerTest extends TestCase
             ->getPager([], 1);
     }
 
-    public function testGetPagerWithEnabledSnapshots()
+    public function testGetPagerWithEnabledSnapshots(): void
     {
         $self = $this;
         $this
@@ -125,7 +125,7 @@ class SnapshotManagerTest extends TestCase
             ->getPager(['enabled' => true], 1);
     }
 
-    public function testGetPagerWithDisabledSnapshots()
+    public function testGetPagerWithDisabledSnapshots(): void
     {
         $self = $this;
         $this
@@ -136,7 +136,7 @@ class SnapshotManagerTest extends TestCase
             ->getPager(['enabled' => false], 1);
     }
 
-    public function testGetPagerWithRootSnapshots()
+    public function testGetPagerWithRootSnapshots(): void
     {
         $self = $this;
         $this
@@ -146,7 +146,7 @@ class SnapshotManagerTest extends TestCase
             ->getPager(['root' => true], 1);
     }
 
-    public function testGetPagerWithNonRootSnapshots()
+    public function testGetPagerWithNonRootSnapshots(): void
     {
         $self = $this;
         $this
@@ -156,7 +156,7 @@ class SnapshotManagerTest extends TestCase
             ->getPager(['root' => false], 1);
     }
 
-    public function testGetPagerWithParentChildSnapshots()
+    public function testGetPagerWithParentChildSnapshots(): void
     {
         $self = $this;
         $this
@@ -171,7 +171,7 @@ class SnapshotManagerTest extends TestCase
             ->getPager(['parent' => 13], 1);
     }
 
-    public function testGetPagerWithSiteSnapshots()
+    public function testGetPagerWithSiteSnapshots(): void
     {
         $self = $this;
         $this
@@ -189,7 +189,7 @@ class SnapshotManagerTest extends TestCase
     /**
      * Tests the enableSnapshots() method to ensure execute queries are correct.
      */
-    public function testEnableSnapshots()
+    public function testEnableSnapshots(): void
     {
         // Given
         $page = $this->createMock(PageInterface::class);
@@ -228,7 +228,7 @@ class SnapshotManagerTest extends TestCase
         $manager->enableSnapshots([$snapshot], $date);
     }
 
-    public function testCreateSnapshotPageProxy()
+    public function testCreateSnapshotPageProxy(): void
     {
         $proxyInterface = $this->createMock(SnapshotPageProxyInterface::class);
 
@@ -250,7 +250,7 @@ class SnapshotManagerTest extends TestCase
     /**
      * Tests the enableSnapshots() method to ensure execute queries are not executed when no snapshots are given.
      */
-    public function testEnableSnapshotsWhenNoSnapshots()
+    public function testEnableSnapshotsWhenNoSnapshots(): void
     {
         $connection = $this->createMock(Connection::class);
         $connection->expects($this->never())->method('query');
@@ -272,29 +272,29 @@ class SnapshotManagerTest extends TestCase
         $manager->enableSnapshots([]);
     }
 
-    protected function getSnapshotManager($qbCallback)
+    protected function getSnapshotManager($qbCallback): SnapshotManager
     {
         $query = $this->getMockForAbstractClass(AbstractQuery::class, [], '', false, true, true, ['execute']);
-        $query->expects($this->any())->method('execute')->willReturn(true);
+        $query->method('execute')->willReturn(true);
 
         $qb = $this->getMockBuilder(QueryBuilder::class)
             ->setConstructorArgs([$this->createMock(EntityManager::class)])
             ->getMock();
 
-        $qb->expects($this->any())->method('getRootAliases')->willReturn([]);
-        $qb->expects($this->any())->method('select')->willReturn($qb);
-        $qb->expects($this->any())->method('getQuery')->willReturn($query);
+        $qb->method('getRootAliases')->willReturn([]);
+        $qb->method('select')->willReturn($qb);
+        $qb->method('getQuery')->willReturn($query);
 
         $qbCallback($qb);
 
         $repository = $this->createMock(EntityRepository::class);
-        $repository->expects($this->any())->method('createQueryBuilder')->willReturn($qb);
+        $repository->method('createQueryBuilder')->willReturn($qb);
 
         $em = $this->createMock(EntityManagerInterface::class);
-        $em->expects($this->any())->method('getRepository')->willReturn($repository);
+        $em->method('getRepository')->willReturn($repository);
 
         $registry = $this->createMock(ManagerRegistry::class);
-        $registry->expects($this->any())->method('getManagerForClass')->willReturn($em);
+        $registry->method('getManagerForClass')->willReturn($em);
 
         $snapshotProxyFactory = $this->createMock(SnapshotPageProxyFactoryInterface::class);
 

--- a/tests/Form/Type/PageSelectorTypeTest.php
+++ b/tests/Form/Type/PageSelectorTypeTest.php
@@ -77,7 +77,7 @@ class PageSelectorTypeTest extends TestCase
     {
         $manager = $this->createMock(PageManagerInterface::class);
 
-        $manager->expects($this->any())
+        $manager
             ->method('loadPages')
             ->willReturn($this->pages);
 
@@ -87,7 +87,7 @@ class PageSelectorTypeTest extends TestCase
     /**
      * @group legacy
      */
-    public function testNoSite()
+    public function testNoSite(): void
     {
         $pageSelector = new PageSelectorType($this->getPageManager());
 
@@ -103,7 +103,7 @@ class PageSelectorTypeTest extends TestCase
     /**
      * @group legacy
      */
-    public function testAllRequestMethodChoices()
+    public function testAllRequestMethodChoices(): void
     {
         $pageSelector = new PageSelectorType($this->getPageManager());
 
@@ -116,7 +116,7 @@ class PageSelectorTypeTest extends TestCase
         $this->assertCount(4, $options['choices']);
     }
 
-    public function testGetRequestMethodChoices()
+    public function testGetRequestMethodChoices(): void
     {
         $pageSelector = new PageSelectorType($this->getPageManager());
 
@@ -132,7 +132,7 @@ class PageSelectorTypeTest extends TestCase
         $this->assertRouteNameEquals('get-post', $views[4]);
     }
 
-    public function testPostRequestMethodChoices()
+    public function testPostRequestMethodChoices(): void
     {
         $pageSelector = new PageSelectorType($this->getPageManager());
 
@@ -150,7 +150,7 @@ class PageSelectorTypeTest extends TestCase
         $this->assertRouteNameEquals('get-post', $views[4]);
     }
 
-    public function testRootHierarchyChoices()
+    public function testRootHierarchyChoices(): void
     {
         $pageSelector = new PageSelectorType($this->getPageManager());
 
@@ -167,7 +167,7 @@ class PageSelectorTypeTest extends TestCase
         $this->assertRouteNameEquals('all', $views[1]);
     }
 
-    public function testChildrenHierarchyChoices()
+    public function testChildrenHierarchyChoices(): void
     {
         $pageSelector = new PageSelectorType($this->getPageManager());
 
@@ -186,7 +186,7 @@ class PageSelectorTypeTest extends TestCase
         $this->assertRouteNameEquals('get-post', $views[4]);
     }
 
-    public function testComplexHierarchyChoices()
+    public function testComplexHierarchyChoices(): void
     {
         $pageSelector = new PageSelectorType($this->getPageManager());
 
@@ -204,12 +204,12 @@ class PageSelectorTypeTest extends TestCase
         $this->assertRouteNameEquals('get-post', $views[4]);
     }
 
-    private function assertRouteNameEquals($expected, $choiceView)
+    private function assertRouteNameEquals($expected, $choiceView): void
     {
         if ($choiceView instanceof LegacyChoiceView) { // NEXT_MAJOR: remove conditional
-            return $this->assertSame($expected, $choiceView->label->getRouteName());
+            $this->assertSame($expected, $choiceView->label->getRouteName());
         }
 
-        return $this->assertSame($expected, $choiceView->getRouteName());
+        $this->assertSame($expected, $choiceView->getRouteName());
     }
 }

--- a/tests/Form/Type/TemplateChoiceTypeTest.php
+++ b/tests/Form/Type/TemplateChoiceTypeTest.php
@@ -44,7 +44,7 @@ class TemplateChoiceTypeTest extends TestCase
     /**
      * Test getting options.
      */
-    public function testGetOptions()
+    public function testGetOptions(): void
     {
         $this->manager->expects($this->atLeastOnce())->method('getAll')->willReturn([
             'my_template' => $this->getMockTemplate('Template 1'),
@@ -66,8 +66,8 @@ class TemplateChoiceTypeTest extends TestCase
     protected function getMockTemplate(string $name, string $path = 'path/to/file'): MockObject
     {
         $template = $this->createMock(Template::class);
-        $template->expects($this->any())->method('getName')->willReturn($name);
-        $template->expects($this->any())->method('getPath')->willReturn($path);
+        $template->method('getName')->willReturn($name);
+        $template->method('getPath')->willReturn($path);
 
         return $template;
     }

--- a/tests/Listener/ExceptionListenerTest.php
+++ b/tests/Listener/ExceptionListenerTest.php
@@ -107,7 +107,7 @@ class ExceptionListenerTest extends TestCase
     /**
      * Test an internal exception.
      */
-    public function testInternalException()
+    public function testInternalException(): void
     {
         $exception = $this->createMock(InternalErrorException::class);
         $event = $this->getMockEvent($exception);
@@ -120,7 +120,7 @@ class ExceptionListenerTest extends TestCase
     /**
      * Test the not found exception in editor mode.
      */
-    public function testNotFoundExceptionInEditorMode()
+    public function testNotFoundExceptionInEditorMode(): void
     {
         $exception = new NotFoundHttpException();
         $event = $this->getMockEvent($exception);
@@ -144,10 +144,10 @@ class ExceptionListenerTest extends TestCase
     /**
      * Test the not found exception rendering.
      */
-    public function testNotFoundException()
+    public function testNotFoundException(): void
     {
         $exception = $this->createMock(NotFoundHttpException::class);
-        $exception->expects($this->any())->method('getStatusCode')->willReturn(404);
+        $exception->method('getStatusCode')->willReturn(404);
         $event = $this->getMockEvent($exception);
 
         $this->assertSame('en', $event->getRequest()->getLocale());
@@ -168,21 +168,18 @@ class ExceptionListenerTest extends TestCase
             ->with($this->anything(), $this->equalTo('route_404'))
             ->willReturn($page);
         $this->cmsManager->expects($this->once())->method('setCurrentPage')->with($this->equalTo($page));
-        $this->cmsSelector->expects($this->any())->method('retrieve')->willReturn($this->cmsManager);
+        $this->cmsSelector->method('retrieve')->willReturn($this->cmsManager);
 
         // mocked site selector should return a site
         $this->siteSelector
-            ->expects($this->any())
             ->method('retrieve')
             ->willReturn($this->createMock(SiteInterface::class));
 
         // mocked decorator strategy should allow decorate
         $this->decoratorStrategy
-            ->expects($this->any())
             ->method('isRouteNameDecorable')
             ->willReturn(true);
         $this->decoratorStrategy
-            ->expects($this->any())
             ->method('isRouteUriDecorable')
             ->willReturn(true);
 

--- a/tests/Listener/RequestListenerTest.php
+++ b/tests/Listener/RequestListenerTest.php
@@ -29,7 +29,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class RequestListenerTest extends TestCase
 {
-    public function testValidSite()
+    public function testValidSite(): void
     {
         $page = $this->createMock(PageInterface::class);
         $page->expects($this->once())->method('getEnabled')->willReturn(true);
@@ -59,7 +59,7 @@ class RequestListenerTest extends TestCase
         $listener->onCoreRequest($event);
     }
 
-    public function testNoSite()
+    public function testNoSite(): void
     {
         $this->expectException(InternalErrorException::class);
 

--- a/tests/Listener/ResponseListenerTest.php
+++ b/tests/Listener/ResponseListenerTest.php
@@ -77,7 +77,7 @@ class ResponseListenerTest extends TestCase
     /**
      * Test the listener without a page.
      */
-    public function testWithoutPage()
+    public function testWithoutPage(): void
     {
         $this->expectException(InternalErrorException::class);
 
@@ -95,7 +95,7 @@ class ResponseListenerTest extends TestCase
     /**
      * Test that the  listener does not mess up with response when a page is non decorable.
      */
-    public function testPageIsNonDecorable()
+    public function testPageIsNonDecorable(): void
     {
         $this->decoratorStrategy->expects($this->once())->method('isDecorable')->willReturn(false);
 
@@ -113,7 +113,7 @@ class ResponseListenerTest extends TestCase
     /**
      * Test that the listener correctly decorates the response content when a page is decorable.
      */
-    public function testPageIsDecorable()
+    public function testPageIsDecorable(): void
     {
         // a response content
         $content = 'inner';
@@ -150,7 +150,7 @@ class ResponseListenerTest extends TestCase
     /**
      * Test that the listener correctly alters the http headers when the editor is enabled.
      */
-    public function testPageIsEditor()
+    public function testPageIsEditor(): void
     {
         $this->cmsSelector->expects($this->once())->method('isEditor')->willReturn(true);
         $event = $this->getMockEvent('inner');

--- a/tests/Model/BlockInteractorTest.php
+++ b/tests/Model/BlockInteractorTest.php
@@ -28,12 +28,12 @@ class BlockInteractorTest extends TestCase
     /**
      * Test createNewContainer() method with some values.
      */
-    public function testCreateNewContainer()
+    public function testCreateNewContainer(): void
     {
         $registry = $this->createMock(ManagerRegistry::class);
 
         $blockManager = $this->createMock(BlockManagerInterface::class);
-        $blockManager->expects($this->any())->method('create')->willReturn(new Block());
+        $blockManager->method('create')->willReturn(new Block());
 
         $blockInteractor = new BlockInteractor($registry, $blockManager);
 

--- a/tests/Model/PageTest.php
+++ b/tests/Model/PageTest.php
@@ -25,7 +25,7 @@ class PageTest extends TestCase
      *
      * @group legacy
      */
-    public function testSlugify()
+    public function testSlugify(): void
     {
         setlocale(LC_ALL, 'en_US.utf8');
         setlocale(LC_CTYPE, 'en_US.utf8');
@@ -38,7 +38,7 @@ class PageTest extends TestCase
         $this->assertSame(Page::slugify(urldecode('%2Fc\'est+bientôt+l\'été')), 'c-est-bientot-l-ete');
     }
 
-    public function testHeader()
+    public function testHeader(): void
     {
         $expectedHeaders = [
             'Location' => 'http://www.google.fr',
@@ -138,7 +138,7 @@ class PageTest extends TestCase
         $this->assertSame($page->getHeaders(), $expectedHeaders);
     }
 
-    public function testHasRequestMethod()
+    public function testHasRequestMethod(): void
     {
         $page = new Page();
         $page->setRequestMethod('POST');
@@ -155,7 +155,7 @@ class PageTest extends TestCase
         $this->assertFalse($page->hasRequestMethod('biloute'));
     }
 
-    public function testGetterSetter()
+    public function testGetterSetter(): void
     {
         $page = new Page();
         $page->setEnabled(true);
@@ -221,7 +221,7 @@ class PageTest extends TestCase
         $this->assertSame('Salut', (string) $page);
     }
 
-    public function testParents()
+    public function testParents(): void
     {
         $root = new Page();
         $root->setName('root');
@@ -247,7 +247,7 @@ class PageTest extends TestCase
         $this->assertSame('level 1', $parent->getName());
     }
 
-    public function testPageTypeCMS()
+    public function testPageTypeCMS(): void
     {
         $page = new Page();
         $page->setRouteName(Page::PAGE_ROUTE_CMS_NAME);
@@ -259,7 +259,7 @@ class PageTest extends TestCase
         $this->assertFalse($page->isError(), 'isError');
     }
 
-    public function testPageTypeHybrid()
+    public function testPageTypeHybrid(): void
     {
         $page = new Page();
         $page->setRouteName('foo_bar');
@@ -272,7 +272,7 @@ class PageTest extends TestCase
         $this->assertFalse($page->isError(), 'isError');
     }
 
-    public function testPageTypeInternal()
+    public function testPageTypeInternal(): void
     {
         $page = new Page();
         $page->setName('global');
@@ -285,7 +285,7 @@ class PageTest extends TestCase
         $this->assertFalse($page->isError(), 'isError');
     }
 
-    public function testPageTypeError()
+    public function testPageTypeError(): void
     {
         $page = new Page();
         $page->setName('global');
@@ -298,7 +298,7 @@ class PageTest extends TestCase
         $this->assertTrue($page->isError(), 'isError');
     }
 
-    public function testPageTypeDynamic()
+    public function testPageTypeDynamic(): void
     {
         $page = new Page();
         $page->setRouteName('foo_bar');
@@ -310,19 +310,19 @@ class PageTest extends TestCase
         $this->assertFalse($page->isInternal(), 'isInternal');
     }
 
-    public function testGetContainer()
+    public function testGetContainer(): void
     {
         $page = new Page();
 
         $block1 = $this->createMock(Block::class);
-        $block1->expects($this->any())->method('getType')->willReturn('sonata.page.block.action');
+        $block1->method('getType')->willReturn('sonata.page.block.action');
 
         $block2 = $this->createMock(Block::class);
-        $block2->expects($this->any())->method('getType')->willReturn('sonata.page.block.container');
+        $block2->method('getType')->willReturn('sonata.page.block.container');
         $block2->expects($this->once())->method('getSetting')->willReturn('bar');
 
         $block3 = $this->createMock(Block::class);
-        $block3->expects($this->any())->method('getType')->willReturn('sonata.page.block.container');
+        $block3->method('getType')->willReturn('sonata.page.block.container');
         $block3->expects($this->once())->method('getSetting')->willReturn('gotcha');
 
         $page->addBlocks($block1);
@@ -332,7 +332,7 @@ class PageTest extends TestCase
         $this->assertSame($block3, $page->getContainerByCode('gotcha'));
     }
 
-    public function testGetBlockByType()
+    public function testGetBlockByType(): void
     {
         $page = new Page();
 

--- a/tests/Model/SnapshotPageProxyTest.php
+++ b/tests/Model/SnapshotPageProxyTest.php
@@ -22,7 +22,7 @@ use Sonata\PageBundle\Model\TransformerInterface;
 
 class SnapshotPageProxyTest extends TestCase
 {
-    public function testInterface()
+    public function testInterface(): void
     {
         $this->assertInstanceOf(
             SnapshotPageProxyInterface::class,

--- a/tests/Model/TemplateTest.php
+++ b/tests/Model/TemplateTest.php
@@ -18,7 +18,7 @@ use Sonata\PageBundle\Model\Template;
 
 class TemplateTest extends TestCase
 {
-    public function testArea()
+    public function testArea(): void
     {
         $template = new Template('page', 'template.twig');
 
@@ -47,7 +47,7 @@ class TemplateTest extends TestCase
         $this->assertSame($template->getContainers(), $expected);
     }
 
-    public function testGetContainer()
+    public function testGetContainer(): void
     {
         $template = new Template('page', 'template.twig', ['header' => [
             'name' => 'Header',

--- a/tests/Page/PageServiceManagerTest.php
+++ b/tests/Page/PageServiceManagerTest.php
@@ -42,7 +42,7 @@ class PageServiceManagerTest extends TestCase
     /**
      * Test adding a new page service.
      */
-    public function testAdd()
+    public function testAdd(): void
     {
         $service = $this->createMock(PageServiceInterface::class);
 
@@ -56,7 +56,7 @@ class PageServiceManagerTest extends TestCase
      *
      * @depends testAdd
      */
-    public function testGetByPage()
+    public function testGetByPage(): void
     {
         $service = $this->createMock(PageServiceInterface::class);
         $this->manager->add('my-type', $service);
@@ -76,7 +76,7 @@ class PageServiceManagerTest extends TestCase
      *
      * @depends testAdd
      */
-    public function testGetAll()
+    public function testGetAll(): void
     {
         $this->manager->add('service1', $service1 = $this->createMock(PageServiceInterface::class));
         $this->manager->add('service2', $service2 = $this->createMock(PageServiceInterface::class));
@@ -91,7 +91,7 @@ class PageServiceManagerTest extends TestCase
     /**
      * @depends testAdd
      */
-    public function testDefault()
+    public function testDefault(): void
     {
         $default = $this->createMock(PageServiceInterface::class);
         $this->manager->setDefault($default);
@@ -108,7 +108,7 @@ class PageServiceManagerTest extends TestCase
      *
      * @depends testDefault
      */
-    public function testExecute()
+    public function testExecute(): void
     {
         $request = $this->createMock(Request::class);
         $response = $this->createMock(Response::class);

--- a/tests/Page/Service/BasePageServiceTest.php
+++ b/tests/Page/Service/BasePageServiceTest.php
@@ -21,14 +21,14 @@ use Symfony\Component\HttpFoundation\Response;
 
 class BasePageServiceTest extends TestCase
 {
-    public function testName()
+    public function testName(): void
     {
         $service = new ConcretePageService('my name');
 
         $this->assertSame('my name', $service->getName());
     }
 
-    public function testExecution()
+    public function testExecution(): void
     {
         $service = new ConcretePageService('my name');
         $page = $this->createMock(PageInterface::class);

--- a/tests/Page/Service/DefaultPageServiceTest.php
+++ b/tests/Page/Service/DefaultPageServiceTest.php
@@ -50,7 +50,7 @@ class DefaultPageServiceTest extends TestCase
     /**
      * Test the default page service execution.
      */
-    public function testExecute()
+    public function testExecute(): void
     {
         // mock a http request
         $request = $this->createMock(Request::class);
@@ -60,7 +60,7 @@ class DefaultPageServiceTest extends TestCase
 
         // mock a page instance
         $page = $this->createMock(PageInterface::class);
-        $page->expects($this->any())->method('getTitle')->willReturn('page title');
+        $page->method('getTitle')->willReturn('page title');
         $page->expects($this->atLeastOnce())->method('getMetaDescription')->willReturn('page meta description');
         $page->expects($this->atLeastOnce())->method('getMetaKeyword')->willReturn('page meta keywords');
         $page->expects($this->once())->method('getTemplateCode')->willReturn('template code');

--- a/tests/Page/TemplateManagerTest.php
+++ b/tests/Page/TemplateManagerTest.php
@@ -26,7 +26,7 @@ class TemplateManagerTest extends TestCase
     /**
      * Test adding a new template.
      */
-    public function testAddSingleTemplate()
+    public function testAddSingleTemplate(): void
     {
         $template = $this->getMockTemplate('template');
         $templating = $this->createMock(EngineInterface::class);
@@ -40,7 +40,7 @@ class TemplateManagerTest extends TestCase
     /**
      * Test setting all templates.
      */
-    public function testSetAllTemplates()
+    public function testSetAllTemplates(): void
     {
         $templating = $this->createMock(EngineInterface::class);
         $manager = new TemplateManager($templating);
@@ -60,7 +60,7 @@ class TemplateManagerTest extends TestCase
     /**
      * Test setting the default template code.
      */
-    public function testSetDefaultTemplateCode()
+    public function testSetDefaultTemplateCode(): void
     {
         $templating = $this->createMock(EngineInterface::class);
         $manager = new TemplateManager($templating);
@@ -73,7 +73,7 @@ class TemplateManagerTest extends TestCase
     /**
      * test the rendering of a response.
      */
-    public function testRenderResponse()
+    public function testRenderResponse(): void
     {
         $template = $this->getMockTemplate('template', 'path/to/template');
 
@@ -98,7 +98,7 @@ class TemplateManagerTest extends TestCase
     /**
      * test the rendering of a response with a non existing template code.
      */
-    public function testRenderResponseWithNonExistingCode()
+    public function testRenderResponseWithNonExistingCode(): void
     {
         $templating = $this->createMock(EngineInterface::class);
         $templating
@@ -113,7 +113,7 @@ class TemplateManagerTest extends TestCase
     /**
      * test the rendering of a response with no template code.
      */
-    public function testRenderResponseWithoutCode()
+    public function testRenderResponseWithoutCode(): void
     {
         $response = $this->createMock(Response::class);
         $templating = $this->createMock(EngineInterface::class);
@@ -138,7 +138,7 @@ class TemplateManagerTest extends TestCase
     /**
      * test the rendering of a response with default parameters.
      */
-    public function testRenderResponseWithDefaultParameters()
+    public function testRenderResponseWithDefaultParameters(): void
     {
         $template = $this->getMockTemplate('template', 'path/to/template');
 
@@ -169,8 +169,8 @@ class TemplateManagerTest extends TestCase
     protected function getMockTemplate(string $name, string $path = 'path/to/file'): MockObject
     {
         $template = $this->createMock(Template::class);
-        $template->expects($this->any())->method('getName')->willReturn($name);
-        $template->expects($this->any())->method('getPath')->willReturn($path);
+        $template->method('getName')->willReturn($name);
+        $template->method('getPath')->willReturn($path);
 
         return $template;
     }

--- a/tests/Request/RequestFactoryTest.php
+++ b/tests/Request/RequestFactoryTest.php
@@ -30,31 +30,31 @@ class RequestFactoryTest extends TestCase
         Request::setFactory(null);
     }
 
-    public function testHostAndCreate()
+    public function testHostAndCreate(): void
     {
         $this->assertInstanceOf(Request::class, RequestFactory::create('host', '/'));
         $this->assertInstanceOf(Request::class, Request::create('/'));
     }
 
-    public function testHostAndCreateFromGlobals()
+    public function testHostAndCreateFromGlobals(): void
     {
         $this->assertInstanceOf(Request::class, RequestFactory::createFromGlobals('host'));
         $this->assertInstanceOf(Request::class, Request::create('/'));
     }
 
-    public function testHostWithPathAndCreate()
+    public function testHostWithPathAndCreate(): void
     {
         $this->assertInstanceOf(SiteRequest::class, RequestFactory::create('host_with_path', '/'));
         $this->assertInstanceOf(SiteRequest::class, Request::create('/'));
     }
 
-    public function testHostWithPathAndCreateFromGlobals()
+    public function testHostWithPathAndCreateFromGlobals(): void
     {
         $this->assertInstanceOf(SiteRequest::class, RequestFactory::createFromGlobals('host_with_path'));
         $this->assertInstanceOf(SiteRequest::class, Request::create('/'));
     }
 
-    public function testInvalidType()
+    public function testInvalidType(): void
     {
         $this->expectException(\RuntimeException::class);
 

--- a/tests/Request/SiteRequestTest.php
+++ b/tests/Request/SiteRequestTest.php
@@ -18,7 +18,7 @@ use Sonata\PageBundle\Request\SiteRequest;
 
 class SiteRequestTest extends TestCase
 {
-    public function testSiteRequest()
+    public function testSiteRequest(): void
     {
         $request = new SiteRequest();
         $request->setBaseUrl('folder/app_dev.php');

--- a/tests/Resources/XliffTest.php
+++ b/tests/Resources/XliffTest.php
@@ -37,7 +37,7 @@ class XliffTest extends TestCase
     /**
      * @dataProvider getXliffPaths
      */
-    public function testXliff($path)
+    public function testXliff($path): void
     {
         $this->validatePath($path);
 
@@ -55,7 +55,7 @@ class XliffTest extends TestCase
     /**
      * @return array List all path to validate xliff
      */
-    public function getXliffPaths()
+    public function getXliffPaths(): array
     {
         return [[__DIR__.'/../../Resources/translations']];
     }
@@ -63,7 +63,7 @@ class XliffTest extends TestCase
     /**
      * @param string $file The path to the xliff file
      */
-    protected function validateXliff($file)
+    protected function validateXliff($file): void
     {
         try {
             $this->loader->load($file, 'en');
@@ -76,7 +76,7 @@ class XliffTest extends TestCase
     /**
      * @param string $path The path to lookup for Xliff file
      */
-    protected function validatePath($path)
+    protected function validatePath($path): void
     {
         $files = glob(sprintf('%s/*.xliff', $path));
 

--- a/tests/Route/CmsPageRouterTest.php
+++ b/tests/Route/CmsPageRouterTest.php
@@ -61,51 +61,51 @@ class CmsPageRouterTest extends TestCase
         $this->router = new CmsPageRouter($this->cmsSelector, $this->siteSelector, $this->defaultRouter);
     }
 
-    public function testMatchToPageFound()
+    public function testMatchToPageFound(): void
     {
         $this->expectException(ResourceNotFoundException::class);
 
         $cms = $this->createMock(CmsManagerInterface::class);
-        $this->cmsSelector->expects($this->any())->method('retrieve')->willReturn($cms);
+        $this->cmsSelector->method('retrieve')->willReturn($cms);
 
         $site = $this->createMock(SiteInterface::class);
-        $this->siteSelector->expects($this->any())->method('retrieve')->willReturn($site);
+        $this->siteSelector->method('retrieve')->willReturn($site);
 
         $this->router->match('/');
     }
 
-    public function testMatchOnlyCmsPage()
+    public function testMatchOnlyCmsPage(): void
     {
         $this->expectException(ResourceNotFoundException::class);
 
         $page = $this->createMock(PageInterface::class);
-        $page->expects($this->any())->method('isCms')->willReturn(false);
+        $page->method('isCms')->willReturn(false);
 
         $cms = $this->createMock(CmsManagerInterface::class);
-        $cms->expects($this->any())->method('getPageByUrl')->willReturn($page);
+        $cms->method('getPageByUrl')->willReturn($page);
 
-        $this->cmsSelector->expects($this->any())->method('retrieve')->willReturn($cms);
+        $this->cmsSelector->method('retrieve')->willReturn($cms);
 
         $site = $this->createMock(SiteInterface::class);
-        $this->siteSelector->expects($this->any())->method('retrieve')->willReturn($site);
+        $this->siteSelector->method('retrieve')->willReturn($site);
 
         $this->router->match('/');
     }
 
-    public function testMatch()
+    public function testMatch(): void
     {
         $page = $this->createMock(PageInterface::class);
-        $page->expects($this->any())->method('isCms')->willReturn(true);
-        $page->expects($this->any())->method('getEnabled')->willReturn(true);
+        $page->method('isCms')->willReturn(true);
+        $page->method('getEnabled')->willReturn(true);
 
         $cms = $this->createMock(CmsManagerInterface::class);
-        $cms->expects($this->any())->method('getPageByUrl')->willReturn($page);
+        $cms->method('getPageByUrl')->willReturn($page);
         $cms->expects($this->once())->method('setCurrentPage');
 
-        $this->cmsSelector->expects($this->any())->method('retrieve')->willReturn($cms);
+        $this->cmsSelector->method('retrieve')->willReturn($cms);
 
         $site = $this->createMock(SiteInterface::class);
-        $this->siteSelector->expects($this->any())->method('retrieve')->willReturn($site);
+        $this->siteSelector->method('retrieve')->willReturn($site);
 
         $route = $this->router->match('/');
 
@@ -113,21 +113,21 @@ class CmsPageRouterTest extends TestCase
         $this->assertSame('page_slug', $route['_route']);
     }
 
-    public function testGenerateInvalidPage()
+    public function testGenerateInvalidPage(): void
     {
         $this->expectException(RouteNotFoundException::class);
 
         $this->router->generate('foobar');
     }
 
-    public function testGenerateWithPageSlugInvalidParameterException()
+    public function testGenerateWithPageSlugInvalidParameterException(): void
     {
         $this->expectException(\RuntimeException::class);
 
         $this->router->generate('page_slug', []);
     }
 
-    public function testSupports()
+    public function testSupports(): void
     {
         $this->assertTrue($this->router->supports('page_slug'));
         $this->assertTrue($this->router->supports('_page_alias_homepage'));
@@ -136,14 +136,14 @@ class CmsPageRouterTest extends TestCase
         $this->assertTrue($this->router->supports($this->createMock(PageInterface::class)));
     }
 
-    public function testGenerateWithPageSlugInvalidContext()
+    public function testGenerateWithPageSlugInvalidContext(): void
     {
         $this->expectException(\RuntimeException::class);
 
         $this->router->generate('page_slug', ['path' => '/path/to/page']);
     }
 
-    public function testGenerateWithPageSlugValid()
+    public function testGenerateWithPageSlugValid(): void
     {
         $this->router->setContext(new RequestContext());
 
@@ -185,7 +185,7 @@ class CmsPageRouterTest extends TestCase
     /**
      * @group legacy
      */
-    public function testGenerateWithPage()
+    public function testGenerateWithPage(): void
     {
         $page = $this->createMock(PageInterface::class);
 
@@ -213,7 +213,7 @@ class CmsPageRouterTest extends TestCase
     /**
      * @group legacy
      */
-    public function testGenerateWithPageCustomUrl()
+    public function testGenerateWithPageCustomUrl(): void
     {
         $page = $this->createMock(PageInterface::class);
         $page->expects($this->exactly(5))->method('isHybrid')->willReturn(false);
@@ -240,7 +240,7 @@ class CmsPageRouterTest extends TestCase
     /**
      * @group legacy
      */
-    public function testGenerateWithHybridPage()
+    public function testGenerateWithHybridPage(): void
     {
         $page = $this->createMock(PageInterface::class);
         $page->expects($this->exactly(5))->method('isHybrid')->willReturn(true);
@@ -310,14 +310,14 @@ class CmsPageRouterTest extends TestCase
     /**
      * @group legacy
      */
-    public function testGenerateWithPageAlias()
+    public function testGenerateWithPageAlias(): void
     {
         $page = $this->createMock(PageInterface::class);
         $page->expects($this->exactly(5))->method('isHybrid')->willReturn(false);
         $page->expects($this->exactly(5))->method('getUrl')->willReturn('/test/path');
 
         $site = $this->createMock(SiteInterface::class);
-        $this->siteSelector->expects($this->any())->method('retrieve')->willReturn($site);
+        $this->siteSelector->method('retrieve')->willReturn($site);
 
         $cmsManager = $this->createMock(CmsManagerInterface::class);
         $cmsManager->expects($this->exactly(5))->method('getPageByPageAlias')->willReturn($page);
@@ -341,7 +341,7 @@ class CmsPageRouterTest extends TestCase
         $this->assertSame('//localhost/test/path?key=value', $url);
     }
 
-    public function testGenerateWithPageAliasFromHybridPage()
+    public function testGenerateWithPageAliasFromHybridPage(): void
     {
         $page = $this->createMock(PageInterface::class);
         $page->expects($this->exactly(5))->method('isHybrid')->willReturn(true);
@@ -415,12 +415,12 @@ class CmsPageRouterTest extends TestCase
         $this->assertSame('//localhost/test/key/value', $url);
     }
 
-    public function testGenerateWithPageAndNewSiteContext()
+    public function testGenerateWithPageAndNewSiteContext(): void
     {
         $site1 = $this->createMock(SiteInterface::class);
-        $site1->expects($this->exactly(1))->method('getRelativePath')->willReturn('/site1');
+        $site1->expects($this->once())->method('getRelativePath')->willReturn('/site1');
         $site2 = $this->createMock(SiteInterface::class);
-        $site2->expects($this->exactly(1))->method('getRelativePath')->willReturn('/site2');
+        $site2->expects($this->once())->method('getRelativePath')->willReturn('/site2');
 
         $page = $this->createMock(PageInterface::class);
 
@@ -428,11 +428,11 @@ class CmsPageRouterTest extends TestCase
         $page->expects($this->exactly(2))->method('getUrl')->willReturn('/test/path');
 
         $page2 = clone $page;
-        $page2->expects($this->exactly(1))->method('getSite')->willReturn($site2);
-        $page->expects($this->exactly(1))->method('getSite')->willReturn($site1);
+        $page2->expects($this->once())->method('getSite')->willReturn($site2);
+        $page->expects($this->once())->method('getSite')->willReturn($site1);
 
         $siteSelector = $this->createMock(SiteSelectorInterface::class);
-        $siteSelector->expects($this->exactly(1))->method('retrieve')->willReturn($site1);
+        $siteSelector->expects($this->once())->method('retrieve')->willReturn($site1);
 
         $this->router->setContext(new SiteRequestContext($siteSelector));
 

--- a/tests/Route/RoutePageGeneratorTest.php
+++ b/tests/Route/RoutePageGeneratorTest.php
@@ -46,7 +46,7 @@ class RoutePageGeneratorTest extends TestCase
     /**
      * Tests site update route method with.
      */
-    public function testUpdateRoutes()
+    public function testUpdateRoutes(): void
     {
         $site = $this->getSiteMock();
 
@@ -78,7 +78,7 @@ class RoutePageGeneratorTest extends TestCase
     /**
      * Tests site update route method with.
      */
-    public function testUpdateRoutesClean()
+    public function testUpdateRoutesClean(): void
     {
         $site = $this->getSiteMock();
 
@@ -113,8 +113,8 @@ class RoutePageGeneratorTest extends TestCase
     protected function getSiteMock(): SiteInterface
     {
         $site = $this->createMock(SiteInterface::class);
-        $site->expects($this->any())->method('getHost')->willReturn('sonata-project.org');
-        $site->expects($this->any())->method('getId')->willReturn(1);
+        $site->method('getHost')->willReturn('sonata-project.org');
+        $site->method('getId')->willReturn(1);
 
         return $site;
     }
@@ -143,7 +143,7 @@ class RoutePageGeneratorTest extends TestCase
         ));
 
         $router = $this->createMock(RouterInterface::class);
-        $router->expects($this->any())->method('getRouteCollection')->willReturn($collection);
+        $router->method('getRouteCollection')->willReturn($collection);
 
         return $router;
     }
@@ -156,7 +156,7 @@ class RoutePageGeneratorTest extends TestCase
         $router = $this->getRouterMock();
 
         $pageManager = $this->createMock(PageManager::class);
-        $pageManager->expects($this->any())->method('create')->willReturn(new Page());
+        $pageManager->method('create')->willReturn(new Page());
 
         $hybridPageNotExists = new Page();
         $hybridPageNotExists->setRouteName('test_hybrid_page_not_exists');
@@ -172,14 +172,14 @@ class RoutePageGeneratorTest extends TestCase
             ->with($this->equalTo(['routeName' => 'test_hybrid_page_with_bad_host', 'site' => 1]))
             ->willReturn($hybridPageWithBadHost);
 
-        $pageManager->expects($this->any())
+        $pageManager
             ->method('getHybridPages')
             ->willReturn([$hybridPageNotExists, $hybridPageWithGoodHost, $hybridPageWithBadHost]);
 
         $decoratorStrategy = new DecoratorStrategy([], [], []);
 
         $exceptionListener = $this->createMock(ExceptionListener::class);
-        $exceptionListener->expects($this->any())->method('getHttpErrorCodes')->willReturn([404, 500]);
+        $exceptionListener->method('getHttpErrorCodes')->willReturn([404, 500]);
 
         return new RoutePageGenerator($router, $pageManager, $decoratorStrategy, $exceptionListener);
     }

--- a/tests/Site/BaseLocaleSiteSelectorTest.php
+++ b/tests/Site/BaseLocaleSiteSelectorTest.php
@@ -45,7 +45,7 @@ abstract class BaseLocaleSiteSelectorTest extends TestCase
      *
      * @return Site[]
      */
-    protected function getSites()
+    protected function getSites(): array
     {
         $sites = [];
 
@@ -68,10 +68,8 @@ abstract class BaseLocaleSiteSelectorTest extends TestCase
 
     /**
      * Gets the site from site selector.
-     *
-     * @return Site|null
      */
-    protected function getSite()
+    protected function getSite(): ?Site
     {
         return $this->siteSelector->retrieve();
     }

--- a/tests/Site/HostByLocaleSiteSelectorTest.php
+++ b/tests/Site/HostByLocaleSiteSelectorTest.php
@@ -41,7 +41,7 @@ class HostByLocaleSiteSelectorTest extends BaseLocaleSiteSelectorTest
     /**
      * Tests handleKernelRequest method selects the site /en.
      */
-    public function testHandleKernelRequestSelectsEn()
+    public function testHandleKernelRequestSelectsEn(): void
     {
         $kernel = $this->createMock(HttpKernelInterface::class);
         $request = SiteRequest::create('http://www.example.com');
@@ -71,7 +71,7 @@ class HostByLocaleSiteSelectorTest extends BaseLocaleSiteSelectorTest
     /**
      * Tests handleKernelRequest method selects the site /fr.
      */
-    public function testHandleKernelRequestSelectsFr()
+    public function testHandleKernelRequestSelectsFr(): void
     {
         $kernel = $this->createMock(HttpKernelInterface::class);
         $request = SiteRequest::create('http://www.example.com', 'GET', [], [], [], [

--- a/tests/Site/HostPathByLocaleSiteSelectorTest.php
+++ b/tests/Site/HostPathByLocaleSiteSelectorTest.php
@@ -42,7 +42,7 @@ class HostPathByLocaleSiteSelectorTest extends BaseLocaleSiteSelectorTest
     /**
      * Tests handleKernelRequest method redirects to /en.
      */
-    public function testHandleKernelRequestRedirectsToEn()
+    public function testHandleKernelRequestRedirectsToEn(): void
     {
         $kernel = $this->createMock(HttpKernelInterface::class);
         $request = SiteRequest::create('http://www.example.com');
@@ -81,7 +81,7 @@ class HostPathByLocaleSiteSelectorTest extends BaseLocaleSiteSelectorTest
     /**
      * Tests handleKernelRequest method redirects to /fr.
      */
-    public function testHandleKernelRequestRedirectsToFr()
+    public function testHandleKernelRequestRedirectsToFr(): void
     {
         $kernel = $this->createMock(HttpKernelInterface::class);
         $request = SiteRequest::create('http://www.example.com', 'GET', [], [], [], [

--- a/tests/Site/HostPathSiteSelectorTest.php
+++ b/tests/Site/HostPathSiteSelectorTest.php
@@ -34,10 +34,10 @@ class HostPathSiteSelectorTest extends TestCase
     /**
      * @dataProvider siteProvider
      */
-    public function testSite(string $expectedName, string $url, string $expectedPath = '/')
+    public function testSite(string $expectedName, string $url, string $expectedPath = '/'): void
     {
         // Retrieve the site that would be matched from the request
-        list($site, $event) = $this->performHandleKernelRequestTest($url);
+        [$site, $event] = $this->performHandleKernelRequestTest($url);
 
         // Ensure we retrieved the correct site.
         $this->assertSame($expectedName, $site->getName());
@@ -64,10 +64,10 @@ class HostPathSiteSelectorTest extends TestCase
     /**
      * @dataProvider siteWithRedirectProvider
      */
-    public function testSiteWithRedirect(string $expectedRedirectUri, string $url, string $path)
+    public function testSiteWithRedirect(string $expectedRedirectUri, string $url, string $path): void
     {
         // Retrieve the site that would be matched from the request
-        list($site, $event) = $this->performHandleKernelRequestTest($url);
+        [$site, $event] = $this->performHandleKernelRequestTest($url);
 
         // Ensure no site was retrieved
         $this->assertNull($site);
@@ -152,10 +152,8 @@ class HostPathSiteSelector extends BaseSiteSelector
      * @static
      *
      * @param string $property
-     *
-     * @return string
      */
-    public static function _camelize($property)
+    public static function _camelize($property): string
     {
         return preg_replace_callback('/(^|[_. ])+(.)/', static function ($match) {
             return ('.' === $match[1] ? '_' : '').strtoupper($match[2]);
@@ -173,10 +171,7 @@ class HostPathSiteSelector extends BaseSiteSelector
         ]);
     }
 
-    /**
-     * @return array
-     */
-    protected function _findSites(array $params)
+    protected function _findSites(array $params): array
     {
         $all_sites = $this->_getAllSites();
 
@@ -207,10 +202,7 @@ class HostPathSiteSelector extends BaseSiteSelector
         return $matched_sites;
     }
 
-    /**
-     * @return array
-     */
-    protected function _getAllSites()
+    protected function _getAllSites(): array
     {
         $always = null;
         $now = new \DateTime();
@@ -347,7 +339,7 @@ class HostPathSiteSelector extends BaseSiteSelector
 
         foreach ($getters as $getter) {
             if (method_exists($object, $getter)) {
-                return \call_user_func([$object, $getter]);
+                return $object->$getter();
             }
         }
 

--- a/tests/Site/HostSiteSelectorTest.php
+++ b/tests/Site/HostSiteSelectorTest.php
@@ -32,10 +32,10 @@ class HostSiteSelectorTest extends TestCase
     /**
      * @dataProvider siteProvider
      */
-    public function testSite(string $expectedName, string $url)
+    public function testSite(string $expectedName, string $url): void
     {
         // Retrieve the site that would be matched from the request
-        list($site, $event) = $this->performHandleKernelRequestTest($url);
+        [$site, $event] = $this->performHandleKernelRequestTest($url);
 
         // Ensure we retrieved the correct site.
         $this->assertSame($expectedName, $site->getName());
@@ -112,10 +112,8 @@ class HostSiteSelector extends BaseSiteSelector
      * @static
      *
      * @param string $property
-     *
-     * @return string
      */
-    public static function _camelize($property)
+    public static function _camelize($property): string
     {
         return preg_replace_callback('/(^|[_. ])+(.)/', static function ($match) {
             return ('.' === $match[1] ? '_' : '').strtoupper($match[2]);
@@ -137,10 +135,8 @@ class HostSiteSelector extends BaseSiteSelector
 
     /**
      * @param array $params
-     *
-     * @return array
      */
-    protected function _findSites($params)
+    protected function _findSites($params): array
     {
         $all_sites = $this->_getAllSites();
 
@@ -171,10 +167,7 @@ class HostSiteSelector extends BaseSiteSelector
         return $matched_sites;
     }
 
-    /**
-     * @return array
-     */
-    protected function _getAllSites()
+    protected function _getAllSites(): array
     {
         $always = null;
         $now = new \DateTime();
@@ -282,7 +275,7 @@ class HostSiteSelector extends BaseSiteSelector
 
         foreach ($getters as $getter) {
             if (method_exists($object, $getter)) {
-                return \call_user_func([$object, $getter]);
+                return $object->$getter();
             }
         }
 

--- a/tests/SonataPageBundleTest.php
+++ b/tests/SonataPageBundleTest.php
@@ -34,11 +34,11 @@ class SonataPageBundleTest extends TestCase
     /**
      * @dataProvider getSlug
      */
-    public function testBoot($text, $expected)
+    public function testBoot($text, $expected): void
     {
         $bundle = new SonataPageBundle();
         $container = $this->createMock(ContainerInterface::class);
-        $container->expects($this->exactly(1))->method('hasParameter')->willReturn(true);
+        $container->expects($this->once())->method('hasParameter')->willReturn(true);
         $container->expects($this->exactly(2))->method('getParameter')->willReturnCallback(static function ($value) {
             if ('sonata.page.page.class' === $value) {
                 return Page::class;
@@ -58,7 +58,7 @@ class SonataPageBundleTest extends TestCase
         $this->assertSame($page->getSlug(), $expected);
     }
 
-    public function getSlug()
+    public function getSlug(): array
     {
         return [
             ['Salut comment ca va ?',  'salut-comment-ca-va'],

--- a/tests/Template/Matrix/ParserTest.php
+++ b/tests/Template/Matrix/ParserTest.php
@@ -18,7 +18,7 @@ use Sonata\PageBundle\Template\Matrix\Parser;
 
 class ParserTest extends TestCase
 {
-    public function testParserWithInvalidTemplateMatrix()
+    public function testParserWithInvalidTemplateMatrix(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage(
@@ -28,7 +28,7 @@ class ParserTest extends TestCase
         Parser::parse('', []);
     }
 
-    public function testParserWithInvalidRowLength()
+    public function testParserWithInvalidRowLength(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage(
@@ -38,7 +38,7 @@ class ParserTest extends TestCase
         Parser::parse("YYYY\nNNNNNN", ['Y' => 'top']);
     }
 
-    public function testParserWithInvalidMapping()
+    public function testParserWithInvalidMapping(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage(
@@ -48,7 +48,7 @@ class ParserTest extends TestCase
         Parser::parse("YYYY\nNNNNNN", []);
     }
 
-    public function testValidMapping()
+    public function testValidMapping(): void
     {
         $result = Parser::parse("TTTT\nLLRR", [
             'T' => 'top',

--- a/tests/Twig/Extension/PageExtensionTest.php
+++ b/tests/Twig/Extension/PageExtensionTest.php
@@ -29,7 +29,7 @@ use Twig\Environment;
 
 class PageExtensionTest extends TestCase
 {
-    public function testAjaxUrl()
+    public function testAjaxUrl(): void
     {
         $router = $this->createMock(RouterInterface::class);
         $router->expects($this->once())->method('generate')->willReturn('/foo/bar');
@@ -54,7 +54,7 @@ class PageExtensionTest extends TestCase
     /**
      * @doesNotPerformAssertions
      */
-    public function testController()
+    public function testController(): void
     {
         $site = $this->createMock(SiteInterface::class);
         $site->method('getRelativePath')->willReturn('/foo/bar');
@@ -85,7 +85,7 @@ class PageExtensionTest extends TestCase
     /**
      * @doesNotPerformAssertions
      */
-    public function testControllerWithoutSite()
+    public function testControllerWithoutSite(): void
     {
         $request = $this->createMock(Request::class);
         $request->method('getPathInfo')->willReturn('/');

--- a/tests/Validator/Constraints/UniqueUrlTest.php
+++ b/tests/Validator/Constraints/UniqueUrlTest.php
@@ -18,7 +18,7 @@ use Sonata\PageBundle\Validator\Constraints\UniqueUrl;
 
 class UniqueUrlTest extends TestCase
 {
-    public function testInstance()
+    public function testInstance(): void
     {
         $constraint = new UniqueUrl();
 

--- a/tests/Validator/UniqueUrlValidatorTest.php
+++ b/tests/Validator/UniqueUrlValidatorTest.php
@@ -29,7 +29,7 @@ class UniqueUrlValidatorTest extends TestCase
     /**
      * @group legacy
      */
-    public function testValidateWithNoPageFound()
+    public function testValidateWithNoPageFound(): void
     {
         $site = $this->createMock(SiteInterface::class);
 
@@ -49,17 +49,17 @@ class UniqueUrlValidatorTest extends TestCase
         $validator->validate($page, new UniqueUrl());
     }
 
-    public function testValidateWithPageFound()
+    public function testValidateWithPageFound(): void
     {
         $site = $this->createMock(SiteInterface::class);
 
         $page = $this->createMock(PageInterface::class);
         $page->expects($this->exactly(2))->method('getSite')->willReturn($site);
         $page->expects($this->exactly(2))->method('isError')->willReturn(false);
-        $page->expects($this->any())->method('getUrl')->willReturn('/salut');
+        $page->method('getUrl')->willReturn('/salut');
 
         $pageFound = $this->createMock(PageInterface::class);
-        $pageFound->expects($this->any())->method('getUrl')->willReturn('/salut');
+        $pageFound->method('getUrl')->willReturn('/salut');
 
         $manager = $this->createMock(PageManagerInterface::class);
         $manager->expects($this->once())->method('fixUrl');
@@ -73,18 +73,18 @@ class UniqueUrlValidatorTest extends TestCase
         $validator->validate($page, new UniqueUrl());
     }
 
-    public function testValidateWithRootUrlAndNoParent()
+    public function testValidateWithRootUrlAndNoParent(): void
     {
         $site = $this->createMock(SiteInterface::class);
 
         $page = $this->createMock(PageInterface::class);
         $page->expects($this->exactly(2))->method('getSite')->willReturn($site);
         $page->expects($this->exactly(2))->method('isError')->willReturn(false);
-        $page->expects($this->exactly(1))->method('getParent')->willReturn(null);
-        $page->expects($this->any())->method('getUrl')->willReturn('/');
+        $page->expects($this->once())->method('getParent')->willReturn(null);
+        $page->method('getUrl')->willReturn('/');
 
         $pageFound = $this->createMock(PageInterface::class);
-        $pageFound->expects($this->any())->method('getUrl')->willReturn('/');
+        $pageFound->method('getUrl')->willReturn('/');
 
         $manager = $this->createMock(PageManagerInterface::class);
         $manager->expects($this->once())->method('fixUrl');
@@ -98,7 +98,7 @@ class UniqueUrlValidatorTest extends TestCase
         $validator->validate($page, new UniqueUrl());
     }
 
-    public function testValidateWithPageDynamic()
+    public function testValidateWithPageDynamic(): void
     {
         $site = $this->createMock(SiteInterface::class);
 
@@ -106,7 +106,7 @@ class UniqueUrlValidatorTest extends TestCase
         $page->expects($this->once())->method('getSite')->willReturn($site);
         $page->expects($this->once())->method('isError')->willReturn(false);
         $page->expects($this->once())->method('isDynamic')->willReturn(true);
-        $page->expects($this->any())->method('getUrl')->willReturn('/salut');
+        $page->method('getUrl')->willReturn('/salut');
 
         $manager = $this->createMock(PageManagerInterface::class);
 
@@ -118,7 +118,7 @@ class UniqueUrlValidatorTest extends TestCase
         $validator->validate($page, new UniqueUrl());
     }
 
-    private function getContext()
+    private function getContext(): ExecutionContext
     {
         $translator = $this->createMock(TranslatorInterface::class);
         $validator = $this->createMock(ValidatorInterface::class);
@@ -129,7 +129,7 @@ class UniqueUrlValidatorTest extends TestCase
         $context->setGroup('MyGroup');
         $context->setNode('InvalidValue', null, null, 'property.path');
         $context->setConstraint(new UniqueUrl());
-        $validator->expects($this->any())
+        $validator
             ->method('inContext')
             ->with($context)
             ->willReturn($contextualValidator);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Updating the project dropping Symfony < 4.3
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1135

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataPageBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Support for Symfony < 4.3
### Fixed
- Missing var type declaration
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
