### PR TITLE
Catch possible null error when retriving site

### DIFF
--- a/src/Block/ChildrenPagesBlockService.php
+++ b/src/Block/ChildrenPagesBlockService.php
@@ -67,10 +67,13 @@ class ChildrenPagesBlockService extends AbstractAdminBlockService
         } elseif ($settings['pageId']) {
             $page = $settings['pageId'];
         } else {
+            $page = false;
             try {
-                $page = $cmsManager->getPage($this->siteSelector->retrieve(), '/');
+                $site = $this->siteSelector->retrieve();
+                if (null !== $site) {
+                    $page = $cmsManager->getPage($site, '/');
+                }
             } catch (PageNotFoundException $e) {
-                $page = false;
             }
         }
 

--- a/src/Route/CmsPageRouter.php
+++ b/src/Route/CmsPageRouter.php
@@ -302,6 +302,11 @@ class CmsPageRouter implements ChainedRouterInterface
     protected function getPageByPageAlias($alias)
     {
         $site = $this->siteSelector->retrieve();
+
+        if (null === $site) {
+            return null;
+        }
+
         $page = $this->cmsSelector->retrieve()->getPageByPageAlias($site, $alias);
 
         return $page;

--- a/src/Site/BaseSiteSelector.php
+++ b/src/Site/BaseSiteSelector.php
@@ -44,7 +44,7 @@ abstract class BaseSiteSelector implements SiteSelectorInterface
     protected $seoPage;
 
     /**
-     * @var SiteInterface
+     * @var SiteInterface|null
      */
     protected $site;
 

--- a/src/Site/SiteSelectorInterface.php
+++ b/src/Site/SiteSelectorInterface.php
@@ -25,7 +25,7 @@ use Symfony\Component\Routing\RequestContext;
 interface SiteSelectorInterface
 {
     /**
-     * @return SiteInterface
+     * @return SiteInterface|null
      */
     public function retrieve();
 

--- a/src/Twig/Extension/PageExtension.php
+++ b/src/Twig/Extension/PageExtension.php
@@ -147,10 +147,14 @@ class PageExtension extends AbstractExtension implements InitRuntimeInterface
             $breadcrumbs = $page->getParents();
 
             if ($options['force_view_home_page'] && (!isset($breadcrumbs[0]) || 'homepage' !== $breadcrumbs[0]->getRouteName())) {
+                $site = $this->siteSelector->retrieve();
+
+                $homePage = false;
                 try {
-                    $homePage = $this->cmsManagerSelector->retrieve()->getPageByRouteName($this->siteSelector->retrieve(), 'homepage');
+                    if (null !== $site) {
+                        $homePage = $this->cmsManagerSelector->retrieve()->getPageByRouteName($site, 'homepage');
+                    }
                 } catch (PageNotFoundException $e) {
-                    $homePage = false;
                 }
 
                 if ($homePage) {
@@ -201,7 +205,7 @@ class PageExtension extends AbstractExtension implements InitRuntimeInterface
         try {
             if (null === $page) {
                 $targetPage = $cms->getCurrentPage();
-            } elseif (!$page instanceof PageInterface && \is_string($page)) {
+            } elseif (null !== $site && !$page instanceof PageInterface && \is_string($page)) {
                 $targetPage = $cms->getInternalRoute($site, $page);
             } elseif ($page instanceof PageInterface) {
                 $targetPage = $page;


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

In some rare cases, there could be a problem to determine the current site, e.g. you try to load the site for an ignored route/path.

This bug could have been covered when using phpstan for this project :/

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataPageBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Catch possible null error when retriving site
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
