### PR TITLE
Fixes parent call and return int in commands

### DIFF
--- a/src/Admin/BlockAdmin.php
+++ b/src/Admin/BlockAdmin.php
@@ -62,7 +62,7 @@ class BlockAdmin extends BaseBlockAdmin
 
     protected function configurePersistentParameters(): array
     {
-        $parameters = [];
+        $parameters = parent::configurePersistentParameters();
 
         if (!$this->hasRequest()) {
             return $parameters;

--- a/src/Command/CleanupSnapshotsCommand.php
+++ b/src/Command/CleanupSnapshotsCommand.php
@@ -93,5 +93,7 @@ class CleanupSnapshotsCommand extends BaseCommand
         }
 
         $output->writeln('<info>done!</info>');
+
+        return 0;
     }
 }

--- a/src/Command/CloneSiteCommand.php
+++ b/src/Command/CloneSiteCommand.php
@@ -179,6 +179,8 @@ final class CloneSiteCommand extends BaseCommand
         }
 
         $output->writeln('<info>done!</info>');
+
+        return 0;
     }
 
     /**

--- a/src/Command/CreateBlockContainerCommand.php
+++ b/src/Command/CreateBlockContainerCommand.php
@@ -70,6 +70,8 @@ final class CreateBlockContainerCommand extends BaseCommand
         ));
 
         $output->writeln('<info>done!</info>');
+
+        return 0;
     }
 
     /**

--- a/src/Command/CreateSiteCommand.php
+++ b/src/Command/CreateSiteCommand.php
@@ -126,5 +126,7 @@ INFO
         } else {
             $output->writeln('<error>Site creation cancelled !</error>');
         }
+
+        return 0;
     }
 }

--- a/src/Command/CreateSnapshotsCommand.php
+++ b/src/Command/CreateSnapshotsCommand.php
@@ -47,7 +47,7 @@ class CreateSnapshotsCommand extends BaseCommand
                 $output->writeln(sprintf(' % 5s - % -30s - %s', $site->getId(), $site->getName(), $site->getUrl()));
             }
 
-            return;
+            return 0;
         }
 
         foreach ($this->getSites($input) as $site) {
@@ -74,5 +74,7 @@ class CreateSnapshotsCommand extends BaseCommand
         }
 
         $output->writeln('<info>done!</info>');
+
+        return 0;
     }
 }

--- a/src/Command/DumpPageCommand.php
+++ b/src/Command/DumpPageCommand.php
@@ -73,6 +73,8 @@ HELP
         foreach ($page->getBlocks() as $block) {
             $this->renderBlock($block, $output, $input->getOption('extended'));
         }
+
+        return 0;
     }
 
     /**

--- a/src/Command/MigrateBlockNameSettingCommand.php
+++ b/src/Command/MigrateBlockNameSettingCommand.php
@@ -88,6 +88,8 @@ class MigrateBlockNameSettingCommand extends BaseCommand
         $this->getEntityManager()->flush();
 
         $output->writeln("<info>Migrated $count blocks</info>");
+
+        return 0;
     }
 
     /**

--- a/src/Command/MigrateToJsonTypeCommand.php
+++ b/src/Command/MigrateToJsonTypeCommand.php
@@ -43,5 +43,7 @@ class MigrateToJsonTypeCommand extends BaseCommand
         }
 
         $output->writeln("Migrated $count blocks");
+
+        return 0;
     }
 }

--- a/src/Command/RenderBlockCommand.php
+++ b/src/Command/RenderBlockCommand.php
@@ -83,5 +83,7 @@ HELP
         $output->writeln($this->getContainer()->get('sonata.block.renderer')->render($context));
 
         $this->getContainer()->leaveScope('request');
+
+        return 0;
     }
 }

--- a/src/Command/UpdateCoreRoutesCommand.php
+++ b/src/Command/UpdateCoreRoutesCommand.php
@@ -56,7 +56,7 @@ class UpdateCoreRoutesCommand extends BaseCommand
                 $output->writeln(sprintf(' % 5s - % -30s - %s', $site->getId(), $site->getName(), $site->getUrl()));
             }
 
-            return;
+            return 0;
         }
 
         foreach ($this->getSites($input) as $site) {
@@ -86,6 +86,8 @@ class UpdateCoreRoutesCommand extends BaseCommand
         }
 
         $output->writeln('<info>done!</info>');
+
+        return 0;
     }
 
     /**


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

We missed in https://github.com/sonata-project/SonataPageBundle/pull/1284 the parent call, otherwise `PageAdmin` overrides:

https://github.com/sonata-project/SonataPageBundle/blob/9f808b3608feef0ec78752051a6f3dcc0f900bb0/src/Admin/BaseBlockAdmin.php#L228-L237

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataPageBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed deprecations using commands because of not returning `int`
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
