### PR TITLE
Fixes #786 Snapshot end date manipulation on new snapshot

### DIFF
--- a/src/Entity/SnapshotManager.php
+++ b/src/Entity/SnapshotManager.php
@@ -99,7 +99,7 @@ class SnapshotManager extends BaseEntityManager implements SnapshotManagerInterf
         $this->getEntityManager()->flush();
         //@todo: strange sql and low-level pdo usage: use dql or qb
         $sql = sprintf(
-            "UPDATE %s SET publication_date_end = '%s' WHERE id NOT IN(%s) AND page_id IN (%s)",
+            "UPDATE %s SET publication_date_end = '%s' WHERE id NOT IN(%s) AND page_id IN (%s) and publication_date_end IS NULL",
             $this->getTableName(),
             $date->format('Y-m-d H:i:s'),
             implode(',', $snapshotIds),

--- a/tests/Entity/SnapshotManagerTest.php
+++ b/tests/Entity/SnapshotManagerTest.php
@@ -206,7 +206,7 @@ class SnapshotManagerTest extends TestCase
             ->expects($this->once())
             ->method('query')
             ->with(sprintf(
-                "UPDATE page_snapshot SET publication_date_end = '%s' WHERE id NOT IN(123) AND page_id IN (456)",
+                "UPDATE page_snapshot SET publication_date_end = '%s' WHERE id NOT IN(123) AND page_id IN (456) and publication_date_end IS NULL",
                 $date->format('Y-m-d H:i:s')
             ));
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Snapshot manager effects on `publication_date_end` on all previous snapshots when new snapshot is created. Only the last one should be affected.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because is is a bug fix.

Closes #786 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataPageBundle/releases,
    please keep it short and clear and to the point
-->
<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Newly created snapshot does not effect on all previous snapshots end dates only the last one

```