### PR TITLE
Replace truncate filter with u filter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,8 @@
         "symfony/security-http": "^4.3",
         "symfony/templating": "^4.3",
         "symfony/validator": "^4.3",
-        "twig/twig": "^2.10"
+        "twig/string-extra": "^3.0",
+        "twig/twig": "^2.12.1"
     },
     "conflict": {
         "friendsofsymfony/rest-bundle": "<2.1 || >=3.0",
@@ -64,6 +65,9 @@
         "symfony/browser-kit": "^4.3",
         "symfony/css-selector": "^4.3",
         "symfony/phpunit-bridge": "^5.0"
+    },
+    "suggest": {
+        "twig/extra-bundle": "Auto configures the Twig Intl extension"
     },
     "config": {
         "sort-packages": true

--- a/src/DependencyInjection/SonataPageExtension.php
+++ b/src/DependencyInjection/SonataPageExtension.php
@@ -23,6 +23,7 @@ use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Twig\Extra\String\StringExtension;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -90,6 +91,7 @@ class SonataPageExtension extends Extension implements PrependExtensionInterface
         $this->configureExceptions($container, $config);
         $this->configurePageDefaults($container, $config);
         $this->configurePageServices($container, $config);
+        $this->configureStringExtension($container);
 
         $container->setParameter('sonata.page.assets', $config['assets']);
         $container->setParameter('sonata.page.slugify_service', $config['slugify_service']);
@@ -507,5 +509,15 @@ class SonataPageExtension extends Extension implements PrependExtensionInterface
         // set the default page service to use when no page type has been set. (backward compatibility)
         $definition = $container->getDefinition('sonata.page.page_service_manager');
         $definition->addMethodCall('setDefault', [new Reference($config['default_page_service'])]);
+    }
+
+    private function configureStringExtension(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition('twig.extension.string') || !is_a($container->getDefinition('twig.extension.string')->getClass(), StringExtension::class)) {
+            $definition = new Definition(StringExtension::class);
+            $definition->addTag('twig.extension');
+
+            $container->setDefinition(StringExtension::class, $definition);
+        }
     }
 }

--- a/src/Resources/views/PageAdmin/compose.html.twig
+++ b/src/Resources/views/PageAdmin/compose.html.twig
@@ -12,7 +12,7 @@ file that was distributed with this source code.
 {% extends '@SonataAdmin/CRUD/action.html.twig' %}
 
 {% block title %}
-    {{ "title_edit"|trans({'%name%': admin.toString(object)|truncate(15) }, 'SonataAdminBundle') }}
+    {{ "title_edit"|trans({'%name%': admin.toString(object)|u.truncate(15) }, 'SonataAdminBundle') }}
 {% endblock %}
 
 {% block navbar_title %}

--- a/tests/DependencyInjection/SonataPageExtensionTest.php
+++ b/tests/DependencyInjection/SonataPageExtensionTest.php
@@ -16,6 +16,7 @@ namespace Sonata\PageBundle\Tests\DependencyInjection;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 use Sonata\PageBundle\DependencyInjection\SonataPageExtension;
 use Symfony\Bundle\TwigBundle\DependencyInjection\TwigExtension;
+use Twig\Extra\String\StringExtension;
 
 /**
  * @author Rémi Marseille <marseille@ekino.com>
@@ -77,6 +78,15 @@ class SonataPageExtensionTest extends AbstractExtensionTestCase
             '@SonataCore/Form/datepicker.html.twig',
             $this->container->getParameter('twig.form.resources')
         );
+    }
+
+    public function testLoadTwigStringExtension(): void
+    {
+        $this->container->setParameter('kernel.bundles', []);
+
+        $this->load();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithTag(StringExtension::class, 'twig.extension');
     }
 
     protected function getContainerExtensions(): array


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
This bundle was using `truncate` filter without explicitly require `twig/extensions`, with this PR it uses `u` filter.

I added `twig/extra-bundle` to autoload the Twig extension and a fallback in case Flex is not used.

Ref: sonata-project/SonataAdminBundle#6132


<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->



## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataNewsBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `twig/string-extra` dependency.
### Changed
- Changed use of `truncate` filter with `u` filter.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
