### PR TITLE
There is a direct dependency on the jms serializer bundle in api_form.xml

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "cocur/slugify": "^3.0 || ^4.0",
         "doctrine/doctrine-bundle": "^1.12.3 || ^2.0",
         "doctrine/persistence": "^1.3.4 || ^2.0",
+        "jms/serializer-bundle": "^2.0 || ^3.0",
         "sonata-project/admin-bundle": "^3.91.1",
         "sonata-project/block-bundle": "^3.20",
         "sonata-project/cache": "^1.0.3 || ^2.0",
@@ -62,7 +63,6 @@
     "require-dev": {
         "doctrine/annotations": "^1.10.3",
         "friendsofsymfony/rest-bundle": "^2.1 || ^3.0",
-        "jms/serializer-bundle": "^2.0 || ^3.0",
         "matthiasnoback/symfony-dependency-injection-test": "^4.1.1",
         "nelmio/api-doc-bundle": "^2.4",
         "symfony/browser-kit": "^4.4",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
         "cocur/slugify": "^3.0 || ^4.0",
         "doctrine/doctrine-bundle": "^1.12.3 || ^2.0",
         "doctrine/persistence": "^1.3.4 || ^2.0",
-        "jms/serializer-bundle": "^2.0 || ^3.0",
         "sonata-project/admin-bundle": "^3.91.1",
         "sonata-project/block-bundle": "^3.20",
         "sonata-project/cache": "^1.0.3 || ^2.0",
@@ -63,6 +62,7 @@
     "require-dev": {
         "doctrine/annotations": "^1.10.3",
         "friendsofsymfony/rest-bundle": "^2.1 || ^3.0",
+        "jms/serializer-bundle": "^2.0 || ^3.0",
         "matthiasnoback/symfony-dependency-injection-test": "^4.1.1",
         "nelmio/api-doc-bundle": "^2.4",
         "symfony/browser-kit": "^4.4",

--- a/src/DependencyInjection/SonataPageExtension.php
+++ b/src/DependencyInjection/SonataPageExtension.php
@@ -67,7 +67,7 @@ class SonataPageExtension extends Extension implements PrependExtensionInterface
             'getRequestContext',
         ]);
 
-        if (isset($bundles['FOSRestBundle'], $bundles['NelmioApiDocBundle'])) {
+        if (isset($bundles['FOSRestBundle'], $bundles['NelmioApiDocBundle'], $bundles['JMSSerializerBundle'])) {
             $loader->load('serializer.xml');
 
             $loader->load('api_controllers.xml');

--- a/tests/DependencyInjection/SonataPageExtensionTest.php
+++ b/tests/DependencyInjection/SonataPageExtensionTest.php
@@ -35,7 +35,7 @@ class SonataPageExtensionTest extends AbstractExtensionTestCase
             'FOSRestBundle' => true,
             'NelmioApiDocBundle' => true,
             'SonataDoctrineBundle' => true,
-            'JMSSerializerBundle' => true
+            'JMSSerializerBundle' => true,
         ]);
         $this->load();
         $this->assertContainerBuilderHasService('sonata.page.serializer.handler.page');

--- a/tests/DependencyInjection/SonataPageExtensionTest.php
+++ b/tests/DependencyInjection/SonataPageExtensionTest.php
@@ -35,6 +35,7 @@ class SonataPageExtensionTest extends AbstractExtensionTestCase
             'FOSRestBundle' => true,
             'NelmioApiDocBundle' => true,
             'SonataDoctrineBundle' => true,
+            'JMSSerializerBundle' => true
         ]);
         $this->load();
         $this->assertContainerBuilderHasService('sonata.page.serializer.handler.page');


### PR DESCRIPTION
## Subject

There is a direct dependency on the jms serializer bundle in api_form.xml, so I moved the bundle from the dev dependencies into the dependencies section.

The dependency is there for all environments and will cause issues if the `jms_serializer.metadata_factory` service id does not exist.

I am targeting this branch, because it is the current version.

## Changelog

```markdown
### Fixed
- Do not load `api_form.xml` if `JMSSerializerBundle` is not installed
```