### PR TITLE
Make sonata-project/notification-bundle optional

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -4,6 +4,18 @@ UPGRADE 3.x
 UPGRADE FROM 3.x to 3.x
 =======================
 
+### SonataNotificationBundle is optional
+
+All publishing commands are synchronous by default.
+
+If you still want to use asynchronous processing, you should explicitly require `sonata-project/notification-bundle` and add the following configuration:
+
+```yaml
+
+sonata_page:
+  publisher: "@Sonata\PageBundle\Publisher\NotificationPublisher"
+```
+
 UPGRADE FROM 3.18.0 to 3.19.0
 =============================
 

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,6 @@
         "sonata-project/doctrine-extensions": "^1.8",
         "sonata-project/doctrine-orm-admin-bundle": "^3.19",
         "sonata-project/form-extensions": "^0.1.1 || ^1.4",
-        "sonata-project/notification-bundle": "^3.8",
         "sonata-project/seo-bundle": "^2.11",
         "sonata-project/twig-extensions": "^0.1.1 || ^1.3",
         "symfony-cmf/routing-bundle": "^2.1",
@@ -65,6 +64,7 @@
         "jms/serializer-bundle": "^2.0 || ^3.0",
         "matthiasnoback/symfony-dependency-injection-test": "^4.1.1",
         "nelmio/api-doc-bundle": "^2.4",
+        "sonata-project/notification-bundle": "^3.8",
         "symfony/browser-kit": "^4.4",
         "symfony/css-selector": "^4.4",
         "symfony/phpunit-bridge": "^5.1.4"

--- a/docs/reference/advanced_configuration.rst
+++ b/docs/reference/advanced_configuration.rst
@@ -120,6 +120,8 @@ Full configuration options:
                 site: App\Entity\SonataPageSite
             direct_publication: false
 
+            publisher: "@Sonata\\PageBundle\\Publisher\\SimplePublisher"
+
     .. code-block:: yaml
 
         # config/packages/doctrine.yaml

--- a/docs/reference/installation.rst
+++ b/docs/reference/installation.rst
@@ -17,11 +17,14 @@ Required dependencies:
 * `SonataBlockBundle_ <https://sonata-project.org/bundles/block>`_
 * `SonataCacheBundle_ <https://sonata-project.org/bundles/cache>`_
 * `SonataSeoBundle_ <https://sonata-project.org/bundles/seo>`_
-* `SonataNotificationBundle_ <https://sonata-project.org/bundles/notification>`_
 
 And the persistence bundle (currently, not all the implementations of the Sonata persistence bundles are available):
 
 * `SonataDoctrineOrmAdminBundle <https://sonata-project.org/bundles/doctrine-orm-admin>`_
+
+Add this dependency if you rely on asynchronous processing, e.g. if you site structure is very complex.
+
+* `SonataNotificationBundle_ <https://sonata-project.org/bundles/notification>`_
 
 Follow also their configuration step; you will find everything you need in
 their own installation chapter.

--- a/src/Admin/Extension/CreateSnapshotAdminExtension.php
+++ b/src/Admin/Extension/CreateSnapshotAdminExtension.php
@@ -18,6 +18,7 @@ use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\NotificationBundle\Backend\BackendInterface;
 use Sonata\PageBundle\Model\PageInterface;
+use Sonata\PageBundle\Publisher\Publisher;
 
 class CreateSnapshotAdminExtension extends AbstractAdminExtension
 {
@@ -26,9 +27,37 @@ class CreateSnapshotAdminExtension extends AbstractAdminExtension
      */
     protected $backend;
 
-    public function __construct(BackendInterface $backend)
+    /**
+     * @var Publisher
+     */
+    private $publisher;
+
+    /**
+     * @param Publisher|BackendInterface $publisherOrBackend
+     */
+    public function __construct(object $publisherOrBackend)
     {
-        $this->backend = $backend;
+        if ($publisherOrBackend instanceof Publisher) {
+            $this->publisher = $publisherOrBackend;
+        } elseif ($publisherOrBackend instanceof BackendInterface) {
+            @trigger_error(sprintf(
+                'Passing %s as argument 1 to %s() is deprecated since sonata-project/page-bundle 3.x'
+                .' and will throw a \TypeError in version 4.0. You must pass an instance of %s instead.',
+                BackendInterface::class,
+                __METHOD__,
+                Publisher::class
+            ), E_USER_DEPRECATED);
+
+            $this->backend = $publisherOrBackend;
+        } else {
+            throw new TypeError(sprintf(
+                'Argument 1 passed to %s() must be either null or an instance of %s or preferably %s, instance of %s given.',
+                __METHOD__,
+                BackendInterface::class,
+                Publisher::class,
+                \get_class($publisherOrBackend)
+            ));
+        }
     }
 
     public function postUpdate(AdminInterface $admin, $object)
@@ -47,15 +76,21 @@ class CreateSnapshotAdminExtension extends AbstractAdminExtension
     protected function sendMessage($object)
     {
         if ($object instanceof BlockInterface && method_exists($object, 'getPage')) {
-            $pageId = $object->getPage()->getId();
+            $page = $object->getPage();
         } elseif ($object instanceof PageInterface) {
-            $pageId = $object->getId();
+            $page = $object;
         } else {
             return;
         }
 
+        if (null !== $this->publisher) {
+            $this->publisher->createSnapshot($page);
+
+            return;
+        }
+
         $this->backend->createAndPublish('sonata.page.create_snapshot', [
-            'pageId' => $pageId,
+            'pageId' => $page->getId(),
         ]);
     }
 }

