### PR TITLE
Create sonata_page_admin twig variable only when SonataAdminBundle is available

### DIFF
--- a/src/DependencyInjection/Compiler/GlobalVariablesCompilerPass.php
+++ b/src/DependencyInjection/Compiler/GlobalVariablesCompilerPass.php
@@ -30,8 +30,14 @@ class GlobalVariablesCompilerPass implements CompilerPassInterface
             return;
         }
 
-        $container->getDefinition('twig')
-            ->addMethodCall('addGlobal', ['sonata_page', new Reference('sonata.page.twig.global')])
-            ->addMethodCall('addGlobal', ['sonata_page_admin', new Reference('sonata.page.admin.page')]);
+        $twigDefinition = $container->getDefinition('twig');
+
+        $twigDefinition
+            ->addMethodCall('addGlobal', ['sonata_page', new Reference('sonata.page.twig.global')]);
+
+        if ($container->hasDefinition('sonata.page.admin.page')) {
+            $twigDefinition
+                ->addMethodCall('addGlobal', ['sonata_page_admin', new Reference('sonata.page.admin.page')]);
+        }
     }
 }

--- a/src/Resources/views/Block/block_pagelist.html.twig
+++ b/src/Resources/views/Block/block_pagelist.html.twig
@@ -22,7 +22,7 @@
 
             <div class="list-group">
                 {% for page in elements %}
-                    {% if settings.mode == 'admin' %}
+                    {% if settings.mode == 'admin' and sonata_page_admin is defined %}
                         <a href="{{ sonata_page_admin.generateObjectUrl('compose', page) }}" class="list-group-item">
                             {% if page.enabled %}
                                 <span class="label label-success pull-right">{{ 'label_page_enabled'|trans({}, 'SonataPageBundle') }}</span>
@@ -41,7 +41,7 @@
                 {% endfor %}
             </div>
 
-            {% if settings.mode == 'admin' %}
+            {% if settings.mode == 'admin' and sonata_page_admin is defined %}
                 <h4>{{ 'title_system_pages'|trans({}, 'SonataPageBundle') }}</h4>
                 <div class="list-group">
                     {% for page in systemElements %}
@@ -57,7 +57,7 @@
                 </div>
             {% endif %}
 
-            {% if settings.mode == 'admin' %}
+            {% if settings.mode == 'admin' and sonata_page_admin is defined %}
                 <a href="{{ sonata_page_admin.generateUrl('list', {filter:{hybrid:{value:'cms' }}}) }}" class="btn btn-primary btn-block">
                     <i class="fa fa-list"></i> {{ 'view_all_pages'|trans({}, 'SonataPageBundle') }}
                 </a>

--- a/tests/DependencyInjection/Compiler/GlobalVariablesCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/GlobalVariablesCompilerPassTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\PageBundle\Tests\DependencyInjection\Compiler;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\PageBundle\DependencyInjection\Compiler\GlobalVariablesCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -36,6 +37,19 @@ final class GlobalVariablesCompilerPassTest extends AbstractCompilerPassTestCase
             'addGlobal',
             ['sonata_page', new Reference('sonata.page.twig.global')]
         );
+    }
+
+    public function testLoadsPageAdminTwigGlobalVariables(): void
+    {
+        $twigDefinition = new Definition(Environment::class);
+
+        $this->container
+            ->setDefinition('twig', $twigDefinition);
+
+        $this->container
+            ->register('sonata.page.admin.page', $this->createStub(AdminInterface::class));
+
+        $this->compile();
 
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
             'twig',


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Ref: https://github.com/sonata-project/SonataPageBundle/pull/1297#discussion_r624142231

I also added a check in Twig [where there was one checking `sonata_admin`](https://github.com/sonata-project/SonataPageBundle/pull/1297/files#diff-56f8abfa3794153dd23472b28caaa05eb8a927d5f68363b9e06fd1eeeb383c15). 

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataPageBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed creating `sonata_page_admin` twig variable only when `SonataAdminBundle` is loaded.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
