### PR TITLE
Fix redirect after a batch snapshot

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
         "doctrine/doctrine-bundle": "^1.12.3 || ^2.0",
         "doctrine/persistence": "^1.3.3",
         "sonata-project/admin-bundle": "^3.35",

--- a/composer.json
+++ b/composer.json
@@ -61,6 +61,8 @@
         "jms/serializer-bundle": "^1.0 || ^2.0",
         "matthiasnoback/symfony-dependency-injection-test": "^4.0",
         "nelmio/api-doc-bundle": "^2.4",
+        "symfony/browser-kit": "^4.3",
+        "symfony/css-selector": "^4.3",
         "symfony/phpunit-bridge": "^5.0"
     },
     "config": {

--- a/docs/reference/installation.rst
+++ b/docs/reference/installation.rst
@@ -4,7 +4,7 @@ Installation
 Prerequisites
 -------------
 
-PHP 7.1 and Symfony >=4.3 are needed to make this bundle work, there are
+PHP 7.2 and Symfony >=4.3 are needed to make this bundle work, there are
 also some Sonata dependencies that need to be installed and configured beforehand:
 
     - SonataAdminBundle_

--- a/docs/reference/installation.rst
+++ b/docs/reference/installation.rst
@@ -28,9 +28,6 @@ Add the dependant bundles to the vendor/bundles directory:
 .. code-block:: bash
 
     composer require sonata-project/page-bundle --no-update
-
-    # for SonataPageBundle > 2.3.6
-    composer require sonata-project/datagrid-bundle --no-update
     composer require sonata-project/doctrine-orm-admin-bundle --no-update
 
     # optional when using API
@@ -69,10 +66,6 @@ Add these bundles in the config mapping definition (or enable `auto_mapping`_):
                     mappings:
                         ApplicationSonataPageBundle: ~ # only once the ApplicationSonataPageBundle is generated
                         SonataPageBundle: ~
-
-        dbal:
-            types:
-                json: Sonata\Doctrine\Types\JsonType
 
 CMF Routing Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/Controller/PageAdminController.php
+++ b/src/Controller/PageAdminController.php
@@ -47,7 +47,9 @@ class PageAdminController extends Controller
                 ]);
         }
 
-        return new RedirectResponse($this->admin->generateUrl('list', $this->admin->getFilterParameters()));
+        return new RedirectResponse($this->admin->generateUrl('list', [
+            'filter' => $this->admin->getFilterParameters(),
+        ]));
     }
 
     public function listAction(Request $request = null)

--- a/tests/App/AppKernel.php
+++ b/tests/App/AppKernel.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\PageBundle\Tests\App;
+
+use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
+use Knp\Bundle\MenuBundle\KnpMenuBundle;
+use Sonata\AdminBundle\SonataAdminBundle;
+use Sonata\BlockBundle\SonataBlockBundle;
+use Sonata\CacheBundle\SonataCacheBundle;
+use Sonata\CoreBundle\SonataCoreBundle;
+use Sonata\Doctrine\Bridge\Symfony\Bundle\SonataDoctrineBundle;
+use Sonata\DoctrineORMAdminBundle\SonataDoctrineORMAdminBundle;
+use Sonata\NotificationBundle\SonataNotificationBundle;
+use Sonata\PageBundle\SonataPageBundle;
+use Sonata\SeoBundle\SonataSeoBundle;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Bundle\SecurityBundle\SecurityBundle;
+use Symfony\Bundle\TwigBundle\TwigBundle;
+use Symfony\Cmf\Bundle\RoutingBundle\CmfRoutingBundle;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Routing\RouteCollectionBuilder;
+
+final class AppKernel extends Kernel
+{
+    use MicroKernelTrait;
+
+    public function __construct()
+    {
+        parent::__construct('test', false);
+    }
+
+    public function registerBundles(): array
+    {
+        return [
+            new FrameworkBundle(),
+            new TwigBundle(),
+            new SecurityBundle(),
+            new KnpMenuBundle(),
+            new SonataBlockBundle(),
+            new SonataCoreBundle(),
+            new SonataDoctrineBundle(),
+            new SonataAdminBundle(),
+            new CmfRoutingBundle(),
+            new DoctrineBundle(),
+            new SonataNotificationBundle(),
+            new SonataDoctrineORMAdminBundle(),
+            new SonataSeoBundle(),
+            new SonataCacheBundle(),
+            new SonataPageBundle(),
+        ];
+    }
+
+    public function getCacheDir(): string
+    {
+        return $this->getBaseDir().'cache';
+    }
+
+    public function getLogDir(): string
+    {
+        return $this->getBaseDir().'log';
+    }
+
+    public function getProjectDir(): string
+    {
+        return __DIR__;
+    }
+
+    protected function configureRoutes(RouteCollectionBuilder $routes): void
+    {
+        $routes->import($this->getProjectDir().'/config/routes.yaml');
+    }
+
+    protected function configureContainer(ContainerBuilder $containerBuilder, LoaderInterface $loader): void
+    {
+        $loader->load($this->getProjectDir().'/config/config.yaml');
+    }
+
+    private function getBaseDir(): string
+    {
+        return sys_get_temp_dir().'/sonata-page-bundle/var/';
+    }
+}