--- a/src/CmsManager/CmsPageManager.php
+++ b/src/CmsManager/CmsPageManager.php
@@ -86,7 +86,7 @@ class CmsPageManager extends BaseCmsPageManager
             $page = $this->pageManager->create([
                 'url' => null,
                 'routeName' => $routeName,
-                'name' => sprintf(sprintf('Internal Page : %s', $pageName)),
+                'name' => sprintf('Internal Page : %s', $pageName),
                 'decorate' => false,
             ]);
 

--- a/src/Command/BaseCommand.php
+++ b/src/Command/BaseCommand.php
@@ -21,6 +21,7 @@ use Sonata\PageBundle\Listener\ExceptionListener;
 use Sonata\PageBundle\Model\PageManagerInterface;
 use Sonata\PageBundle\Model\SiteManagerInterface;
 use Sonata\PageBundle\Model\SnapshotManagerInterface;
+use Sonata\PageBundle\Publisher\Publisher;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 
@@ -99,6 +100,11 @@ abstract class BaseCommand extends ContainerAwareCommand
         }
 
         return $this->getContainer()->get('sonata.notification.backend.runtime');
+    }
+
+    final protected function getPublisher(): Publisher
+    {
+        return $this->getContainer()->get(Publisher::class);
     }
 
     /**

--- a/src/Command/CreateSnapshotsCommand.php
+++ b/src/Command/CreateSnapshotsCommand.php
@@ -32,7 +32,7 @@ class CreateSnapshotsCommand extends BaseCommand
         $this->addOption('site', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Site id', null);
         $this->addOption('base-console', null, InputOption::VALUE_OPTIONAL, 'Base symfony console command', 'php app/console');
 
-        $this->addOption('mode', null, InputOption::VALUE_OPTIONAL, 'Run the command asynchronously', 'sync');
+        $this->addOption('mode', null, InputOption::VALUE_OPTIONAL, '[DEPRECATED] Run the command asynchronously', 'sync');
     }
 
     public function execute(InputInterface $input, OutputInterface $output)
@@ -58,10 +58,20 @@ class CreateSnapshotsCommand extends BaseCommand
                     $output->write(sprintf('<info>%s</info> - Generating snapshots ...', $site->getName()));
                 }
 
-                $this->getNotificationBackend($input->getOption('mode'))->createAndPublish('sonata.page.create_snapshots', [
-                    'siteId' => $site->getId(),
-                    'mode' => $input->getOption('mode'),
-                ]);
+                if ('async' === $input->getOption('mode')) {
+                    @trigger_error(
+                        'The "mode" option since sonata-project/page-bundle 3.x.',
+                        E_USER_DEPRECATED
+                    );
+
+                    $this->getNotificationBackend('async')
+                        ->createAndPublish('sonata.page.create_snapshots', [
+                        'siteId' => $site->getId(),
+                        'mode' => $input->getOption('mode'),
+                    ]);
+                } else {
+                    $this->getPublisher()->createSnapshots($site, (int) $input->getOption('keep-snapshots'));
+                }
 
                 $output->writeln(' done!');
             } else {

--- a/src/Controller/PageAdminController.php
+++ b/src/Controller/PageAdminController.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\PageBundle\Controller;
 
 use Sonata\AdminBundle\Controller\CRUDController as Controller;
+use Sonata\PageBundle\Publisher\Publisher;
 use Symfony\Component\Form\FormRenderer;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -40,11 +41,10 @@ class PageAdminController extends Controller
             throw new AccessDeniedException();
         }
 
+        $publisher = $this->get(Publisher::class);
+
         foreach ($query->execute() as $page) {
-            $this->get('sonata.notification.backend')
-                ->createAndPublish('sonata.page.create_snapshot', [
-                    'pageId' => $page->getId(),
-                ]);
+            $publisher->createSnapshot($page);
         }
 
         return new RedirectResponse($this->admin->generateUrl('list', [

--- a/src/Controller/SiteAdminController.php
+++ b/src/Controller/SiteAdminController.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\PageBundle\Controller;
 
 use Sonata\AdminBundle\Controller\CRUDController as Controller;
+use Sonata\PageBundle\Publisher\Publisher;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -50,11 +51,7 @@ class SiteAdminController extends Controller
         $this->admin->setSubject($object);
 
         if ('POST' === $request->getMethod()) {
-            $this->get('sonata.notification.backend')
-                ->createAndPublish('sonata.page.create_snapshots', [
-                    'siteId' => $object->getId(),
-                    'mode' => 'async',
-                ]);
+            $this->get(Publisher::class)->createSnapshots($object);
 
             $this->addFlash('sonata_flash_success', $this->admin->trans('flash_snapshots_created_success'));
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\PageBundle\DependencyInjection;
 
 use Sonata\PageBundle\Model\Template;
+use Sonata\PageBundle\Publisher\SimplePublisher;
 use Sonata\PageBundle\Template\Matrix\Parser;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
@@ -367,6 +368,10 @@ EOF;
             ->booleanNode('direct_publication')
                 ->info($directPublicationInfo)
                 ->defaultValue(false)
+            ->end()
+
+            ->scalarNode('publisher')
+                ->defaultValue(SimplePublisher::class)
             ->end()
         ;
 

--- a/src/DependencyInjection/SonataPageExtension.php
+++ b/src/DependencyInjection/SonataPageExtension.php
@@ -17,6 +17,7 @@ use Sonata\Doctrine\Mapper\Builder\OptionsBuilder;
 use Sonata\Doctrine\Mapper\DoctrineCollector;
 use Sonata\EasyExtendsBundle\Mapper\DoctrineCollector as DeprecatedDoctrineCollector;
 use Sonata\PageBundle\Model\Template;
+use Sonata\PageBundle\Publisher\Publisher;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -112,6 +113,8 @@ class SonataPageExtension extends Extension implements PrependExtensionInterface
             ->replaceArgument(0, $config['ignore_routes'])
             ->replaceArgument(1, $config['ignore_route_patterns'])
             ->replaceArgument(2, $config['ignore_uri_patterns']);
+
+        $container->setAlias(Publisher::class, $config['publisher']);
 
         if (isset($bundles['SonataDoctrineBundle'])) {
             $this->registerSonataDoctrineMapping($config);

--- a/src/Publisher/NotificationPublisher.php
+++ b/src/Publisher/NotificationPublisher.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\PageBundle\Publisher;
+
+use Sonata\NotificationBundle\Backend\BackendInterface;
+use Sonata\PageBundle\Model\PageInterface;
+use Sonata\PageBundle\Model\SiteInterface;
+
+final class NotificationPublisher implements Publisher
+{
+    /**
+     * @var BackendInterface
+     */
+    private $backend;
+
+    public function __construct(BackendInterface $backend)
+    {
+        $this->backend = $backend;
+    }
+
+    public function removeSnapshots(SiteInterface $site, int $keep = 0): void
+    {
+        $this->backend->createAndPublish('sonata.page.cleanup_snapshot', [
+            'siteId' => $site->getId(),
+            'keepSnapshots' => $keep,
+        ]);
+    }
+
+    public function removeSnapshot(PageInterface $page, int $keep = 0): void
+    {
+        $this->backend->createAndPublish('sonata.page.cleanup_snapshot', [
+            'pageId' => $page->getId(),
+            'keepSnapshots' => $keep,
+        ]);
+    }
+
+    public function createSnapshots(SiteInterface $site): void
+    {
+        $this->backend->createAndPublish('sonata.page.create_snapshots', [
+            'siteId' => $site->getId(),
+        ]);
+    }
+
+    public function createSnapshot(PageInterface $page): void
+    {
+        $this->backend->createAndPublish('sonata.page.create_snapshot', [
+            'pageId' => $page->getId(),
+        ]);
+    }
+}

