### PR TITLE
Bump sonata-project/datagrid-bundle to version ^3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "sonata-project/block-bundle": "^3.20",
         "sonata-project/cache": "^1.0.3 || ^2.0",
         "sonata-project/cache-bundle": "^2.4.1",
-        "sonata-project/datagrid-bundle": "^2.5",
+        "sonata-project/datagrid-bundle": "^2.5 || ^3.0",
         "sonata-project/doctrine-extensions": "^1.8",
         "sonata-project/doctrine-orm-admin-bundle": "^3.19",
         "sonata-project/form-extensions": "^0.1.1 || ^1.4",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

Both datagrid version can be used becouse `PageableInteface` is not used. When we remove deprecated from `PageableManagerInterface` then lower version should be drop with little BC-break.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this change respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataNewsBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- support for sonata-project/datagrid-bundle v3
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
