### PR TITLE
Remove usage of sonata_admin twig global variable

### DIFF
--- a/src/DependencyInjection/Compiler/GlobalVariablesCompilerPass.php
+++ b/src/DependencyInjection/Compiler/GlobalVariablesCompilerPass.php
@@ -26,7 +26,12 @@ class GlobalVariablesCompilerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
+        if (!$container->hasDefinition('twig')) {
+            return;
+        }
+
         $container->getDefinition('twig')
-            ->addMethodCall('addGlobal', ['sonata_page', new Reference('sonata.page.twig.global')]);
+            ->addMethodCall('addGlobal', ['sonata_page', new Reference('sonata.page.twig.global')])
+            ->addMethodCall('addGlobal', ['sonata_page_admin', new Reference('sonata.page.admin.page')]);
     }
 }

--- a/src/Resources/views/Block/block_pagelist.html.twig
+++ b/src/Resources/views/Block/block_pagelist.html.twig
@@ -22,8 +22,8 @@
 
             <div class="list-group">
                 {% for page in elements %}
-                    {% if settings.mode == 'admin' and sonata_admin is defined %}
-                        <a href="{{ sonata_admin.url('sonata.page.admin.page', 'compose', { 'id': page.id }) }}" class="list-group-item">
+                    {% if settings.mode == 'admin' %}
+                        <a href="{{ sonata_page_admin.generateObjectUrl('compose', page) }}" class="list-group-item">
                             {% if page.enabled %}
                                 <span class="label label-success pull-right">{{ 'label_page_enabled'|trans({}, 'SonataPageBundle') }}</span>
                             {% else %}
@@ -41,11 +41,11 @@
                 {% endfor %}
             </div>
 
-            {% if settings.mode == 'admin' and sonata_admin is defined %}
+            {% if settings.mode == 'admin' %}
                 <h4>{{ 'title_system_pages'|trans({}, 'SonataPageBundle') }}</h4>
                 <div class="list-group">
                     {% for page in systemElements %}
-                        <a href="{{ sonata_admin.url('sonata.page.admin.page', 'compose', { 'id': page.id }) }}" class="list-group-item">
+                        <a href="{{ sonata_page_admin.generateObjectUrl('compose', page) }}" class="list-group-item">
                             {% if page.enabled %}
                                 <span class="label label-success pull-right">{{ 'label_page_enabled'|trans({}, 'SonataPageBundle') }}</span>
                             {% else %}
@@ -57,8 +57,8 @@
                 </div>
             {% endif %}
 
-            {% if settings.mode == 'admin' and sonata_admin is defined %}
-                <a href="{{ sonata_admin.url('sonata.page.admin.page', 'list', {filter:{hybrid:{value:'cms' }}}) }}" class="btn btn-primary btn-block">
+            {% if settings.mode == 'admin' %}
+                <a href="{{ sonata_page_admin.generateUrl('list', {filter:{hybrid:{value:'cms' }}}) }}" class="btn btn-primary btn-block">
                     <i class="fa fa-list"></i> {{ 'view_all_pages'|trans({}, 'SonataPageBundle') }}
                 </a>
             {% endif %}

--- a/src/Resources/views/Page/create.html.twig
+++ b/src/Resources/views/Page/create.html.twig
@@ -18,7 +18,7 @@ file that was distributed with this source code.
 
         {% if creatable %}
             <p>
-                <a href="{{ sonata_admin.url('sonata.page.admin.page', 'create', {'url': pathInfo, 'siteId': site.id}) }}"
+                <a href="{{ sonata_page_admin.generateUrl('create', {'url': pathInfo, 'siteId': site.id}) }}"
                    class="btn btn-primary"
                 >
                     <i class="fa fa-plus" aria-hidden="true"></i>

--- a/src/Resources/views/base_layout.html.twig
+++ b/src/Resources/views/base_layout.html.twig
@@ -50,15 +50,21 @@ file that was distributed with this source code.
         {% block sonata_page_top_bar %}
             {% block page_top_bar %} {# Deprecated block #}
                 {% if sonata_page.isEditor or ( app.user and is_granted('ROLE_PREVIOUS_ADMIN') ) %}
-
+                    {#
+                        The "page" variable is an instance of SnapshotPageProxy and cannot be used in admin service calls
+                        which expect an instance of the Page model.
+                    #}
                     {% if sonata_page.isEditor and sonata_page.isInlineEditionOn %}
                         <!-- CMS specific variables -->
                         <script>
                             jQuery(document).ready(function() {
                                 Sonata.Page.init({
                                     url: {
-                                        block_save_position: '{{ sonata_admin.objectUrl('sonata.page.admin.page', 'edit', page) }}',
-                                        block_edit:          '{{ sonata_admin.url('sonata.page.admin.page|sonata.page.admin.block', 'edit', {'id': 'BLOCK_ID'}) }}'
+                                        block_save_position: '{{ sonata_page_admin.generateUrl('edit', {(sonata_page_admin.idParameter): page.id}) }}',
+                                        block_edit:          '{{ sonata_page_admin.generateUrl('sonata.page.admin.page|sonata.page.admin.block.edit', {
+                                            (sonata_page_admin.idParameter): page.id,
+                                            (sonata_page_admin.getChild('sonata.page.admin.block').idParameter): 'BLOCK_ID'
+                                        }) }}
                                     }
                                 });
                             });