--- a/src/Publisher/Publisher.php
+++ b/src/Publisher/Publisher.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\PageBundle\Publisher;
+
+use Sonata\PageBundle\Model\PageInterface;
+use Sonata\PageBundle\Model\SiteInterface;
+
+/**
+ * @author Christian Gripp <mail@core23.de>
+ */
+interface Publisher
+{
+    public function createSnapshots(SiteInterface $site): void;
+
+    public function createSnapshot(PageInterface $page): void;
+
+    public function removeSnapshots(SiteInterface $site, int $keep = 0): void;
+
+    public function removeSnapshot(PageInterface $page, int $keep = 0): void;
+}

--- a/src/Publisher/SimplePublisher.php
+++ b/src/Publisher/SimplePublisher.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\PageBundle\Publisher;
+
+use Sonata\PageBundle\Model\PageInterface;
+use Sonata\PageBundle\Model\PageManagerInterface;
+use Sonata\PageBundle\Model\SiteInterface;
+use Sonata\PageBundle\Model\SnapshotManagerInterface;
+use Sonata\PageBundle\Model\TransformerInterface;
+
+/**
+ * @author Christian Gripp <mail@core23.de>
+ */
+final class SimplePublisher implements Publisher
+{
+    /**
+     * @var PageManagerInterface
+     */
+    private $pageManager;
+
+    /**
+     * @var SnapshotManagerInterface
+     */
+    private $snapshotManager;
+
+    /**
+     * @var TransformerInterface
+     */
+    private $transformer;
+
+    public function __construct(
+        PageManagerInterface $pageManager,
+        SnapshotManagerInterface $snapshotManager,
+        TransformerInterface $transformer
+    ) {
+        $this->pageManager = $pageManager;
+        $this->snapshotManager = $snapshotManager;
+        $this->transformer = $transformer;
+    }
+
+    public function createSnapshots(SiteInterface $site): void
+    {
+        $pages = $this->pageManager->findBy([
+            'site' => $site->getId(),
+        ]);
+
+        foreach ($pages as $page) {
+            $this->createSnapshot($page);
+        }
+    }
+
+    public function createSnapshot(PageInterface $page): void
+    {
+        // start a transaction
+        $this->snapshotManager->getConnection()->beginTransaction();
+
+        // creating snapshot
+        $snapshot = $this->transformer->create($page);
+
+        // update the page status
+        $page->setEdited(false);
+        $this->pageManager->save($page);
+
+        // save the snapshot
+        $this->snapshotManager->save($snapshot);
+        $this->snapshotManager->enableSnapshots([$snapshot]);
+
+        // commit the changes
+        $this->snapshotManager->getConnection()->commit();
+    }
+
+    public function removeSnapshots(SiteInterface $site, int $keep = 0): void
+    {
+        $pages = $this->pageManager->findBy([
+            'site' => $site->getId(),
+        ]);
+
+        foreach ($pages as $page) {
+            $this->removeSnapshot($page, $keep);
+        }
+    }
+
+    public function removeSnapshot(PageInterface $page, int $keep = 0): void
+    {
+        // start a transaction
+        $this->snapshotManager->getConnection()->beginTransaction();
+
+        // cleanup snapshots
+        $this->snapshotManager->cleanup($page, $keep);
+
+        // commit the changes
+        $this->snapshotManager->getConnection()->commit();
+    }
+}

--- a/src/Resources/config/publisher.xml
+++ b/src/Resources/config/publisher.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="Sonata\PageBundle\Publisher\SimplePublisher">
+            <argument type="service" id="sonata.page.manager.page"/>
+            <argument type="service" id="sonata.page.manager.snapshot"/>
+            <argument type="service" id="sonata.page.transformer"/>
+        </service>
+        <service id="Sonata\PageBundle\Publisher\NotificationPublisher">
+            <argument type="service" id="sonata.notification.backend" on-invalid="ignore"/>
+        </service>
+        <service id="Sonata\PageBundle\Publisher\Publisher" alias="Sonata\PageBundle\Publisher\SimplePublisher" public="true"/>
+    </services>
+</container>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this feature is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1238

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataPageBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Publishing is synchronous by default
- Made `sonata-project/notification-bundle` optional
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->

## To do

- [ ] Update the tests;
- [x] Update the documentation;
- [x] Add an upgrade note.
