### PR TITLE
Fix StringExtension registration

### DIFF
--- a/src/DependencyInjection/Compiler/TwigStringExtensionCompilerPass.php
+++ b/src/DependencyInjection/Compiler/TwigStringExtensionCompilerPass.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\PageBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Twig\Extra\String\StringExtension;
+
+final class TwigStringExtensionCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        foreach ($container->findTaggedServiceIds('twig.extension') as $id => $attributes) {
+            if (StringExtension::class === $container->getDefinition($id)->getClass()) {
+                return;
+            }
+        }
+
+        $definition = new Definition(StringExtension::class);
+        $definition->addTag('twig.extension');
+        $container->setDefinition(StringExtension::class, $definition);
+    }
+}

--- a/src/DependencyInjection/SonataPageExtension.php
+++ b/src/DependencyInjection/SonataPageExtension.php
@@ -23,7 +23,6 @@ use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
-use Twig\Extra\String\StringExtension;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -100,7 +99,6 @@ class SonataPageExtension extends Extension implements PrependExtensionInterface
         $this->configureExceptions($container, $config);
         $this->configurePageDefaults($container, $config);
         $this->configurePageServices($container, $config);
-        $this->configureStringExtension($container);
 
         $container->setParameter('sonata.page.assets', $config['assets']);
         $container->setParameter('sonata.page.slugify_service', $config['slugify_service']);
@@ -518,15 +516,5 @@ class SonataPageExtension extends Extension implements PrependExtensionInterface
         // set the default page service to use when no page type has been set. (backward compatibility)
         $definition = $container->getDefinition('sonata.page.page_service_manager');
         $definition->addMethodCall('setDefault', [new Reference($config['default_page_service'])]);
-    }
-
-    private function configureStringExtension(ContainerBuilder $container): void
-    {
-        if (!$container->hasDefinition('twig.extension.string') || !is_a($container->getDefinition('twig.extension.string')->getClass(), StringExtension::class)) {
-            $definition = new Definition(StringExtension::class);
-            $definition->addTag('twig.extension');
-
-            $container->setDefinition(StringExtension::class, $definition);
-        }
     }
 }

--- a/src/SonataPageBundle.php
+++ b/src/SonataPageBundle.php
@@ -18,6 +18,7 @@ use Sonata\PageBundle\DependencyInjection\Compiler\CacheCompilerPass;
 use Sonata\PageBundle\DependencyInjection\Compiler\CmfRouterCompilerPass;
 use Sonata\PageBundle\DependencyInjection\Compiler\GlobalVariablesCompilerPass;
 use Sonata\PageBundle\DependencyInjection\Compiler\PageServiceCompilerPass;
+use Sonata\PageBundle\DependencyInjection\Compiler\TwigStringExtensionCompilerPass;
 use Sonata\PageBundle\Form\Type\ApiBlockType;
 use Sonata\PageBundle\Form\Type\ApiPageType;
 use Sonata\PageBundle\Form\Type\ApiSiteType;
@@ -26,6 +27,7 @@ use Sonata\PageBundle\Form\Type\PageSelectorType;
 use Sonata\PageBundle\Form\Type\PageTypeChoiceType;
 use Sonata\PageBundle\Form\Type\TemplateChoiceType;
 use Symfony\Cmf\Bundle\RoutingBundle\Form\Type\RouteTypeType;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -47,6 +49,7 @@ class SonataPageBundle extends Bundle
         $container->addCompilerPass(new GlobalVariablesCompilerPass());
         $container->addCompilerPass(new PageServiceCompilerPass());
         $container->addCompilerPass(new CmfRouterCompilerPass());
+        $container->addCompilerPass(new TwigStringExtensionCompilerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1);
     }
 
     public function boot()

--- a/tests/DependencyInjection/Compiler/CmfRouterAutoRegisterTest.php
+++ b/tests/DependencyInjection/Compiler/CmfRouterAutoRegisterTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Sonata\PageBundle\Tests\DependencyInjection;
+namespace Sonata\PageBundle\Tests\DependencyInjection\Compiler;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
 use Sonata\PageBundle\DependencyInjection\Compiler\CmfRouterCompilerPass;

--- a/tests/DependencyInjection/Compiler/TwigStringExtensionCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/TwigStringExtensionCompilerPassTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\PageBundle\Tests\DependencyInjection\Compiler;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Sonata\PageBundle\DependencyInjection\Compiler\TwigStringExtensionCompilerPass;
+use Symfony\Bundle\TwigBundle\DependencyInjection\Compiler\TwigEnvironmentPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Twig\Extra\String\StringExtension;
+
+class TwigStringExtensionCompilerPassTest extends AbstractCompilerPassTestCase
+{
+    public function testLoadTwigStringExtension(): void
+    {
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithTag(StringExtension::class, 'twig.extension');
+    }
+
+    public function testLoadTwigStringExtensionWithExtraBundle(): void
+    {
+        $definition = new Definition(StringExtension::class);
+        $definition->addTag('twig.extension');
+        $this->container->setDefinition('twig.extension.string', $definition);
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithTag('twig.extension.string', 'twig.extension');
+        $this->assertContainerBuilderNotHasService(StringExtension::class);
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new TwigEnvironmentPass());
+        $container->addCompilerPass(new TwigStringExtensionCompilerPass());
+    }
+}

--- a/tests/DependencyInjection/SonataPageExtensionTest.php
+++ b/tests/DependencyInjection/SonataPageExtensionTest.php
@@ -16,7 +16,6 @@ namespace Sonata\PageBundle\Tests\DependencyInjection;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 use Sonata\PageBundle\DependencyInjection\SonataPageExtension;
 use Symfony\Bundle\TwigBundle\DependencyInjection\TwigExtension;
-use Twig\Extra\String\StringExtension;
 
 /**
  * @author Rémi Marseille <marseille@ekino.com>
@@ -97,15 +96,6 @@ class SonataPageExtensionTest extends AbstractExtensionTestCase
             '@SonataForm/Form/datepicker.html.twig',
             $this->container->getParameter('twig.form.resources')
         );
-    }
-
-    public function testLoadTwigStringExtension(): void
-    {
-        $this->container->setParameter('kernel.bundles', []);
-
-        $this->load();
-
-        $this->assertContainerBuilderHasServiceDefinitionWithTag(StringExtension::class, 'twig.extension');
     }
 
     protected function getContainerExtensions(): array


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
This PR contains:
- move StringExtension registration to Compiler pass and check all `twig.extension` service to avoid duplication
- improve tests
- fix previus broken checking
```php
... !is_a($container->getDefinition('twig.extension.string')->getClass(), StringExtension::class)) ...
// it is like this:   !is_a('Twig\Extra\String\StringExtension', StringExtension::class)) ...
```


<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this change respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

PATCH for #1166.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataPageBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fix `Twig\Extra\String\StringExtension` optional auto-registration to avoid duplication `twig.extension` service 
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