--- a/tests/App/Entity/SonataPageBlock.php
+++ b/tests/App/Entity/SonataPageBlock.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\PageBundle\Tests\App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Sonata\PageBundle\Entity\BaseBlock;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="page__block")
+ * @ORM\HasLifecycleCallbacks
+ */
+class SonataPageBlock extends BaseBlock
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
+     *
+     * @var int
+     */
+    protected $id;
+
+    /**
+     * @ORM\OneToMany(
+     *     targetEntity="Sonata\PageBundle\Tests\App\Entity\SonataPageBlock",
+     *     mappedBy="parent", cascade={"remove", "persist"}, orphanRemoval=true
+     * )
+     * @ORM\OrderBy({"position"="ASC"})
+     *
+     * @var SonataPageBlock[]
+     */
+    protected $children;
+
+    /**
+     * @ORM\ManyToOne(
+     *     targetEntity="Sonata\PageBundle\Tests\App\Entity\SonataPageBlock",
+     *     inversedBy="children"
+     * )
+     * @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
+     *
+     * @var SonataPageBlock
+     */
+    protected $parent;
+
+    /**
+     * @ORM\ManyToOne(
+     *     targetEntity="Sonata\PageBundle\Tests\App\Entity\SonataPagePage",
+     *     inversedBy="blocks", cascade={"persist"}
+     * )
+     * @ORM\JoinColumn(name="page_id", referencedColumnName="id", onDelete="CASCADE")
+     *
+     * @var SonataPagePage
+     */
+    protected $page;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @ORM\PrePersist
+     */
+    public function prePersist(): void
+    {
+        parent::prePersist();
+    }
+
+    /**
+     * @ORM\PreUpdate
+     */
+    public function preUpdate(): void
+    {
+        parent::preUpdate();
+    }
+}

