### PR TITLE
Fix switch parent

### DIFF
--- a/src/Controller/BlockAdminController.php
+++ b/src/Controller/BlockAdminController.php
@@ -118,8 +118,8 @@ class BlockAdminController extends Controller
             throw new PageNotFoundException(sprintf('Unable to find parent block with id %d', $parentId));
         }
 
-        $parent->addChildren($block);
-        $this->admin->update($parent);
+        $block->setParent($parent);
+        $this->admin->update($block);
 
         return $this->renderJson(['result' => 'ok']);
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

There is a strange bug, when you try to switch the parent of an existing block and you are using event hooks inside your block (e.g. `BlockServiceInterface::preUpdate`).

The `BlockAdminController::switchParentAction` calls the `Admin::update` method which did not call the correct event hooks for the moved item.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataPageBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fix switch parent
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
