### PR TITLE
Replace prophecy for PHPUnit mocks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
         "nelmio/api-doc-bundle": "^2.4",
         "symfony/browser-kit": "^4.4",
         "symfony/css-selector": "^4.4",
-        "symfony/phpunit-bridge": "^5.1"
+        "symfony/phpunit-bridge": "^5.1.4"
     },
     "suggest": {
         "twig/extra-bundle": "Auto configures the Twig Intl extension"

--- a/tests/Admin/PageAdminTest.php
+++ b/tests/Admin/PageAdminTest.php
@@ -15,7 +15,6 @@ namespace Sonata\PageBundle\Tests\Admin;
 
 use Knp\Menu\MenuFactory;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
 use Sonata\AdminBundle\Route\RouteGeneratorInterface;
 use Sonata\PageBundle\Admin\PageAdmin;
 use Sonata\PageBundle\Controller\PageController;
@@ -37,21 +36,21 @@ class PageAdminTest extends TestCase
         $admin->setMenuFactory(new MenuFactory());
         $admin->setRequest($request);
 
-        $site = $this->prophesize(Site::class);
-        $site->getRelativePath()->willReturn('/my-subsite');
+        $site = $this->createStub(Site::class);
+        $site->method('getRelativePath')->willReturn('/my-subsite');
 
-        $page = $this->prophesize(Page::class);
-        $page->getRouteName()->willReturn(Page::PAGE_ROUTE_CMS_NAME);
-        $page->getUrl()->willReturn('/my-page');
-        $page->isHybrid()->willReturn(false);
-        $page->isInternal()->willReturn(false);
-        $page->getSite()->willReturn($site->reveal());
-        $admin->setSubject($page->reveal());
+        $page = $this->createStub(Page::class);
+        $page->method('getRouteName')->willReturn(Page::PAGE_ROUTE_CMS_NAME);
+        $page->method('getUrl')->willReturn('/my-page');
+        $page->method('isHybrid')->willReturn(false);
+        $page->method('isInternal')->willReturn(false);
+        $page->method('getSite')->willReturn($site);
+        $admin->setSubject($page);
 
-        $routeGenerator = $this->prophesize(RouteGeneratorInterface::class);
-        $routeGenerator->generateMenuUrl(
+        $routeGenerator = $this->createMock(RouteGeneratorInterface::class);
+        $routeGenerator->method('generateMenuUrl')->with(
             $admin,
-            Argument::any(),
+            $this->anything(),
             ['id' => 42],
             UrlGeneratorInterface::ABSOLUTE_PATH
         )->willReturn([
@@ -60,13 +59,13 @@ class PageAdminTest extends TestCase
             'routeAbsolute' => true,
         ]);
 
-        $routeGenerator->generate(
+        $routeGenerator->expects($this->once())->method('generate')->with(
             'page_slug',
             ['path' => '/my-subsite/my-page']
-        )->shouldBeCalled();
+        );
 
-        $admin->setRouteGenerator($routeGenerator->reveal());
-        $admin->setSubject($page->reveal());
+        $admin->setRouteGenerator($routeGenerator);
+        $admin->setSubject($page);
 
         $admin->buildTabMenu('edit');
     }

--- a/tests/Block/PageListBlockServiceTest.php
+++ b/tests/Block/PageListBlockServiceTest.php
@@ -57,17 +57,10 @@ class PageListBlockServiceTest extends AbstractBlockServiceTestCase
         $page2 = $this->createMock(PageInterface::class);
         $systemPage = $this->createMock(PageInterface::class);
 
-        $this->pageManager->expects($this->at(0))->method('findBy')
-            ->with($this->equalTo([
-                'routeName' => Page::PAGE_ROUTE_CMS_NAME,
-            ]))
-            ->willReturn([$page1, $page2]);
-        $this->pageManager->expects($this->at(1))->method('findBy')
-            ->with($this->equalTo([
-                'url' => null,
-                'parent' => null,
-            ]))
-            ->willReturn([$systemPage]);
+        $this->pageManager->expects($this->exactly(2))->method('findBy')->willReturnMap([
+            [['routeName' => Page::PAGE_ROUTE_CMS_NAME], null, null, null, [$page1, $page2]],
+            [['url' => null, 'parent' => null], null, null, null, [$systemPage]],
+        ]);
 
         $block = new Block();
 

--- a/tests/Command/BaseCommandTest.php
+++ b/tests/Command/BaseCommandTest.php
@@ -33,10 +33,7 @@ class BaseCommandTest extends TestCase
      */
     protected function setUp(): void
     {
-        $this->command = $this->getMockBuilder(BaseCommand::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getSiteManager'])
-            ->getMock();
+        $this->command = $this->createMock(BaseCommand::class);
     }
 
     /**
@@ -49,24 +46,21 @@ class BaseCommandTest extends TestCase
         $method->setAccessible(true);
 
         $input = $this->createMock(InputInterface::class);
-
-        $siteManager = $this->getMockBuilder(SiteManager::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $siteManager = $this->createMock(SiteManager::class);
 
         $this->command->method('getSiteManager')->willReturn($siteManager);
 
-        // Test --site=all value
-        $input->expects($this->at(0))->method('getOption')->with('site')->willReturn(['all']);
-        $siteManager->expects($this->at(0))->method('findBy')->with([]);
+        $input->expects($this->exactly(3))->method('getOption')->with('site')->willReturnOnConsecutiveCalls(
+            ['all'],
+            ['10'],
+            ['10', '11']
+        );
 
-        // Test --site=10 value
-        $input->expects($this->at(1))->method('getOption')->with('site')->willReturn(['10']);
-        $siteManager->expects($this->at(1))->method('findBy')->with(['id' => 10]);
-
-        // Test --site=10 --site=11 value
-        $input->expects($this->at(2))->method('getOption')->with('site')->willReturn(['10', '11']);
-        $siteManager->expects($this->at(2))->method('findBy')->with(['id' => [10, 11]]);
+        $siteManager->expects($this->exactly(3))->method('findBy')->withConsecutive(
+            [[]],
+            [['id' => 10]],
+            [['id' => [10, 11]]]
+        );
 
         $method->invoke($this->command, $input);
         $method->invoke($this->command, $input);

--- a/tests/Entity/BlockManagerTest.php
+++ b/tests/Entity/BlockManagerTest.php
@@ -15,7 +15,6 @@ namespace Sonata\PageBundle\Tests\Entity;
 
 use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
@@ -55,7 +54,7 @@ class BlockManagerTest extends TestCase
         $repository = $this->createMock(EntityRepository::class);
         $repository->method('createQueryBuilder')->willReturn($qb);
 
-        $em = $this->createMock(EntityManagerInterface::class);
+        $em = $this->createStub(EntityManager::class);
         $em->method('getRepository')->willReturn($repository);
 
         $registry = $this->createMock(ManagerRegistry::class);

--- a/tests/Entity/PageManagerTest.php
+++ b/tests/Entity/PageManagerTest.php
@@ -15,7 +15,6 @@ namespace Sonata\PageBundle\Tests\Entity;
 
 use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
@@ -283,7 +282,7 @@ class PageManagerTest extends TestCase
             'routeName',
         ]);
 
-        $em = $this->createMock(EntityManagerInterface::class);
+        $em = $this->createStub(EntityManager::class);
         $em->method('getRepository')->willReturn($repository);
         $em->method('getClassMetadata')->willReturn($metadata);
 

--- a/tests/Entity/SiteManagerTest.php
+++ b/tests/Entity/SiteManagerTest.php
@@ -15,7 +15,6 @@ namespace Sonata\PageBundle\Tests\Entity;
 
 use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
@@ -147,7 +146,7 @@ class SiteManagerTest extends TestCase
             'host',
         ]);
 
-        $em = $this->createMock(EntityManagerInterface::class);
+        $em = $this->createStub(EntityManager::class);
         $em->method('getRepository')->willReturn($repository);
         $em->method('getClassMetadata')->willReturn($metadata);
 

--- a/tests/Entity/SnapshotManagerTest.php
+++ b/tests/Entity/SnapshotManagerTest.php
@@ -290,7 +290,7 @@ class SnapshotManagerTest extends TestCase
         $repository = $this->createMock(EntityRepository::class);
         $repository->method('createQueryBuilder')->willReturn($qb);
 
-        $em = $this->createMock(EntityManagerInterface::class);
+        $em = $this->createMock(EntityManager::class);
         $em->method('getRepository')->willReturn($repository);
 
         $registry = $this->createMock(ManagerRegistry::class);

--- a/tests/Route/CmsPageRouterTest.php
+++ b/tests/Route/CmsPageRouterTest.php
@@ -246,50 +246,12 @@ class CmsPageRouterTest extends TestCase
         $page->expects($this->exactly(5))->method('isHybrid')->willReturn(true);
         $page->expects($this->exactly(5))->method('getRouteName')->willReturn('test_route');
 
-        $this->defaultRouter->expects($this->at(0))
-            ->method('generate')
-            ->with(
-                $this->equalTo('test_route'),
-                $this->equalTo(['key' => 'value']),
-                $this->equalTo(UrlGeneratorInterface::ABSOLUTE_PATH)
-            )
-            ->willReturn('/test/path?key=value');
-
-        $this->defaultRouter->expects($this->at(1))
-            ->method('generate')
-            ->with(
-                $this->equalTo('test_route'),
-                $this->equalTo(['key' => 'value']),
-                $this->equalTo(UrlGeneratorInterface::ABSOLUTE_PATH)
-            )
-            ->willReturn('/test/path?key=value');
-
-        $this->defaultRouter->expects($this->at(2))
-            ->method('generate')
-            ->with(
-                $this->equalTo('test_route'),
-                $this->equalTo(['key' => 'value']),
-                $this->equalTo(UrlGeneratorInterface::RELATIVE_PATH)
-            )
-            ->willReturn('test/path?key=value');
-
-        $this->defaultRouter->expects($this->at(3))
-            ->method('generate')
-            ->with(
-                $this->equalTo('test_route'),
-                $this->equalTo(['key' => 'value']),
-                $this->equalTo(UrlGeneratorInterface::ABSOLUTE_URL)
-            )
-            ->willReturn('http://localhost/test/path?key=value');
-
-        $this->defaultRouter->expects($this->at(4))
-            ->method('generate')
-            ->with(
-                $this->equalTo('test_route'),
-                $this->equalTo(['key' => 'value']),
-                $this->equalTo(UrlGeneratorInterface::NETWORK_PATH)
-            )
-            ->willReturn('//localhost/test/path?key=value');
+        $this->defaultRouter->expects($this->exactly(5))->method('generate')->willReturnMap([
+            ['test_route', ['key' => 'value'], UrlGeneratorInterface::ABSOLUTE_PATH, '/test/path?key=value'],
+            ['test_route', ['key' => 'value'], UrlGeneratorInterface::RELATIVE_PATH, 'test/path?key=value'],
+            ['test_route', ['key' => 'value'], UrlGeneratorInterface::ABSOLUTE_URL, 'http://localhost/test/path?key=value'],
+            ['test_route', ['key' => 'value'], UrlGeneratorInterface::NETWORK_PATH, '//localhost/test/path?key=value'],
+        ]);
 
         $url = $this->router->generate($page, ['key' => 'value']);
         $this->assertSame('/test/path?key=value', $url);
@@ -354,50 +316,12 @@ class CmsPageRouterTest extends TestCase
         $cmsManager->expects($this->exactly(5))->method('getPageByPageAlias')->willReturn($page);
         $this->cmsSelector->expects($this->exactly(5))->method('retrieve')->willReturn($cmsManager);
 
-        $this->defaultRouter->expects($this->at(0))
-            ->method('generate')
-            ->with(
-                $this->equalTo('test_route'),
-                $this->equalTo(['key' => 'value']),
-                $this->equalTo(UrlGeneratorInterface::ABSOLUTE_PATH)
-            )
-            ->willReturn('/test/key/value');
-
-        $this->defaultRouter->expects($this->at(1))
-            ->method('generate')
-            ->with(
-                $this->equalTo('test_route'),
-                $this->equalTo(['key' => 'value']),
-                $this->equalTo(UrlGeneratorInterface::ABSOLUTE_PATH)
-            )
-            ->willReturn('/test/key/value');
-
-        $this->defaultRouter->expects($this->at(2))
-            ->method('generate')
-            ->with(
-                $this->equalTo('test_route'),
-                $this->equalTo(['key' => 'value']),
-                $this->equalTo(UrlGeneratorInterface::RELATIVE_PATH)
-            )
-            ->willReturn('test/key/value');
-
-        $this->defaultRouter->expects($this->at(3))
-            ->method('generate')
-            ->with(
-                $this->equalTo('test_route'),
-                $this->equalTo(['key' => 'value']),
-                $this->equalTo(UrlGeneratorInterface::ABSOLUTE_URL)
-            )
-            ->willReturn('http://localhost/test/key/value');
-
-        $this->defaultRouter->expects($this->at(4))
-            ->method('generate')
-            ->with(
-                $this->equalTo('test_route'),
-                $this->equalTo(['key' => 'value']),
-                $this->equalTo(UrlGeneratorInterface::NETWORK_PATH)
-            )
-            ->willReturn('//localhost/test/key/value');
+        $this->defaultRouter->expects($this->exactly(5))->method('generate')->willReturnMap([
+            ['test_route', ['key' => 'value'], UrlGeneratorInterface::ABSOLUTE_PATH, '/test/key/value'],
+            ['test_route', ['key' => 'value'], UrlGeneratorInterface::RELATIVE_PATH, 'test/key/value'],
+            ['test_route', ['key' => 'value'], UrlGeneratorInterface::ABSOLUTE_URL, 'http://localhost/test/key/value'],
+            ['test_route', ['key' => 'value'], UrlGeneratorInterface::NETWORK_PATH, '//localhost/test/key/value'],
+        ]);
 
         $url = $this->router->generate('_page_alias_homepage', ['key' => 'value']);
         $this->assertSame('/test/key/value', $url);

--- a/tests/Route/RoutePageGeneratorTest.php
+++ b/tests/Route/RoutePageGeneratorTest.php
@@ -62,17 +62,17 @@ class RoutePageGeneratorTest extends TestCase
             $output = fread($tmpFile, 4096);
         }
 
-        $this->assertRegExp('/CREATE(.*)route1(.*)\/first_custom_route/', $output);
-        $this->assertRegExp('/CREATE(.*)route1(.*)\/first_custom_route/', $output);
-        $this->assertRegExp('/CREATE(.*)test_hybrid_page_with_good_host(.*)\/third_custom_route/', $output);
-        $this->assertRegExp('/CREATE(.*)404/', $output);
-        $this->assertRegExp('/CREATE(.*)500/', $output);
+        $this->assertMatchesRegularExpression('/CREATE(.*)route1(.*)\/first_custom_route/', $output);
+        $this->assertMatchesRegularExpression('/CREATE(.*)route1(.*)\/first_custom_route/', $output);
+        $this->assertMatchesRegularExpression('/CREATE(.*)test_hybrid_page_with_good_host(.*)\/third_custom_route/', $output);
+        $this->assertMatchesRegularExpression('/CREATE(.*)404/', $output);
+        $this->assertMatchesRegularExpression('/CREATE(.*)500/', $output);
 
-        $this->assertRegExp('/DISABLE(.*)test_hybrid_page_with_bad_host(.*)\/fourth_custom_route/', $output);
+        $this->assertMatchesRegularExpression('/DISABLE(.*)test_hybrid_page_with_bad_host(.*)\/fourth_custom_route/', $output);
 
-        $this->assertRegExp('/UPDATE(.*)test_hybrid_page_with_bad_host(.*)\/fourth_custom_route/', $output);
+        $this->assertMatchesRegularExpression('/UPDATE(.*)test_hybrid_page_with_bad_host(.*)\/fourth_custom_route/', $output);
 
-        $this->assertRegExp('/ERROR(.*)test_hybrid_page_not_exists/', $output);
+        $this->assertMatchesRegularExpression('/ERROR(.*)test_hybrid_page_not_exists/', $output);
     }
 
     /**
@@ -94,17 +94,17 @@ class RoutePageGeneratorTest extends TestCase
             $output = fread($tmpFile, 4096);
         }
 
-        $this->assertRegExp('#CREATE(.*)route1(.*)/first_custom_route#', $output);
-        $this->assertRegExp('#CREATE(.*)route1(.*)/first_custom_route#', $output);
-        $this->assertRegExp('#CREATE(.*)test_hybrid_page_with_good_host(.*)/third_custom_route#', $output);
-        $this->assertRegExp('#CREATE(.*)404#', $output);
-        $this->assertRegExp('#CREATE(.*)500#', $output);
+        $this->assertMatchesRegularExpression('#CREATE(.*)route1(.*)/first_custom_route#', $output);
+        $this->assertMatchesRegularExpression('#CREATE(.*)route1(.*)/first_custom_route#', $output);
+        $this->assertMatchesRegularExpression('#CREATE(.*)test_hybrid_page_with_good_host(.*)/third_custom_route#', $output);
+        $this->assertMatchesRegularExpression('#CREATE(.*)404#', $output);
+        $this->assertMatchesRegularExpression('#CREATE(.*)500#', $output);
 
-        $this->assertRegExp('#DISABLE(.*)test_hybrid_page_with_bad_host(.*)/fourth_custom_route#', $output);
+        $this->assertMatchesRegularExpression('#DISABLE(.*)test_hybrid_page_with_bad_host(.*)/fourth_custom_route#', $output);
 
-        $this->assertRegExp('#UPDATE(.*)test_hybrid_page_with_bad_host(.*)/fourth_custom_route#', $output);
+        $this->assertMatchesRegularExpression('#UPDATE(.*)test_hybrid_page_with_bad_host(.*)/fourth_custom_route#', $output);
 
-        $this->assertRegExp('#REMOVED(.*)test_hybrid_page_not_exists#', $output);
+        $this->assertMatchesRegularExpression('#REMOVED(.*)test_hybrid_page_not_exists#', $output);
     }
 
     /**
@@ -167,10 +167,11 @@ class RoutePageGeneratorTest extends TestCase
         $hybridPageWithBadHost = new Page();
         $hybridPageWithBadHost->setRouteName('test_hybrid_page_with_bad_host');
 
-        $pageManager->expects($this->at(12))
+        $pageManager->expects($this->atLeastOnce())
             ->method('findOneBy')
-            ->with($this->equalTo(['routeName' => 'test_hybrid_page_with_bad_host', 'site' => 1]))
-            ->willReturn($hybridPageWithBadHost);
+            ->willReturnMap([
+                [['routeName' => 'test_hybrid_page_with_bad_host', 'site' => 1], null, $hybridPageWithBadHost],
+            ]);
 
         $pageManager
             ->method('getHybridPages')


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is pedantic.

It will not pass the build for php 8 but it will make the error more obvious