--- a/tests/App/Entity/SonataPagePage.php
+++ b/tests/App/Entity/SonataPagePage.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\PageBundle\Tests\App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Sonata\PageBundle\Entity\BasePage;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="page__page")
+ * @ORM\HasLifecycleCallbacks
+ */
+class SonataPagePage extends BasePage
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
+     *
+     * @var int
+     */
+    protected $id;
+
+    /**
+     * @ORM\OneToMany(
+     *     targetEntity="Sonata\PageBundle\Tests\App\Entity\SonataPagePage",
+     *     mappedBy="parent", cascade={"persist"}, orphanRemoval=false
+     * )
+     * @ORM\OrderBy({"position"="ASC"})
+     *
+     * @var SonataPagePage[]
+     */
+    protected $children;
+
+    /**
+     * @ORM\OneToMany(
+     *     targetEntity="Sonata\PageBundle\Tests\App\Entity\SonataPageBlock",
+     *     mappedBy="page", cascade={"remove", "persist", "refresh", "merge", "detach"}, orphanRemoval=false
+     * )
+     * @ORM\OrderBy({"position"="ASC"})
+     *
+     * @var SonataPageBlock[]
+     */
+    protected $blocks;
+
+    /**
+     * @ORM\ManyToOne(
+     *     targetEntity="Sonata\PageBundle\Tests\App\Entity\SonataPageSite",
+     *     cascade={"persist"}
+     * )
+     * @ORM\JoinColumn(name="site_id", referencedColumnName="id", onDelete="CASCADE")
+     *
+     * @var SonataPageSite
+     */
+    protected $site;
+
+    /**
+     * @ORM\ManyToOne(
+     *     targetEntity="Sonata\PageBundle\Tests\App\Entity\SonataPagePage",
+     *     inversedBy="children", cascade={"persist"}
+     * )
+     * @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
+     *
+     * @var SonataPagePage
+     */
+    protected $parent;
+
+    /**
+     * @ORM\OneToMany(
+     *     targetEntity="Sonata\PageBundle\Tests\App\Entity\SonataPagePage",
+     *     mappedBy="target", orphanRemoval=false
+     * )
+     *
+     * @var SonataPagePage[]
+     */
+    protected $sources;
+
+    /**
+     * @ORM\ManyToOne(
+     *     targetEntity="Sonata\PageBundle\Tests\App\Entity\SonataPagePage",
+     *     inversedBy="sources", cascade={"persist"}
+     * )
+     * @ORM\JoinColumn(name="target_id", referencedColumnName="id", onDelete="CASCADE")
+     *
+     * @var SonataPagePage
+     */
+    protected $target;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @ORM\PrePersist
+     */
+    public function prePersist(): void
+    {
+        parent::prePersist();
+    }
+
+    /**
+     * @ORM\PreUpdate
+     */
+    public function preUpdate(): void
+    {
+        parent::preUpdate();
+    }
+}

--- a/tests/App/Entity/SonataPageSite.php
+++ b/tests/App/Entity/SonataPageSite.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\PageBundle\Tests\App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Sonata\PageBundle\Entity\BaseSite;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="page__site")
+ * @ORM\HasLifecycleCallbacks
+ */
+class SonataPageSite extends BaseSite
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     *
+     * @var int
+     */
+    protected $id;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @ORM\PrePersist
+     */
+    public function prePersist(): void
+    {
+        parent::prePersist();
+    }
+
+    /**
+     * @ORM\PreUpdate
+     */
+    public function preUpdate(): void
+    {
+        parent::preUpdate();
+    }
+}

--- a/tests/App/Entity/SonataPageSnapshot.php
+++ b/tests/App/Entity/SonataPageSnapshot.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\PageBundle\Tests\App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Sonata\PageBundle\Entity\BaseSnapshot;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="page__snapshot", indexes={
+ *     @ORM\Index(
+ *         name="idx_snapshot_dates_enabled", columns={"publication_date_start", "publication_date_end","enabled"
+ *     })
+ * })
+ */
+class SonataPageSnapshot extends BaseSnapshot
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
+     *
+     * @var int
+     */
+    protected $id;
+
+    /**
+     * @ORM\ManyToOne(
+     *     targetEntity="Sonata\PageBundle\Tests\App\Entity\SonataPageSite",
+     *     cascade={"persist"}
+     * )
+     * @ORM\JoinColumn(name="site_id", referencedColumnName="id", onDelete="CASCADE")
+     *
+     * @var SonataPageSite
+     */
+    protected $site;
+
+    /**
+     * @ORM\ManyToOne(
+     *     targetEntity="Sonata\PageBundle\Tests\App\Entity\SonataPagePage",
+     *     cascade={"persist"}
+     * )
+     * @ORM\JoinColumn(name="page_id", referencedColumnName="id", onDelete="CASCADE")
+     *
+     * @var SonataPagePage
+     */
+    protected $page;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+}

