### PR TITLE
Adding Technical Alias example in the doc

### DIFF
--- a/docs/reference/twig_helpers.rst
+++ b/docs/reference/twig_helpers.rst
@@ -16,6 +16,13 @@ Render a page url
 
     {{ url(page, {}, true) }} => //sonata-project.org/network/path/to/url
 
+.. note::
+
+    In case you need to use a page's router in twig files, you can use ``pageAlias`` e.g:
+      ``{{ path('_page_alias_your_page') }}``.
+
+    You will find this field in your sonata page admin, the ``pageAlias`` is named of ``Technical Alias``.
+
 Render a block url to render it in AJAX (given we have a block id = 1 used on a page id = 2)
 
 .. code-block:: jinja


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Adding Technical Alias example in the doc

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because there isn't any example saying how use `Technical Alias`.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataPageBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added  `Technical Alias` example in the doc
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [x] Update the documentation;
-->
