### PR TITLE
Fix page composer block validation

### DIFF
--- a/assets/src/js/composer.js
+++ b/assets/src/js/composer.js
@@ -385,6 +385,9 @@
                     url:  formAction + '&' + $.param({'composer': 1}),
                     data: $form.serialize(),
                     type: formMethod,
+                    headers: {
+                      Accept: 'text/html, application/xhtml+xml;'
+                    },
                     success: function (resp) {
                         if (resp.result && resp.result === 'ok' && resp.objectId) {
                             var createdEvent = $.Event('blockcreated');


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because {reason}.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1318.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataPageBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed 
- page composer block validation
```

## Explanation (copy-past from the issue #1318 )

What's happening then? Well, [this commit changed](https://github.com/sonata-project/SonataAdminBundle/commit/7d92242f230c070a8b993ad0d18def7b82fca29f) the way Ajax requests are threated. This is [the related PR](https://github.com/sonata-project/SonataAdminBundle/pull/6222).

To put it simple:

1. Page composer send requests using Ajax without any `Accept` header, that is `*/*`
2. That commit changed the Ajax request handling, as  `*/*` is now inside the `getAcceptableContentTypes()` array:


```php
private function handleXmlHttpRequestErrorResponse(Request $request, FormInterface $form): ?JsonResponse
{
    if (empty(array_intersect(['application/json', '*/*'], $request->getAcceptableContentTypes()))) {
        // Do not handle the XmlHttpRequest
        return null;
    }

   // Return a JSON response
}
```

Before that commit, the same methods looks like:

```php
private function handleXmlHttpRequestErrorResponse(Request $request, FormInterface $form): ?JsonResponse
{
    if (!\in_array('application/json', $request->getAcceptableContentTypes(), true)) {
        // Do not handle the XmlHttpRequest
        return null;
    }

     // Return a JSON response
}
```

3. As a result, a JSON response is returned but SonataPageBundle **can only handle HTML responses**

Easy fix is adding an `Accept` header in [`assets/src/js/composer.js`](https://github.com/sonata-project/SonataPageBundle/blob/3.x/assets/src/js/composer.js#L384), inside the props of `$.ajax`:

```js
headers: {
  Accept: 'text/html, application/xhtml+xml;'
},
```