@@ -69,8 +75,11 @@ file that was distributed with this source code.
                     {% if sonata_page.isEditor and sonata_page.isInlineEditionOn %}
                         data-page-editor='{{ {
                             url: {
-                                block_save_position: sonata_admin.objectUrl('sonata.page.admin.page', 'edit', page),
-                                block_edit:          sonata_admin.url('sonata.page.admin.page|sonata.page.admin.block', 'edit', {'id': 'BLOCK_ID'})
+                                block_save_position: sonata_page_admin.generateUrl('edit', {(sonata_page_admin.idParameter): page.id}),
+                                block_edit:          sonata_page_admin.generateUrl('sonata.page.admin.page|sonata.page.admin.block.edit', {
+                                    (sonata_page_admin.idParameter): page.id,
+                                    (sonata_page_admin.getChild('sonata.page.admin.block').idParameter): 'BLOCK_ID'
+                                })
                             }
                         }|json_encode()|raw }}'
                     {% endif %}>
@@ -98,12 +107,12 @@ file that was distributed with this source code.
                                         <a href="#" class="dropdown-toggle" data-toggle="dropdown">Page <span class="caret"></span></a>
                                         <ul class="dropdown-menu">
                                             {% if page is defined %}
-                                                <li><a href="{{ sonata_admin.objectUrl('sonata.page.admin.page', 'edit', page) }}" target="_new">{{ "header.edit_page"|trans({}, 'SonataPageBundle') }}</a></li>
-                                                <li><a href="{{ sonata_admin.objectUrl('sonata.page.admin.page|sonata.page.admin.snapshot', 'list', page) }}" target="_new">{{ "header.create_snapshot"|trans({}, 'SonataPageBundle') }}</a></li>
+                                                <li><a href="{{ sonata_page_admin.generateUrl('edit', {(sonata_page_admin.idParameter): page.id}) }}" target="_new">{{ "header.edit_page"|trans({}, 'SonataPageBundle') }}</a></li>
+                                                <li><a href="{{ sonata_page_admin.generateUrl('sonata.page.admin.page|sonata.page.admin.snapshot.list', {(sonata_page_admin.idParameter): page.id}) }}" target="_new">{{ "header.create_snapshot"|trans({}, 'SonataPageBundle') }}</a></li>
                                                 <li class="divider"></li>
                                             {% endif %}
 
-                                            <li><a href="{{ sonata_admin.url('sonata.page.admin.page', 'list') }}" target="_new">{{ "header.view_all_pages"|trans({}, 'SonataPageBundle') }}</a></li>
+                                            <li><a href="{{ sonata_page_admin.generateUrl('list') }}" target="_new">{{ "header.view_all_pages"|trans({}, 'SonataPageBundle') }}</a></li>
 
                                             {% if error_codes is defined and error_codes|length %}
                                                 <li class="divider"></li>
@@ -114,7 +123,7 @@ file that was distributed with this source code.
 
                                     {% if page is defined %}
                                         <li>
-                                            <a href="{{ sonata_admin.url('sonata.page.admin.page', 'compose', {'id': page.id}) }}">
+                                            <a href="{{ sonata_page_admin.generateUrl('compose', {(sonata_page_admin.idParameter): page.id}) }}">
                                                 <i class="fa fa-magic"></i>
                                                 {{ 'header.compose_page'|trans({}, 'SonataPageBundle')}}
                                             </a>

--- a/tests/DependencyInjection/Compiler/GlobalVariablesCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/GlobalVariablesCompilerPassTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\PageBundle\Tests\DependencyInjection\Compiler;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Sonata\PageBundle\DependencyInjection\Compiler\GlobalVariablesCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use Twig\Environment;
+
+final class GlobalVariablesCompilerPassTest extends AbstractCompilerPassTestCase
+{
+    public function testLoadTwigGlobalVariables(): void
+    {
+        $twigDefinition = new Definition(Environment::class);
+
+        $this->container
+            ->setDefinition('twig', $twigDefinition);
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'twig',
+            'addGlobal',
+            ['sonata_page', new Reference('sonata.page.twig.global')]
+        );
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'twig',
+            'addGlobal',
+            ['sonata_page_admin', new Reference('sonata.page.admin.page')]
+        );
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new GlobalVariablesCompilerPass());
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

In order to fix #1282, I've added a `sonata_page_admin` variable which holds the `sonata.page.admin.page` service.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1282 and #1299.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataPageBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `sonata_page_admin` Twig global variable which holds `sonata.page.admin.page` service
### Removed
- Removed deprecations from `sonata-project/admin-bundle` using `sonata_admin` Twig global variable
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
