### PR TITLE
Fix deleted blocks (from composer) still visible

### DIFF
--- a/src/Admin/Extension/CreateSnapshotAdminExtension.php
+++ b/src/Admin/Extension/CreateSnapshotAdminExtension.php
@@ -41,6 +41,11 @@ class CreateSnapshotAdminExtension extends AbstractAdminExtension
         $this->sendMessage($object);
     }
 
+    public function postRemove(AdminInterface $admin, $object)
+    {
+        $this->sendMessage($object);
+    }
+
     /**
      * @param PageInterface $object
      */

--- a/tests/Admin/Extension/CreateSnapshotAdminExtensionTest.php
+++ b/tests/Admin/Extension/CreateSnapshotAdminExtensionTest.php
@@ -95,4 +95,24 @@ class CreateSnapshotAdminExtensionTest extends TestCase
         $extension = new CreateSnapshotAdminExtension($backend);
         $extension->postPersist($admin, $block);
     }
+
+    public function testPostRemoveOnBlock(): void
+    {
+        $page = $this->createMock(PageInterface::class);
+        $page->expects($this->once())->method('getId')->willReturn(42);
+
+        $block = $this->createMock(PageBlockInterface::class);
+        $block->expects($this->once())->method('getPage')->willReturn($page);
+
+        $admin = $this->createStub(AdminInterface::class);
+
+        $backend = $this->createMock(BackendInterface::class);
+        $backend->expects($this->once())->method('createAndPublish')->with(
+            'sonata.page.create_snapshot',
+            ['pageId' => 42]
+        );
+
+        $extension = new CreateSnapshotAdminExtension($backend);
+        $extension->postRemove($admin, $block);
+    }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1292

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataPageBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `CreateSnapshotAdminExtension::postRemove()` method in order to create a snapshot when a block is deleted.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