--- a/tests/App/config/config.yaml
+++ b/tests/App/config/config.yaml
@@ -1,0 +1,20 @@
+imports:
+    - security.yaml
+    - doctrine.yaml
+    - sonata.yaml
+
+framework:
+    test: true
+    secret: secret
+    session:
+        handler_id: session.handler.native_file
+        storage_id: session.storage.mock_file
+        name: MOCKSESSID
+    translator:
+        enabled: true
+    form:
+        enabled: true
+    csrf_protection:
+        enabled: true
+    templating:
+        engines: [twig]

--- a/tests/App/config/doctrine.yaml
+++ b/tests/App/config/doctrine.yaml
@@ -1,0 +1,15 @@
+doctrine:
+    dbal:
+        url: 'sqlite:///%kernel.cache_dir%/data.db'
+    orm:
+        auto_generate_proxy_classes: true
+        naming_strategy: doctrine.orm.naming_strategy.underscore_number_aware
+        auto_mapping: true
+        mappings:
+            App:
+                is_bundle: false
+                type: annotation
+                dir: '%kernel.project_dir%/Entity'
+                prefix: 'Sonata\PageBundle\Tests\App\Entity'
+                alias: App
+            SonataPageBundle: ~

--- a/tests/App/config/routes.yaml
+++ b/tests/App/config/routes.yaml
@@ -1,0 +1,12 @@
+admin_area:
+    resource: "@SonataAdminBundle/Resources/config/routing/sonata_admin.xml"
+    prefix: /admin
+
+_sonata_admin:
+    resource: .
+    type: sonata_admin
+    prefix: /admin
+
+sonata_page_exceptions:
+    resource: '@SonataPageBundle/Resources/config/routing/exceptions.xml'
+    prefix: /

--- a/tests/App/config/security.yaml
+++ b/tests/App/config/security.yaml
@@ -1,0 +1,11 @@
+security:
+    providers:
+        users_in_memory: {memory: null}
+    firewalls:
+        dev:
+            pattern: ^/(_(profiler|wdt)|css|images|js)/
+            security: false
+        main:
+            anonymous: true
+            provider: users_in_memory
+    access_control:

--- a/tests/App/config/sonata.yaml
+++ b/tests/App/config/sonata.yaml
@@ -1,0 +1,89 @@
+sonata_core:
+    form:
+        mapping:
+            enabled: false
+
+sonata_block:
+    blocks:
+        sonata.admin.block.admin_list:
+            contexts: [admin]
+    context_manager: sonata.page.block.context_manager
+    default_contexts: [sonata_page_bundle]
+
+sonata_page:
+    slugify_service: sonata.core.slugify.cocur
+    multisite: host
+    use_streamed_response: false
+
+    router_auto_register:
+        enabled: true
+        priority: 150
+    ignore_route_patterns:
+        - ^(.*)admin(.*)   # ignore admin route, ie route containing 'admin'
+        - ^_(.*)          # ignore symfony routes
+    ignore_routes:
+        - sonata_page_cache_esi
+        - sonata_page_cache_ssi
+        - sonata_page_js_sync_cache
+        - sonata_page_js_async_cache
+        - sonata_cache_esi
+        - sonata_cache_ssi
+        - sonata_cache_js_async
+        - sonata_cache_js_sync
+        - sonata_cache_apc
+    ignore_uri_patterns:
+        - ^/admin\/   # ignore admin route, ie route containing 'admin'
+
+    default_template: default
+    templates:
+        default:
+            path: '@SonataPage/layout.html.twig'
+            name: 'default'
+            containers:
+                header:
+                    name: Header
+                content_top:
+                    name: Top content
+                content:
+                    name: Main content
+                content_bottom:
+                    name: Bottom content
+                footer:
+                    name: Footer
+            matrix:
+                layout: |
+                    HHHHHHHH
+                    HHHHHHHH
+                    TTTTTTTT
+                    TTTTTTTT
+                    CCCCCCCC
+                    CCCCCCCC
+                    BBBBBBBB
+                    BBBBBBBB
+                    FFFFFFFF
+                    FFFFFFFF
+
+                mapping:
+                    H: header
+                    T: content_top
+                    C: content
+                    B: content_bottom
+                    F: footer
+
+    direct_publication: '%kernel.debug%'
+
+    catch_exceptions:
+        not_found: [404]
+        fatal: [500]
+
+    class:
+        page: 'Sonata\PageBundle\Tests\App\Entity\SonataPagePage'
+        snapshot: 'Sonata\PageBundle\Tests\App\Entity\SonataPageSnapshot'
+        block: 'Sonata\PageBundle\Tests\App\Entity\SonataPageBlock'
+        site: 'Sonata\PageBundle\Tests\App\Entity\SonataPageSite'
+
+sonata_notification:
+    consumers:
+        register_default: false
+    admin:
+        enabled: false

