### PR TITLE
Update Swagger definition in order to be compatible with string identifiers

### DIFF
--- a/src/Controller/Api/BlockController.php
+++ b/src/Controller/Api/BlockController.php
@@ -49,7 +49,7 @@ class BlockController extends FOSRestController
      * @ApiDoc(
      *  resource=true,
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Block identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Block identifier"}
      *  },
      *  output={"class"="Sonata\PageBundle\Model\BlockInterface", "groups"={"sonata_api_read"}},
      *  statusCodes={
@@ -60,7 +60,7 @@ class BlockController extends FOSRestController
      *
      * @Rest\View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
-     * @param $id
+     * @param string $id Block identifier
      *
      * @return BlockInterface
      */
@@ -74,7 +74,7 @@ class BlockController extends FOSRestController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Block identifier"},
+     *      {"name"="id", "dataType"="string", "description"="Block identifier"},
      *  },
      *  input={"class"="sonata_page_api_form_block", "name"="", "groups"={"sonata_api_write"}},
      *  output={"class"="Sonata\PageBundle\Model\Block", "groups"={"sonata_api_read"}},
@@ -87,7 +87,7 @@ class BlockController extends FOSRestController
      *
      * @Rest\View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
-     * @param int     $id      Block identifier
+     * @param string  $id      Block identifier
      * @param Request $request Symfony request
      *
      * @throws NotFoundHttpException
@@ -120,7 +120,7 @@ class BlockController extends FOSRestController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Block identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Block identifier"}
      *  },
      *  statusCodes={
      *      200="Returned when block is successfully deleted",
@@ -129,7 +129,7 @@ class BlockController extends FOSRestController
      *  }
      * )
      *
-     * @param int $id Block identifier
+     * @param string $id Block identifier
      *
      * @throws NotFoundHttpException
      *
@@ -147,7 +147,7 @@ class BlockController extends FOSRestController
     /**
      * Retrieves Block with id $id or throws an exception if it doesn't exist.
      *
-     * @param $id
+     * @param string $id
      *
      * @throws NotFoundHttpException
      *

--- a/src/Controller/Api/PageController.php
+++ b/src/Controller/Api/PageController.php
@@ -128,7 +128,7 @@ class PageController extends FOSRestController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Page identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Page identifier"}
      *  },
      *  output={"class"="Sonata\PageBundle\Model\PageInterface", "groups"={"sonata_api_read"}},
      *  statusCodes={
@@ -139,7 +139,7 @@ class PageController extends FOSRestController
      *
      * @Rest\View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
-     * @param $id
+     * @param string $id Page identifier
      *
      * @return PageInterface
      */
@@ -153,7 +153,7 @@ class PageController extends FOSRestController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Page identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Page identifier"}
      *  },
      *  output={"class"="Sonata\BlockBundle\Model\BlockInterface", "groups"={"sonata_api_read"}},
      *  statusCodes={
@@ -164,7 +164,7 @@ class PageController extends FOSRestController
      *
      * @Rest\View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
-     * @param $id
+     * @param string $id Page identifier
      *
      * @return BlockInterface[]
      */
@@ -178,7 +178,7 @@ class PageController extends FOSRestController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Page identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Page identifier"}
      *  },
      *  output={"class"="Sonata\BlockBundle\Model\BlockInterface", "groups"={"sonata_api_read"}},
      *  statusCodes={
@@ -189,7 +189,7 @@ class PageController extends FOSRestController
      *
      * @Rest\View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
-     * @param $id
+     * @param string $id Page identifier
      *
      * @return PageInterface[]
      */
@@ -205,7 +205,7 @@ class PageController extends FOSRestController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Page identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Page identifier"}
      *  },
      *  input={"class"="sonata_page_api_form_block", "name"="", "groups"={"sonata_api_write"}},
      *  output={"class"="Sonata\PageBundle\Model\Block", "groups"={"sonata_api_read"}},
@@ -218,7 +218,7 @@ class PageController extends FOSRestController
      *
      * @Rest\View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
-     * @param int     $id      Page identifier
+     * @param string  $id      Page identifier
      * @param Request $request Symfony request
      *
      * @throws NotFoundHttpException
@@ -276,7 +276,7 @@ class PageController extends FOSRestController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Page identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Page identifier"}
      *  },
      *  input={"class"="sonata_page_api_form_page", "name"="", "groups"={"sonata_api_write"}},
      *  output={"class"="Sonata\PageBundle\Model\Page", "groups"={"sonata_api_read"}},
@@ -287,7 +287,7 @@ class PageController extends FOSRestController
      *  }
      * )
      *
-     * @param int     $id      Page identifier
+     * @param string  $id      Page identifier
      * @param Request $request Symfony request
      *
      * @throws NotFoundHttpException
@@ -304,7 +304,7 @@ class PageController extends FOSRestController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Page identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Page identifier"}
      *  },
      *  statusCodes={
      *      200="Returned when page is successfully deleted",
@@ -313,7 +313,7 @@ class PageController extends FOSRestController
      *  }
      * )
      *
-     * @param int $id Page identifier
+     * @param string $id Page identifier
      *
      * @throws NotFoundHttpException
      *
@@ -333,7 +333,7 @@ class PageController extends FOSRestController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Page identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Page identifier"}
      *  },
      *  statusCodes={
      *      200="Returned when snapshots are successfully queued for creation",
@@ -342,7 +342,7 @@ class PageController extends FOSRestController
      *  }
      * )
      *