--- a/tests/Functional/ResetableDBWebTestTest.php
+++ b/tests/Functional/ResetableDBWebTestTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\PageBundle\Tests\Functional;
+
+use Sonata\PageBundle\Tests\App\AppKernel;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+
+abstract class ResetableDBWebTestTest extends WebTestCase
+{
+    /**
+     * @var KernelBrowser
+     */
+    protected $client;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->client = static::createClient();
+
+        $application = new Application($this->client->getKernel());
+        $application->setAutoExit(false);
+
+        $application->run(new ArrayInput([
+            'command' => 'doctrine:database:create',
+        ]));
+
+        $application->run(new ArrayInput([
+            'command' => 'doctrine:schema:create',
+        ]));
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $application = new Application($this->client->getKernel());
+        $application->setAutoExit(false);
+        $application->run(new ArrayInput([
+            'command' => 'doctrine:database:drop',
+            '--force' => '1',
+        ]));
+    }
+
+    protected static function getKernelClass(): string
+    {
+        return AppKernel::class;
+    }
+}

--- a/tests/Functional/Ticket/Issue1134Test.php
+++ b/tests/Functional/Ticket/Issue1134Test.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\PageBundle\Tests\Functional\Ticket;
+
+use Sonata\PageBundle\Tests\App\Entity\SonataPageSite;
+use Sonata\PageBundle\Tests\Functional\ResetableDBWebTestTest;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class Issue1134Test extends ResetableDBWebTestTest
+{
+    public function testLabelInShowAction(): void
+    {
+        $site = new SonataPageSite();
+        $site->setId(1);
+        $site->setName('name');
+        $site->setHost('http://localhost');
+        $site->setIsDefault(true);
+
+        $entityManager = $this->client->getContainer()->get('doctrine')->getManager();
+        $entityManager->persist($site);
+        $entityManager->flush();
+
+        $tokenManager = $this->client->getContainer()->get('security.csrf.token_manager');
+        $csrfToken = $tokenManager->getToken('sonata.batch');
+
+        $crawler = $this->client->request(
+            Request::METHOD_POST,
+            '/admin/tests/app/sonatapagepage/batch?filter%5Bsite%5D%5Bvalue%5D=1',
+            [
+                'all_elements' => '1',
+                'action' => 'snapshot',
+                '_sonata_csrf_token' => $csrfToken->getValue(),
+            ]
+        );
+
+        $form = $crawler->selectButton('Yes, execute')->form();
+
+        $this->client->submit($form);
+
+        $this->client->request('GET', $this->client->getResponse()->headers->get('Location'));
+
+        $this->assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+    }
+}

--- a/tests/Model/PageTest.php
+++ b/tests/Model/PageTest.php
@@ -28,7 +28,11 @@ class PageTest extends TestCase
     public function testSlugify(): void
     {
         setlocale(LC_ALL, 'en_US.utf8');
-        setlocale(LC_CTYPE, 'en_US.utf8');
+
+        $reflectionClass = new \ReflectionClass(Page::class);
+        $property = $reflectionClass->getProperty('slugifyMethod');
+        $property->setAccessible(true);
+        $property->setValue(null);
 
         $this->assertSame(Page::slugify('test'), 'test');
         $this->assertSame(Page::slugify('S§!@@#$#$alut'), 's-alut');


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
This is made on top of #1137
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1134

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataPageBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Redirecting after batch snapshot
```