-     * @param int $id Page identifier
+     * @param string $id Page identifier
      *
      * @throws NotFoundHttpException
      *
@@ -389,7 +389,7 @@ class PageController extends FOSRestController
     /**
      * Retrieves page with id $id or throws an exception if it doesn't exist.
      *
-     * @param $id
+     * @param string $id Page identifier
      *
      * @throws NotFoundHttpException
      *
@@ -409,7 +409,7 @@ class PageController extends FOSRestController
     /**
      * Retrieves Block with id $id or throws an exception if it doesn't exist.
      *
-     * @param $id
+     * @param string $id Block identifier
      *
      * @throws NotFoundHttpException
      *
@@ -429,8 +429,8 @@ class PageController extends FOSRestController
     /**
      * Write a page, this method is used by both POST and PUT action methods.
      *
-     * @param Request  $request Symfony request
-     * @param int|null $id      Page identifier
+     * @param Request     $request Symfony request
+     * @param string|null $id      Page identifier
      *
      * @return FormInterface
      */

--- a/src/Controller/Api/SiteController.php
+++ b/src/Controller/Api/SiteController.php
@@ -98,7 +98,7 @@ class SiteController extends FOSRestController
      * @ApiDoc(
      *  resource=true,
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Site identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Site identifier"}
      *  },
      *  output={"class"="Sonata\PageBundle\Model\SiteInterface", "groups"={"sonata_api_read"}},
      *  statusCodes={
@@ -109,7 +109,7 @@ class SiteController extends FOSRestController
      *
      * @Rest\View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
-     * @param $id
+     * @param string $id Site identifier
      *
      * @return SiteInterface
      */
@@ -146,7 +146,7 @@ class SiteController extends FOSRestController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Site identifier"},
+     *      {"name"="id", "dataType"="string", "description"="Site identifier"},
      *  },
      *  input={"class"="sonata_page_api_form_site", "name"="", "groups"={"sonata_api_write"}},
      *  output={"class"="Sonata\PageBundle\Model\Site", "groups"={"sonata_api_read"}},
@@ -157,7 +157,7 @@ class SiteController extends FOSRestController
      *  }
      * )
      *
-     * @param int     $id      Site identifier
+     * @param string  $id      Site identifier
      * @param Request $request Symfony request
      *
      * @throws NotFoundHttpException
@@ -174,7 +174,7 @@ class SiteController extends FOSRestController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Site identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Site identifier"}
      *  },
      *  statusCodes={
      *      200="Returned when site is successfully deleted",
@@ -183,7 +183,7 @@ class SiteController extends FOSRestController
      *  }
      * )
      *
-     * @param int $id Site identifier
+     * @param string $id Site identifier
      *
      * @throws NotFoundHttpException
      *
@@ -201,7 +201,7 @@ class SiteController extends FOSRestController
     /**
      * Retrieves Site with id $id or throws an exception if it doesn't exist.
      *
-     * @param $id
+     * @param string $id Site identifier
      *
      * @throws NotFoundHttpException
      *
@@ -221,8 +221,8 @@ class SiteController extends FOSRestController
     /**
      * Write a site, this method is used by both POST and PUT action methods.
      *
-     * @param Request  $request Symfony request
-     * @param int|null $id      Site identifier
+     * @param Request     $request Symfony request
+     * @param string|null $id      Site identifier
      *
      * @return FormInterface|View
      */

--- a/src/Controller/Api/SnapshotController.php
+++ b/src/Controller/Api/SnapshotController.php
@@ -96,7 +96,7 @@ class SnapshotController extends FOSRestController
      * @ApiDoc(
      *  resource=true,
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Snapshot identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Snapshot identifier"}
      *  },
      *  output={"class"="Sonata\PageBundle\Model\SnapshotInterface", "groups"={"sonata_api_read"}},
      *  statusCodes={
@@ -107,7 +107,7 @@ class SnapshotController extends FOSRestController
      *
      * @Rest\View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
-     * @param $id
+     * @param string $id Snapshot identifier
      *
      * @return SnapshotInterface
      */
@@ -121,7 +121,7 @@ class SnapshotController extends FOSRestController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Snapshot identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Snapshot identifier"}
      *  },
      *  statusCodes={
      *      200="Returned when snapshots is successfully deleted",
@@ -130,7 +130,7 @@ class SnapshotController extends FOSRestController
      *  }
      * )
      *
-     * @param int $id Snapshot identifier
+     * @param string $id Snapshot identifier
      *
      * @throws NotFoundHttpException
      *
@@ -148,7 +148,7 @@ class SnapshotController extends FOSRestController
     /**
      * Retrieves Snapshot with id $id or throws an exception if it doesn't exist.
      *
-     * @param $id
+     * @param string $id Snapshot identifier
      *
      * @throws NotFoundHttpException
      *


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Update OpenAPI (Swagger) definition in order to be compatible with string identifiers (like UUIDs).

These changes are consistent with the API narrowing made at sonata-project/admin-bundle (see AdminInterface::id()).

I am targeting this branch, because these changes respect BC.

Part of https://github.com/sonata-project/dev-kit/issues/778

Based on: https://github.com/sonata-project/SonataUserBundle/pull/1198

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataPageBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Removed requirements that were only allowing integers for model identifiers at Open API definitions.
### Fixed
- Fixed support for string model identifiers at Open API definitions.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
