### PR TITLE
Remove deprecated usage of ContainerAwareCommand

### DIFF
--- a/src/Command/BaseCommand.php
+++ b/src/Command/BaseCommand.php
@@ -15,7 +15,7 @@ namespace Sonata\PageBundle\Command;
 
 use Sonata\Doctrine\Model\ManagerInterface;
 use Sonata\NotificationBundle\Backend\BackendInterface;
-use Sonata\PageBundle\CmsManager\CmsPageManager;
+use Sonata\PageBundle\CmsManager\CmsManagerInterface;
 use Sonata\PageBundle\Listener\ExceptionListener;
 use Sonata\PageBundle\Model\PageManagerInterface;
 use Sonata\PageBundle\Model\SiteManagerInterface;
@@ -42,7 +42,7 @@ abstract class BaseCommand extends Command
     /** @var ManagerInterface */
     protected $blockManager;
 
-    /** @var CmsPageManager */
+    /** @var CmsManagerInterface */
     protected $cmsPageManager;
 
     /** @var ExceptionListener */
@@ -59,7 +59,7 @@ abstract class BaseCommand extends Command
         PageManagerInterface $pageManager,
         SnapshotManagerInterface $snapshotManager,
         ManagerInterface $blockManager,
-        CmsPageManager $cmsPageManager,
+        CmsManagerInterface $cmsPageManager,
         ExceptionListener $exceptionListener,
         BackendInterface $backend,
         BackendInterface $backendRuntime

--- a/src/Command/BaseCommand.php
+++ b/src/Command/BaseCommand.php
@@ -16,12 +16,11 @@ namespace Sonata\PageBundle\Command;
 use Sonata\Doctrine\Model\ManagerInterface;
 use Sonata\NotificationBundle\Backend\BackendInterface;
 use Sonata\PageBundle\CmsManager\CmsPageManager;
-use Sonata\PageBundle\CmsManager\DecoratorStrategyInterface;
 use Sonata\PageBundle\Listener\ExceptionListener;
 use Sonata\PageBundle\Model\PageManagerInterface;
 use Sonata\PageBundle\Model\SiteManagerInterface;
 use Sonata\PageBundle\Model\SnapshotManagerInterface;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 
 /**
@@ -29,62 +28,52 @@ use Symfony\Component\Console\Input\InputInterface;
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-abstract class BaseCommand extends ContainerAwareCommand
+abstract class BaseCommand extends Command
 {
-    /**
-     * @return SiteManagerInterface
-     */
-    public function getSiteManager()
-    {
-        return $this->getContainer()->get('sonata.page.manager.site');
-    }
+    /** @var SiteManagerInterface */
+    protected $siteManager;
 
-    /**
-     * @return PageManagerInterface
-     */
-    public function getPageManager()
-    {
-        return $this->getContainer()->get('sonata.page.manager.page');
-    }
+    /** @var PageManagerInterface */
+    protected $pageManager;
 
-    /**
-     * @return ManagerInterface
-     */
-    public function getBlockManager()
-    {
-        return $this->getContainer()->get('sonata.page.manager.block');
-    }
+    /** @var SnapshotManagerInterface */
+    protected $snapshotManager;
 
-    /**
-     * @return SnapshotManagerInterface
-     */
-    public function getSnapshotManager()
-    {
-        return $this->getContainer()->get('sonata.page.manager.snapshot');
-    }
+    /** @var ManagerInterface */
+    protected $blockManager;
 
-    /**
-     * @return CmsPageManager
-     */
-    public function getCmsPageManager()
-    {
-        return $this->getContainer()->get('sonata.page.cms.page');
-    }
+    /** @var CmsPageManager */
+    protected $cmsPageManager;
 
-    /**
-     * @return DecoratorStrategyInterface
-     */
-    public function getDecoratorStrategy()
-    {
-        return $this->getContainer()->get('sonata.page.decorator_strategy');
-    }
+    /** @var ExceptionListener */
+    protected $exceptionListener;
 
-    /**
-     * @return ExceptionListener
-     */
-    public function getErrorListener()
-    {
-        return $this->getContainer()->get('sonata.page.kernel.exception_listener');
+    /** @var BackendInterface */
+    protected $backend;
+
+    /** @var BackendInterface */
+    protected $backendRuntime;
+
+    public function __construct(
+        SiteManagerInterface $siteManager,
+        PageManagerInterface $pageManager,
+        SnapshotManagerInterface $snapshotManager,
+        ManagerInterface $blockManager,
+        CmsPageManager $cmsPageManager,
+        ExceptionListener $exceptionListener,
+        BackendInterface $backend,
+        BackendInterface $backendRuntime
+    ) {
+        parent::__construct();
+
+        $this->siteManager = $siteManager;
+        $this->pageManager = $pageManager;
+        $this->snapshotManager = $snapshotManager;
+        $this->blockManager = $blockManager;
+        $this->cmsPageManager = $cmsPageManager;
+        $this->exceptionListener = $exceptionListener;
+        $this->backend = $backend;
+        $this->backendRuntime = $backendRuntime;
     }
 
     /**
@@ -95,10 +84,10 @@ abstract class BaseCommand extends ContainerAwareCommand
     public function getNotificationBackend($mode)
     {
         if ('async' === $mode) {
-            return $this->getContainer()->get('sonata.notification.backend');
+            return $this->backend;
         }
 
-        return $this->getContainer()->get('sonata.notification.backend.runtime');
+        return $this->backendRuntime;
     }
 
     /**
@@ -113,6 +102,6 @@ abstract class BaseCommand extends ContainerAwareCommand
             $parameters['id'] = 1 === \count($identifiers) ? current($identifiers) : $identifiers;
         }
 
-        return $this->getSiteManager()->findBy($parameters);
+        return $this->siteManager->findBy($parameters);
     }
 }

--- a/src/Command/CleanupSnapshotsCommand.php
+++ b/src/Command/CleanupSnapshotsCommand.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\PageBundle\Command;
 
+use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -25,6 +26,11 @@ use Symfony\Component\Process\Process;
  */
 class CleanupSnapshotsCommand extends BaseCommand
 {
+    public function __construct(ContainerInterface $locator)
+    {
+        parent::__construct($locator);
+    }
+
     public function configure(): void
     {
         $this->setDescription('Cleanups the deprecated snapshots by a given site');
@@ -43,7 +49,7 @@ class CleanupSnapshotsCommand extends BaseCommand
 
             $output->writeln(sprintf(' % 5s - % -30s - %s', 'ID', 'Name', 'Url'));
 
-            foreach ($this->siteManager->findBy([]) as $site) {
+            foreach (($this->locator)('sonata.page.manager.site')->findBy([]) as $site) {
                 $output->writeln(sprintf(' % 5s - % -30s - %s', $site->getId(), $site->getName(), $site->getUrl()));
             }
 

--- a/src/Command/CleanupSnapshotsCommand.php
+++ b/src/Command/CleanupSnapshotsCommand.php
@@ -27,7 +27,6 @@ class CleanupSnapshotsCommand extends BaseCommand
 {
     public function configure(): void
     {
-        $this->setName('sonata:page:cleanup-snapshots');
         $this->setDescription('Cleanups the deprecated snapshots by a given site');
 
         $this->addOption('site', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Site id', null);

--- a/src/Command/CleanupSnapshotsCommand.php
+++ b/src/Command/CleanupSnapshotsCommand.php
@@ -44,7 +44,7 @@ class CleanupSnapshotsCommand extends BaseCommand
 
             $output->writeln(sprintf(' % 5s - % -30s - %s', 'ID', 'Name', 'Url'));
 
-            foreach ($this->getSiteManager()->findBy([]) as $site) {
+            foreach ($this->siteManager->findBy([]) as $site) {
                 $output->writeln(sprintf(' % 5s - % -30s - %s', $site->getId(), $site->getName(), $site->getUrl()));
             }
 

--- a/src/Command/CloneSiteCommand.php
+++ b/src/Command/CloneSiteCommand.php
@@ -68,17 +68,17 @@ final class CloneSiteCommand extends BaseCommand
         }
 
         /** @var SiteInterface $sourceSite */
-        $sourceSite = $this->getSiteManager()->find($input->getOption('source-id'));
+        $sourceSite = $this->siteManager->find($input->getOption('source-id'));
 
         /** @var SiteInterface $destSite */
-        $destSite = $this->getSiteManager()->find($input->getOption('dest-id'));
+        $destSite = $this->siteManager->find($input->getOption('dest-id'));
 
         $pageClones = [];
         $blockClones = [];
 
         $output->writeln('Cloning pages');
         /** @var PageInterface[] $pages */
-        $pages = $this->getPageManager()->findBy([
+        $pages = $this->pageManager->findBy([
             'site' => $sourceSite,
         ]);
         foreach ($pages as $page) {
@@ -100,13 +100,13 @@ final class CloneSiteCommand extends BaseCommand
             }
 
             $newPage->setSite($destSite);
-            $this->getPageManager()->save($newPage);
+            $this->pageManager->save($newPage);
 
             $pageClones[$page->getId()] = $newPage;
 
             // Clone page blocks
             /** @var BlockInterface[] $blocks */
-            $blocks = $this->getBlockManager()->findBy([
+            $blocks = $this->blockManager->findBy([
                 'page' => $page,
             ]);
             foreach ($blocks as $block) {
@@ -114,7 +114,7 @@ final class CloneSiteCommand extends BaseCommand
                 $newBlock = clone $block;
                 $newBlock->setPage($newPage);
                 $blockClones[$block->getId()] = $newBlock;
-                $this->getBlockManager()->save($newBlock);
+                $this->blockManager->save($newBlock);
             }
         }
 
@@ -151,12 +151,12 @@ final class CloneSiteCommand extends BaseCommand
                 }
             }
 
-            $this->getPageManager()->save($newPage, true);
+            $this->pageManager->save($newPage, true);
         }
 
         $output->writeln('Fixing block parents');
         foreach ($pageClones as $page) {
-            $blocks = $this->getBlockManager()->findBy([
+            $blocks = $this->blockManager->findBy([
                 'page' => $page,
             ]);
             foreach ($blocks as $block) {
@@ -173,7 +173,7 @@ final class CloneSiteCommand extends BaseCommand
                         $block->setParent(null);
                     }
 
-                    $this->getBlockManager()->save($block, true);
+                    $this->blockManager->save($block, true);
                 }
             }
         }
@@ -190,7 +190,7 @@ final class CloneSiteCommand extends BaseCommand
     {
         $output->writeln(sprintf(' % 5s - % -30s - %s', 'ID', 'Name', 'Url'));
 
-        $sites = $this->getSiteManager()->findAll();
+        $sites = $this->siteManager->findAll();
 
         foreach ($sites as $site) {
             $output->writeln(sprintf(' % 5s - % -30s - %s', $site->getId(), $site->getName(), $site->getUrl()));

--- a/src/Command/CloneSiteCommand.php
+++ b/src/Command/CloneSiteCommand.php
@@ -31,7 +31,6 @@ final class CloneSiteCommand extends BaseCommand
     public function configure(): void
     {
         $this
-            ->setName('sonata:page:clone-site')
             ->setDescription('Clone a complete site including all their pages')
             ->addOption('source-id', 'so', InputOption::VALUE_REQUIRED, 'Source site id', null)
             ->addOption('dest-id', 'd', InputOption::VALUE_REQUIRED, 'Destination site id', null)

--- a/src/Command/CreateBlockContainerCommand.php
+++ b/src/Command/CreateBlockContainerCommand.php
@@ -15,7 +15,7 @@ namespace Sonata\PageBundle\Command;
 
 use Sonata\Doctrine\Model\ManagerInterface;
 use Sonata\NotificationBundle\Backend\BackendInterface;
-use Sonata\PageBundle\CmsManager\CmsPageManager;
+use Sonata\PageBundle\CmsManager\CmsManagerInterface;
 use Sonata\PageBundle\Entity\BlockInteractor;
 use Sonata\PageBundle\Listener\ExceptionListener;
 use Sonata\PageBundle\Model\PageInterface;
@@ -41,7 +41,7 @@ final class CreateBlockContainerCommand extends BaseCommand
         PageManagerInterface $pageManager,
         SnapshotManagerInterface $snapshotManager,
         ManagerInterface $blockManager,
-        CmsPageManager $cmsPageManager,
+        CmsManagerInterface $cmsPageManager,
         ExceptionListener $exceptionListener,
         BackendInterface $backend,
         BackendInterface $backendRuntime,

--- a/src/Command/CreateBlockContainerCommand.php
+++ b/src/Command/CreateBlockContainerCommand.php
@@ -63,8 +63,6 @@ final class CreateBlockContainerCommand extends BaseCommand
 
     protected function configure(): void
     {
-        $this->setName('sonata:page:create-block-container');
-
         $this->addArgument('templateCode', InputArgument::REQUIRED, 'Template name according to sonata_page.yml (e.g. default)');
         $this->addArgument('blockCode', InputArgument::REQUIRED, 'Block alias (e.g. content_bottom)');
         $this->addArgument('blockName', InputArgument::OPTIONAL, 'Block name (e.g. Bottom container)');

--- a/src/Command/CreateSiteCommand.php
+++ b/src/Command/CreateSiteCommand.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\PageBundle\Command;
 
+use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -28,6 +29,11 @@ use Symfony\Component\Console\Question\Question;
  */
 class CreateSiteCommand extends BaseCommand
 {
+    public function __construct(ContainerInterface $locator)
+    {
+        parent::__construct($locator);
+    }
+
     public function configure(): void
     {
         $this->addOption('no-confirmation', null, InputOption::VALUE_OPTIONAL, 'Ask confirmation before generating the site', false);
@@ -77,8 +83,9 @@ EOT
             }
         }
 
+        $siteManager = ($this->locator)('sonata.page.manager.site');
         // create the object
-        $site = $this->siteManager->create();
+        $site = $siteManager->create();
 
         $site->setName($values['name']);
 
@@ -113,7 +120,7 @@ INFO
         }
 
         if ($confirmation) {
-            $this->siteManager->save($site);
+            $siteManager->save($site);
 
             $output->writeln([
                 '',

--- a/src/Command/CreateSiteCommand.php
+++ b/src/Command/CreateSiteCommand.php
@@ -80,7 +80,7 @@ EOT
         }
 
         // create the object
-        $site = $this->getSiteManager()->create();
+        $site = $this->siteManager->create();
 
         $site->setName($values['name']);
 
@@ -115,7 +115,7 @@ INFO
         }
 
         if ($confirmation) {
-            $this->getSiteManager()->save($site);
+            $this->siteManager->save($site);
 
             $output->writeln([
                 '',

--- a/src/Command/CreateSiteCommand.php
+++ b/src/Command/CreateSiteCommand.php
@@ -30,8 +30,6 @@ class CreateSiteCommand extends BaseCommand
 {
     public function configure(): void
     {
-        $this->setName('sonata:page:create-site');
-
         $this->addOption('no-confirmation', null, InputOption::VALUE_OPTIONAL, 'Ask confirmation before generating the site', false);
 
         $this->addOption('enabled', null, InputOption::VALUE_OPTIONAL, 'Site.enabled', false);

--- a/src/Command/CreateSnapshotsCommand.php
+++ b/src/Command/CreateSnapshotsCommand.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\PageBundle\Command;
 
+use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -27,6 +28,11 @@ use Symfony\Component\Process\Process;
  */
 class CreateSnapshotsCommand extends BaseCommand
 {
+    public function __construct(ContainerInterface $locator)
+    {
+        parent::__construct($locator);
+    }
+
     public function configure(): void
     {
         $this->setDescription('Create a snapshots of all pages available');
@@ -44,7 +50,7 @@ class CreateSnapshotsCommand extends BaseCommand
 
             $output->writeln(sprintf(' % 5s - % -30s - %s', 'ID', 'Name', 'Url'));
 
-            foreach ($this->siteManager->findBy([]) as $site) {
+            foreach (($this->locator)('sonata.page.manager.site')->findBy([]) as $site) {
                 $output->writeln(sprintf(' % 5s - % -30s - %s', $site->getId(), $site->getName(), $site->getUrl()));
             }
 

--- a/src/Command/CreateSnapshotsCommand.php
+++ b/src/Command/CreateSnapshotsCommand.php
@@ -45,7 +45,7 @@ class CreateSnapshotsCommand extends BaseCommand
 
             $output->writeln(sprintf(' % 5s - % -30s - %s', 'ID', 'Name', 'Url'));
 
-            foreach ($this->getSiteManager()->findBy([]) as $site) {
+            foreach ($this->siteManager->findBy([]) as $site) {
                 $output->writeln(sprintf(' % 5s - % -30s - %s', $site->getId(), $site->getName(), $site->getUrl()));
             }
 

--- a/src/Command/CreateSnapshotsCommand.php
+++ b/src/Command/CreateSnapshotsCommand.php
@@ -29,7 +29,6 @@ class CreateSnapshotsCommand extends BaseCommand
 {
     public function configure(): void
     {
-        $this->setName('sonata:page:create-snapshots');
         $this->setDescription('Create a snapshots of all pages available');
         $this->addOption('site', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Site id', null);
         $this->addOption('base-console', null, InputOption::VALUE_OPTIONAL, 'Base symfony console command', 'php app/console');

--- a/src/Command/DumpPageCommand.php
+++ b/src/Command/DumpPageCommand.php
@@ -17,7 +17,6 @@ use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\Doctrine\Model\ManagerInterface;
 use Sonata\NotificationBundle\Backend\BackendInterface;
 use Sonata\PageBundle\CmsManager\CmsManagerInterface;
-use Sonata\PageBundle\CmsManager\CmsPageManager;
 use Sonata\PageBundle\Listener\ExceptionListener;
 use Sonata\PageBundle\Model\PageManagerInterface;
 use Sonata\PageBundle\Model\SiteManagerInterface;
@@ -42,7 +41,7 @@ class DumpPageCommand extends BaseCommand
         PageManagerInterface $pageManager,
         SnapshotManagerInterface $snapshotManager,
         ManagerInterface $blockManager,
-        CmsPageManager $cmsPageManager,
+        CmsManagerInterface $cmsPageManager,
         ExceptionListener $exceptionListener,
         BackendInterface $backend,
         BackendInterface $backendRuntime,

--- a/src/Command/DumpPageCommand.php
+++ b/src/Command/DumpPageCommand.php
@@ -13,14 +13,9 @@ declare(strict_types=1);
 
 namespace Sonata\PageBundle\Command;
 
+use Psr\Container\ContainerInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
-use Sonata\Doctrine\Model\ManagerInterface;
-use Sonata\NotificationBundle\Backend\BackendInterface;
 use Sonata\PageBundle\CmsManager\CmsManagerInterface;
-use Sonata\PageBundle\Listener\ExceptionListener;
-use Sonata\PageBundle\Model\PageManagerInterface;
-use Sonata\PageBundle\Model\SiteManagerInterface;
-use Sonata\PageBundle\Model\SnapshotManagerInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -36,27 +31,10 @@ class DumpPageCommand extends BaseCommand
     /** @var CmsManagerInterface */
     private $cmsSnapshotManager;
 
-    public function __construct(
-        SiteManagerInterface $siteManager,
-        PageManagerInterface $pageManager,
-        SnapshotManagerInterface $snapshotManager,
-        ManagerInterface $blockManager,
-        CmsManagerInterface $cmsPageManager,
-        ExceptionListener $exceptionListener,
-        BackendInterface $backend,
-        BackendInterface $backendRuntime,
-        CmsManagerInterface $cmsSnapshotManager
-    ) {
-        parent::__construct(
-            $siteManager,
-            $pageManager,
-            $snapshotManager,
-            $blockManager,
-            $cmsPageManager,
-            $exceptionListener,
-            $backend,
-            $backendRuntime
-        );
+    public function __construct(ContainerInterface $locator, CmsManagerInterface $cmsSnapshotManager)
+    {
+        parent::__construct($locator);
+
         $this->cmsSnapshotManager = $cmsSnapshotManager;
     }
 

--- a/src/Command/DumpPageCommand.php
+++ b/src/Command/DumpPageCommand.php
@@ -62,7 +62,6 @@ class DumpPageCommand extends BaseCommand
 
     public function configure(): void
     {
-        $this->setName('sonata:page:dump-page');
         $this->setDescription('Dump page information');
         $this->setHelp(
             <<<HELP

--- a/src/Command/MigrateBlockNameSettingCommand.php
+++ b/src/Command/MigrateBlockNameSettingCommand.php
@@ -42,7 +42,6 @@ class MigrateBlockNameSettingCommand extends Command
 
     public function configure(): void
     {
-        $this->setName('sonata:page:migrate-block-setting');
         $this->addOption(
             'class',
             null,

--- a/src/Command/MigrateBlockNameSettingCommand.php
+++ b/src/Command/MigrateBlockNameSettingCommand.php
@@ -14,8 +14,10 @@ declare(strict_types=1);
 namespace Sonata\PageBundle\Command;
 
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Sonata\BlockBundle\Model\BlockInterface;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -25,9 +27,18 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @final since sonata-project/page-bundle 3.26
  */
-class MigrateBlockNameSettingCommand extends BaseCommand
+class MigrateBlockNameSettingCommand extends Command
 {
     public const CONTAINER_TYPE = 'sonata.page.block.container';
+
+    /** @var EntityManagerInterface */
+    private $entityManager;
+
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        parent::__construct();
+        $this->entityManager = $entityManager;
+    }
 
     public function configure(): void
     {
@@ -120,6 +131,6 @@ class MigrateBlockNameSettingCommand extends BaseCommand
      */
     protected function getEntityManager()
     {
-        return $this->getContainer()->get('doctrine.orm.entity_manager');
+        return $this->entityManager;
     }
 }

--- a/src/Command/MigrateToJsonTypeCommand.php
+++ b/src/Command/MigrateToJsonTypeCommand.php
@@ -35,7 +35,6 @@ class MigrateToJsonTypeCommand extends Command
 
     public function configure(): void
     {
-        $this->setName('sonata:page:migrate-block-json');
         $this->addOption('table', null, InputOption::VALUE_OPTIONAL, 'Block table', 'page__block');
         $this->setDescription('Migrate all block settings to the doctrine JsonType');
     }

--- a/src/Command/MigrateToJsonTypeCommand.php
+++ b/src/Command/MigrateToJsonTypeCommand.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sonata\PageBundle\Command;
 
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -20,8 +22,17 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * @final since sonata-project/page-bundle 3.26
  */
-class MigrateToJsonTypeCommand extends BaseCommand
+class MigrateToJsonTypeCommand extends Command
 {
+    /** @var EntityManagerInterface */
+    private $entityManager;
+
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        parent::__construct();
+        $this->entityManager = $entityManager;
+    }
+
     public function configure(): void
     {
         $this->setName('sonata:page:migrate-block-json');
@@ -33,7 +44,7 @@ class MigrateToJsonTypeCommand extends BaseCommand
     {
         $count = 0;
         $table = $input->getOption('table');
-        $connection = $this->getContainer()->get('doctrine.orm.entity_manager')->getConnection();
+        $connection = $this->entityManager->getConnection();
         $blocks = $connection->fetchAll("SELECT * FROM $table");
 
         foreach ($blocks as $block) {

--- a/src/Command/RenderBlockCommand.php
+++ b/src/Command/RenderBlockCommand.php
@@ -18,7 +18,6 @@ use Sonata\BlockBundle\Block\BlockRendererInterface;
 use Sonata\Doctrine\Model\ManagerInterface;
 use Sonata\NotificationBundle\Backend\BackendInterface;
 use Sonata\PageBundle\CmsManager\CmsManagerInterface;
-use Sonata\PageBundle\CmsManager\CmsPageManager;
 use Sonata\PageBundle\Listener\ExceptionListener;
 use Sonata\PageBundle\Model\PageManagerInterface;
 use Sonata\PageBundle\Model\SiteManagerInterface;
@@ -49,7 +48,7 @@ class RenderBlockCommand extends BaseCommand
         PageManagerInterface $pageManager,
         SnapshotManagerInterface $snapshotManager,
         ManagerInterface $blockManager,
-        CmsPageManager $cmsPageManager,
+        CmsManagerInterface $cmsPageManager,
         ExceptionListener $exceptionListener,
         BackendInterface $backend,
         BackendInterface $backendRuntime,

--- a/src/Command/RenderBlockCommand.php
+++ b/src/Command/RenderBlockCommand.php
@@ -13,7 +13,16 @@ declare(strict_types=1);
 
 namespace Sonata\PageBundle\Command;
 
+use Sonata\BlockBundle\Block\BlockContextManagerInterface;
+use Sonata\BlockBundle\Block\BlockRendererInterface;
+use Sonata\Doctrine\Model\ManagerInterface;
+use Sonata\NotificationBundle\Backend\BackendInterface;
 use Sonata\PageBundle\CmsManager\CmsManagerInterface;
+use Sonata\PageBundle\CmsManager\CmsPageManager;
+use Sonata\PageBundle\Listener\ExceptionListener;
+use Sonata\PageBundle\Model\PageManagerInterface;
+use Sonata\PageBundle\Model\SiteManagerInterface;
+use Sonata\PageBundle\Model\SnapshotManagerInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -26,6 +35,43 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class RenderBlockCommand extends BaseCommand
 {
+    /** @var CmsManagerInterface */
+    private $cmsSnapshotManager;
+
+    /** @var BlockContextManagerInterface */
+    private $blockContextManager;
+
+    /** @var BlockRendererInterface */
+    private $blockRenderer;
+
+    public function __construct(
+        SiteManagerInterface $siteManager,
+        PageManagerInterface $pageManager,
+        SnapshotManagerInterface $snapshotManager,
+        ManagerInterface $blockManager,
+        CmsPageManager $cmsPageManager,
+        ExceptionListener $exceptionListener,
+        BackendInterface $backend,
+        BackendInterface $backendRuntime,
+        CmsManagerInterface $cmsSnapshotManager,
+        BlockContextManagerInterface $blockContextManager,
+        BlockRendererInterface $blockRenderer
+    ) {
+        parent::__construct(
+            $siteManager,
+            $pageManager,
+            $snapshotManager,
+            $blockManager,
+            $cmsPageManager,
+            $exceptionListener,
+            $backend,
+            $backendRuntime
+        );
+        $this->cmsSnapshotManager = $cmsSnapshotManager;
+        $this->blockContextManager = $blockContextManager;
+        $this->blockRenderer = $blockRenderer;
+    }
+
     public function configure(): void
     {
         $this->setName('sonata:page:render-block');
@@ -41,21 +87,22 @@ HELP
         );
 
         $this->addArgument('manager', InputArgument::REQUIRED, 'The manager service id');
-        $this->addArgument('page_id', InputArgument::REQUIRED, 'The page id');
-        $this->addArgument('block_id', InputArgument::REQUIRED, 'The page id');
+        $this->addArgument('block_id', InputArgument::REQUIRED, 'The block id');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $manager = $this->getContainer()->get($input->getArgument('manager'));
+        $manager = $input->getArgument('manager');
 
-        if (!$manager instanceof CmsManagerInterface) {
-            throw new \RuntimeException('The service does not implement the CmsManagerInterface');
+        if (!\in_array($manager, ['sonata.page.cms.snapshot', 'sonata.page.cms.page'], true)) {
+            throw new \RuntimeException(
+                'Available managers are "sonata.page.cms.snapshot" and "sonata.page.cms.page"'
+            );
         }
 
-        $page = $manager->getPageById($input->getArgument('page_id'));
+        $managerService = 'sonata.page.cms.snapshot' === $manager ? $this->cmsSnapshotManager : $this->cmsPageManager;
 
-        $block = $manager->getBlock($input->getArgument('block_id'));
+        $block = $managerService->getBlock($input->getArgument('block_id'));
 
         if (!$block) {
             throw new \RuntimeException('Unable to find the related block');
@@ -68,7 +115,7 @@ HELP
             $output->writeln(sprintf('   >> %s: %s', $name, json_encode($value)));
         }
 
-        $context = $this->getContainer()->get('sonata.block.context_manager')->get($block);
+        $context = $this->blockContextManager->get($block);
 
         $output->writeln("\n<info>BlockContext Information</info>");
         foreach ($context->getSettings() as $name => $value) {
@@ -78,13 +125,7 @@ HELP
         $output->writeln("\n<info>Response Output</info>");
 
         // fake request
-        $request = new Request();
-        $this->getContainer()->enterScope('request');
-        $this->getContainer()->set('request', $request, 'request');
-
-        $output->writeln($this->getContainer()->get('sonata.block.renderer')->render($context));
-
-        $this->getContainer()->leaveScope('request');
+        $output->writeln($this->blockRenderer->render($context));
 
         return 0;
     }

--- a/src/Command/RenderBlockCommand.php
+++ b/src/Command/RenderBlockCommand.php
@@ -66,14 +66,12 @@ class RenderBlockCommand extends BaseCommand
             $backend,
             $backendRuntime
         );
-        $this->cmsSnapshotManager = $cmsSnapshotManager;
         $this->blockContextManager = $blockContextManager;
         $this->blockRenderer = $blockRenderer;
     }
 
     public function configure(): void
     {
-        $this->setName('sonata:page:render-block');
         $this->setDescription('Dump page information');
         $this->setHelp(
             <<<HELP

--- a/src/Command/UpdateCoreRoutesCommand.php
+++ b/src/Command/UpdateCoreRoutesCommand.php
@@ -13,6 +13,13 @@ declare(strict_types=1);
 
 namespace Sonata\PageBundle\Command;
 
+use Sonata\Doctrine\Model\ManagerInterface;
+use Sonata\NotificationBundle\Backend\BackendInterface;
+use Sonata\PageBundle\CmsManager\CmsPageManager;
+use Sonata\PageBundle\Listener\ExceptionListener;
+use Sonata\PageBundle\Model\PageManagerInterface;
+use Sonata\PageBundle\Model\SiteManagerInterface;
+use Sonata\PageBundle\Model\SnapshotManagerInterface;
 use Sonata\PageBundle\Route\RoutePageGenerator;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
@@ -28,6 +35,33 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class UpdateCoreRoutesCommand extends BaseCommand
 {
+    /** @var RoutePageGenerator */
+    private $routePageGenerator;
+
+    public function __construct(
+        SiteManagerInterface $siteManager,
+        PageManagerInterface $pageManager,
+        SnapshotManagerInterface $snapshotManager,
+        ManagerInterface $blockManager,
+        CmsPageManager $cmsPageManager,
+        ExceptionListener $exceptionListener,
+        BackendInterface $backend,
+        BackendInterface $backendRuntime,
+        RoutePageGenerator $routePageGenerator
+    ) {
+        parent::__construct(
+            $siteManager,
+            $pageManager,
+            $snapshotManager,
+            $blockManager,
+            $cmsPageManager,
+            $exceptionListener,
+            $backend,
+            $backendRuntime
+        );
+        $this->routePageGenerator = $routePageGenerator;
+    }
+
     public function configure(): void
     {
         $this->setName('sonata:page:update-core-routes');
@@ -54,7 +88,7 @@ class UpdateCoreRoutesCommand extends BaseCommand
 
             $output->writeln(sprintf(' % 5s - % -30s - %s', 'ID', 'Name', 'Url'));
 
-            foreach ($this->getSiteManager()->findBy([]) as $site) {
+            foreach ($this->siteManager->findBy([]) as $site) {
                 $output->writeln(sprintf(' % 5s - % -30s - %s', $site->getId(), $site->getName(), $site->getUrl()));
             }
 
@@ -95,6 +129,6 @@ class UpdateCoreRoutesCommand extends BaseCommand
      */
     private function getRoutePageGenerator()
     {
-        return $this->getContainer()->get('sonata.page.route.page.generator');
+        return $this->routePageGenerator;
     }
 }

--- a/src/Command/UpdateCoreRoutesCommand.php
+++ b/src/Command/UpdateCoreRoutesCommand.php
@@ -64,7 +64,6 @@ class UpdateCoreRoutesCommand extends BaseCommand
 
     public function configure(): void
     {
-        $this->setName('sonata:page:update-core-routes');
         $this->setDescription('Update core routes, from routing files to page manager');
         // NEXT_MAJOR: Remove the "all" option.
         $this->addOption('all', null, InputOption::VALUE_NONE, 'Create snapshots for all sites');

--- a/src/Command/UpdateCoreRoutesCommand.php
+++ b/src/Command/UpdateCoreRoutesCommand.php
@@ -15,7 +15,7 @@ namespace Sonata\PageBundle\Command;
 
 use Sonata\Doctrine\Model\ManagerInterface;
 use Sonata\NotificationBundle\Backend\BackendInterface;
-use Sonata\PageBundle\CmsManager\CmsPageManager;
+use Sonata\PageBundle\CmsManager\CmsManagerInterface;
 use Sonata\PageBundle\Listener\ExceptionListener;
 use Sonata\PageBundle\Model\PageManagerInterface;
 use Sonata\PageBundle\Model\SiteManagerInterface;
@@ -43,7 +43,7 @@ class UpdateCoreRoutesCommand extends BaseCommand
         PageManagerInterface $pageManager,
         SnapshotManagerInterface $snapshotManager,
         ManagerInterface $blockManager,
-        CmsPageManager $cmsPageManager,
+        CmsManagerInterface $cmsPageManager,
         ExceptionListener $exceptionListener,
         BackendInterface $backend,
         BackendInterface $backendRuntime,

--- a/src/DependencyInjection/Compiler/CmsManagerServiceLocatorCompilerPass.php
+++ b/src/DependencyInjection/Compiler/CmsManagerServiceLocatorCompilerPass.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sonata\PageBundle\DependencyInjection\Compiler;
+
+use Sonata\PageBundle\CmsManager\CmsManagerInterface;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * CmsManagerServiceLocatorCompilerPass.
+ *
+ * @author Valentin Merlet <merlet.valentin@gmail.com>
+ */
+final class CmsManagerServiceLocatorCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $locatableServices = [];
+
+        $cmsManagerServiceLocator = $container->findDefinition('sonata.cms_manager.service_locator');
+
+        /** @var Definition $definition */
+        foreach ($container->getDefinitions() as $definition) {
+            $definitionClass = $definition->getClass();
+            if (null === $definitionClass) {
+                continue;
+            }
+            $interfaces = (new \ReflectionClass($definitionClass))->getInterfaces();
+
+            if (\in_array(CmsManagerInterface::class, $interfaces)) {
+                $locatableServices[$definition->innerServiceId] = new Reference($definition->innerServiceId);
+            }
+        }
+
+        $cmsManagerServiceLocator->addArgument(ServiceLocatorTagPass::register($container, $locatableServices));
+    }
+}

--- a/src/DependencyInjection/Compiler/CmsManagerServiceLocatorCompilerPass.php
+++ b/src/DependencyInjection/Compiler/CmsManagerServiceLocatorCompilerPass.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Sonata\PageBundle\DependencyInjection\Compiler;
 
 use Sonata\PageBundle\CmsManager\CmsManagerInterface;
@@ -32,7 +41,7 @@ final class CmsManagerServiceLocatorCompilerPass implements CompilerPassInterfac
             }
             $interfaces = (new \ReflectionClass($definitionClass))->getInterfaces();
 
-            if (\in_array(CmsManagerInterface::class, $interfaces)) {
+            if (\in_array(CmsManagerInterface::class, $interfaces, true)) {
                 $locatableServices[$definition->innerServiceId] = new Reference($definition->innerServiceId);
             }
         }

--- a/src/DependencyInjection/SonataPageExtension.php
+++ b/src/DependencyInjection/SonataPageExtension.php
@@ -89,6 +89,7 @@ class SonataPageExtension extends Extension implements PrependExtensionInterface
         $loader->load('validators.xml');
         $loader->load('command.xml');
         $loader->load('slugify.xml');
+        $loader->load('service_locator.xml');
 
         $this->configureMultisite($container, $config);
         $this->configureCache($container, $config);

--- a/src/Resources/config/command.xml
+++ b/src/Resources/config/command.xml
@@ -3,70 +3,28 @@
     <services>
         <service id="Sonata\PageBundle\Command\CleanupSnapshotsCommand" class="Sonata\PageBundle\Command\CleanupSnapshotsCommand" public="true">
             <tag name="console.command" command="sonata:page:cleanup-snapshots"/>
-            <argument type="service" id="sonata.page.manager.site"/>
-            <argument type="service" id="sonata.page.manager.page"/>
-            <argument type="service" id="sonata.page.manager.snapshot"/>
-            <argument type="service" id="sonata.page.manager.block"/>
-            <argument type="service" id="sonata.page.cms.page"/>
-            <argument type="service" id="sonata.page.kernel.exception_listener"/>
-            <argument type="service" id="sonata.notification.backend"/>
-            <argument type="service" id="sonata.notification.backend.runtime"/>
+            <argument type="service" id="sonata.command.container.service_subscriber"/>
         </service>
         <service id="Sonata\PageBundle\Command\CloneSiteCommand" class="Sonata\PageBundle\Command\CloneSiteCommand" public="true">
             <tag name="console.command" command="sonata:page:clone-site"/>
-            <argument type="service" id="sonata.page.manager.site"/>
-            <argument type="service" id="sonata.page.manager.page"/>
-            <argument type="service" id="sonata.page.manager.snapshot"/>
-            <argument type="service" id="sonata.page.manager.block"/>
-            <argument type="service" id="sonata.page.cms.page"/>
-            <argument type="service" id="sonata.page.kernel.exception_listener"/>
-            <argument type="service" id="sonata.notification.backend"/>
-            <argument type="service" id="sonata.notification.backend.runtime"/>
+            <argument type="service" id="sonata.command.container.service_subscriber"/>
         </service>
         <service id="Sonata\PageBundle\Command\CreateBlockContainerCommand" class="Sonata\PageBundle\Command\CreateBlockContainerCommand" public="true">
             <tag name="console.command" command="sonata:page:create-block-container"/>
-            <argument type="service" id="sonata.page.manager.site"/>
-            <argument type="service" id="sonata.page.manager.page"/>
-            <argument type="service" id="sonata.page.manager.snapshot"/>
-            <argument type="service" id="sonata.page.manager.block"/>
-            <argument type="service" id="sonata.page.cms.page"/>
-            <argument type="service" id="sonata.page.kernel.exception_listener"/>
-            <argument type="service" id="sonata.notification.backend"/>
-            <argument type="service" id="sonata.notification.backend.runtime"/>
+            <argument type="service" id="sonata.command.container.service_subscriber"/>
             <argument type="service" id="sonata.page.block_interactor"/>
         </service>
         <service id="Sonata\PageBundle\Command\CreateSiteCommand" class="Sonata\PageBundle\Command\CreateSiteCommand" public="true">
             <tag name="console.command" command="sonata:page:create-site"/>
-            <argument type="service" id="sonata.page.manager.site"/>
-            <argument type="service" id="sonata.page.manager.page"/>
-            <argument type="service" id="sonata.page.manager.snapshot"/>
-            <argument type="service" id="sonata.page.manager.block"/>
-            <argument type="service" id="sonata.page.cms.page"/>
-            <argument type="service" id="sonata.page.kernel.exception_listener"/>
-            <argument type="service" id="sonata.notification.backend"/>
-            <argument type="service" id="sonata.notification.backend.runtime"/>
+            <argument type="service" id="sonata.command.container.service_subscriber"/>
         </service>
         <service id="Sonata\PageBundle\Command\CreateSnapshotsCommand" class="Sonata\PageBundle\Command\CreateSnapshotsCommand" public="true">
             <tag name="console.command" command="sonata:page:create-snapshots"/>
-            <argument type="service" id="sonata.page.manager.site"/>
-            <argument type="service" id="sonata.page.manager.page"/>
-            <argument type="service" id="sonata.page.manager.snapshot"/>
-            <argument type="service" id="sonata.page.manager.block"/>
-            <argument type="service" id="sonata.page.cms.page"/>
-            <argument type="service" id="sonata.page.kernel.exception_listener"/>
-            <argument type="service" id="sonata.notification.backend"/>
-            <argument type="service" id="sonata.notification.backend.runtime"/>
+            <argument type="service" id="sonata.command.container.service_subscriber"/>
         </service>
         <service id="Sonata\PageBundle\Command\DumpPageCommand" class="Sonata\PageBundle\Command\DumpPageCommand" public="true">
             <tag name="console.command" command="sonata:page:dump-page"/>
-            <argument type="service" id="sonata.page.manager.site"/>
-            <argument type="service" id="sonata.page.manager.page"/>
-            <argument type="service" id="sonata.page.manager.snapshot"/>
-            <argument type="service" id="sonata.page.manager.block"/>
-            <argument type="service" id="sonata.page.cms.page"/>
-            <argument type="service" id="sonata.page.kernel.exception_listener"/>
-            <argument type="service" id="sonata.notification.backend"/>
-            <argument type="service" id="sonata.notification.backend.runtime"/>
+            <argument type="service" id="sonata.command.container.service_subscriber"/>
             <argument type="service" id="sonata.page.cms.snapshot"/>
         </service>
         <service id="Sonata\PageBundle\Command\MigrateBlockNameSettingCommand" class="Sonata\PageBundle\Command\MigrateBlockNameSettingCommand" public="true">
@@ -79,27 +37,14 @@
         </service>
         <service id="Sonata\PageBundle\Command\RenderBlockCommand" class="Sonata\PageBundle\Command\RenderBlockCommand" public="true">
             <tag name="console.command" command="sonata:page:render-block"/>
-            <argument type="service" id="sonata.page.manager.site"/>
-            <argument type="service" id="sonata.page.manager.page"/>
-            <argument type="service" id="sonata.page.manager.snapshot"/>
-            <argument type="service" id="sonata.page.manager.block"/>
-            <argument type="service" id="sonata.page.cms.page"/>
-            <argument type="service" id="sonata.page.kernel.exception_listener"/>
-            <argument type="service" id="sonata.notification.backend"/>
-            <argument type="service" id="sonata.notification.backend.runtime"/>
+            <argument type="service" id="sonata.command.container.service_subscriber"/>
             <argument type="service" id="sonata.block.context_manager"/>
             <argument type="service" id="sonata.block.renderer"/>
+            <argument type="service" id="sonata.cms_manager.service_locator"/>
         </service>
         <service id="Sonata\PageBundle\Command\UpdateCoreRoutesCommand" class="Sonata\PageBundle\Command\UpdateCoreRoutesCommand" public="true">
             <tag name="console.command" command="sonata:page:update-core-routes"/>
-            <argument type="service" id="sonata.page.manager.site"/>
-            <argument type="service" id="sonata.page.manager.page"/>
-            <argument type="service" id="sonata.page.manager.snapshot"/>
-            <argument type="service" id="sonata.page.manager.block"/>
-            <argument type="service" id="sonata.page.cms.page"/>
-            <argument type="service" id="sonata.page.kernel.exception_listener"/>
-            <argument type="service" id="sonata.notification.backend"/>
-            <argument type="service" id="sonata.notification.backend.runtime"/>
+            <argument type="service" id="sonata.command.container.service_subscriber"/>
             <argument type="service" id="sonata.page.route.page.generator"/>
         </service>
     </services>

--- a/src/Resources/config/command.xml
+++ b/src/Resources/config/command.xml
@@ -3,33 +3,105 @@
     <services>
         <service id="Sonata\PageBundle\Command\CleanupSnapshotsCommand" class="Sonata\PageBundle\Command\CleanupSnapshotsCommand" public="true">
             <tag name="console.command"/>
+            <argument type="service" id="sonata.page.manager.site"/>
+            <argument type="service" id="sonata.page.manager.page"/>
+            <argument type="service" id="sonata.page.manager.snapshot"/>
+            <argument type="service" id="sonata.page.manager.block"/>
+            <argument type="service" id="sonata.page.cms.page"/>
+            <argument type="service" id="sonata.page.kernel.exception_listener"/>
+            <argument type="service" id="sonata.notification.backend"/>
+            <argument type="service" id="sonata.notification.backend.runtime"/>
         </service>
         <service id="Sonata\PageBundle\Command\CloneSiteCommand" class="Sonata\PageBundle\Command\CloneSiteCommand" public="true">
             <tag name="console.command"/>
+            <argument type="service" id="sonata.page.manager.site"/>
+            <argument type="service" id="sonata.page.manager.page"/>
+            <argument type="service" id="sonata.page.manager.snapshot"/>
+            <argument type="service" id="sonata.page.manager.block"/>
+            <argument type="service" id="sonata.page.cms.page"/>
+            <argument type="service" id="sonata.page.kernel.exception_listener"/>
+            <argument type="service" id="sonata.notification.backend"/>
+            <argument type="service" id="sonata.notification.backend.runtime"/>
         </service>
         <service id="Sonata\PageBundle\Command\CreateBlockContainerCommand" class="Sonata\PageBundle\Command\CreateBlockContainerCommand" public="true">
             <tag name="console.command"/>
+            <argument type="service" id="sonata.page.manager.site"/>
+            <argument type="service" id="sonata.page.manager.page"/>
+            <argument type="service" id="sonata.page.manager.snapshot"/>
+            <argument type="service" id="sonata.page.manager.block"/>
+            <argument type="service" id="sonata.page.cms.page"/>
+            <argument type="service" id="sonata.page.kernel.exception_listener"/>
+            <argument type="service" id="sonata.notification.backend"/>
+            <argument type="service" id="sonata.notification.backend.runtime"/>
+            <argument type="service" id="sonata.page.block_interactor"/>
         </service>
         <service id="Sonata\PageBundle\Command\CreateSiteCommand" class="Sonata\PageBundle\Command\CreateSiteCommand" public="true">
             <tag name="console.command"/>
+            <argument type="service" id="sonata.page.manager.site"/>
+            <argument type="service" id="sonata.page.manager.page"/>
+            <argument type="service" id="sonata.page.manager.snapshot"/>
+            <argument type="service" id="sonata.page.manager.block"/>
+            <argument type="service" id="sonata.page.cms.page"/>
+            <argument type="service" id="sonata.page.kernel.exception_listener"/>
+            <argument type="service" id="sonata.notification.backend"/>
+            <argument type="service" id="sonata.notification.backend.runtime"/>
         </service>
         <service id="Sonata\PageBundle\Command\CreateSnapshotsCommand" class="Sonata\PageBundle\Command\CreateSnapshotsCommand" public="true">
             <tag name="console.command"/>
+            <argument type="service" id="sonata.page.manager.site"/>
+            <argument type="service" id="sonata.page.manager.page"/>
+            <argument type="service" id="sonata.page.manager.snapshot"/>
+            <argument type="service" id="sonata.page.manager.block"/>
+            <argument type="service" id="sonata.page.cms.page"/>
+            <argument type="service" id="sonata.page.kernel.exception_listener"/>
+            <argument type="service" id="sonata.notification.backend"/>
+            <argument type="service" id="sonata.notification.backend.runtime"/>
         </service>
         <service id="Sonata\PageBundle\Command\DumpPageCommand" class="Sonata\PageBundle\Command\DumpPageCommand" public="true">
             <tag name="console.command"/>
+            <argument type="service" id="sonata.page.manager.site"/>
+            <argument type="service" id="sonata.page.manager.page"/>
+            <argument type="service" id="sonata.page.manager.snapshot"/>
+            <argument type="service" id="sonata.page.manager.block"/>
+            <argument type="service" id="sonata.page.cms.page"/>
+            <argument type="service" id="sonata.page.kernel.exception_listener"/>
+            <argument type="service" id="sonata.notification.backend"/>
+            <argument type="service" id="sonata.notification.backend.runtime"/>
+            <argument type="service" id="sonata.page.cms.snapshot"/>
         </service>
         <service id="Sonata\PageBundle\Command\MigrateBlockNameSettingCommand" class="Sonata\PageBundle\Command\MigrateBlockNameSettingCommand" public="true">
             <tag name="console.command"/>
+            <argument type="service" id="doctrine.orm.entity_manager"/>
         </service>
         <service id="Sonata\PageBundle\Command\MigrateToJsonTypeCommand" class="Sonata\PageBundle\Command\MigrateToJsonTypeCommand" public="true">
             <tag name="console.command"/>
+            <argument type="service" id="doctrine.orm.entity_manager"/>
         </service>
         <service id="Sonata\PageBundle\Command\RenderBlockCommand" class="Sonata\PageBundle\Command\RenderBlockCommand" public="true">
             <tag name="console.command"/>
+            <argument type="service" id="sonata.page.manager.site"/>
+            <argument type="service" id="sonata.page.manager.page"/>
+            <argument type="service" id="sonata.page.manager.snapshot"/>
+            <argument type="service" id="sonata.page.manager.block"/>
+            <argument type="service" id="sonata.page.cms.page"/>
+            <argument type="service" id="sonata.page.kernel.exception_listener"/>
+            <argument type="service" id="sonata.notification.backend"/>
+            <argument type="service" id="sonata.notification.backend.runtime"/>
+            <argument type="service" id="sonata.page.cms.snapshot"/>
+            <argument type="service" id="sonata.block.context_manager"/>
+            <argument type="service" id="sonata.block.renderer"/>
         </service>
         <service id="Sonata\PageBundle\Command\UpdateCoreRoutesCommand" class="Sonata\PageBundle\Command\UpdateCoreRoutesCommand" public="true">
             <tag name="console.command"/>
+            <argument type="service" id="sonata.page.manager.site"/>
+            <argument type="service" id="sonata.page.manager.page"/>
+            <argument type="service" id="sonata.page.manager.snapshot"/>
+            <argument type="service" id="sonata.page.manager.block"/>
+            <argument type="service" id="sonata.page.cms.page"/>
+            <argument type="service" id="sonata.page.kernel.exception_listener"/>
+            <argument type="service" id="sonata.notification.backend"/>
+            <argument type="service" id="sonata.notification.backend.runtime"/>
+            <argument type="service" id="sonata.page.route.page.generator"/>
         </service>
     </services>
 </container>

--- a/src/Resources/config/command.xml
+++ b/src/Resources/config/command.xml
@@ -2,7 +2,7 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="Sonata\PageBundle\Command\CleanupSnapshotsCommand" class="Sonata\PageBundle\Command\CleanupSnapshotsCommand" public="true">
-            <tag name="console.command"/>
+            <tag name="console.command" command="sonata:page:cleanup-snapshots"/>
             <argument type="service" id="sonata.page.manager.site"/>
             <argument type="service" id="sonata.page.manager.page"/>
             <argument type="service" id="sonata.page.manager.snapshot"/>
@@ -13,7 +13,7 @@
             <argument type="service" id="sonata.notification.backend.runtime"/>
         </service>
         <service id="Sonata\PageBundle\Command\CloneSiteCommand" class="Sonata\PageBundle\Command\CloneSiteCommand" public="true">
-            <tag name="console.command"/>
+            <tag name="console.command" command="sonata:page:clone-site"/>
             <argument type="service" id="sonata.page.manager.site"/>
             <argument type="service" id="sonata.page.manager.page"/>
             <argument type="service" id="sonata.page.manager.snapshot"/>
@@ -24,7 +24,7 @@
             <argument type="service" id="sonata.notification.backend.runtime"/>
         </service>
         <service id="Sonata\PageBundle\Command\CreateBlockContainerCommand" class="Sonata\PageBundle\Command\CreateBlockContainerCommand" public="true">
-            <tag name="console.command"/>
+            <tag name="console.command" command="sonata:page:create-block-container"/>
             <argument type="service" id="sonata.page.manager.site"/>
             <argument type="service" id="sonata.page.manager.page"/>
             <argument type="service" id="sonata.page.manager.snapshot"/>
@@ -36,7 +36,7 @@
             <argument type="service" id="sonata.page.block_interactor"/>
         </service>
         <service id="Sonata\PageBundle\Command\CreateSiteCommand" class="Sonata\PageBundle\Command\CreateSiteCommand" public="true">
-            <tag name="console.command"/>
+            <tag name="console.command" command="sonata:page:create-site"/>
             <argument type="service" id="sonata.page.manager.site"/>
             <argument type="service" id="sonata.page.manager.page"/>
             <argument type="service" id="sonata.page.manager.snapshot"/>
@@ -47,7 +47,7 @@
             <argument type="service" id="sonata.notification.backend.runtime"/>
         </service>
         <service id="Sonata\PageBundle\Command\CreateSnapshotsCommand" class="Sonata\PageBundle\Command\CreateSnapshotsCommand" public="true">
-            <tag name="console.command"/>
+            <tag name="console.command" command="sonata:page:create-snapshots"/>
             <argument type="service" id="sonata.page.manager.site"/>
             <argument type="service" id="sonata.page.manager.page"/>
             <argument type="service" id="sonata.page.manager.snapshot"/>
@@ -58,7 +58,7 @@
             <argument type="service" id="sonata.notification.backend.runtime"/>
         </service>
         <service id="Sonata\PageBundle\Command\DumpPageCommand" class="Sonata\PageBundle\Command\DumpPageCommand" public="true">
-            <tag name="console.command"/>
+            <tag name="console.command" command="sonata:page:dump-page"/>
             <argument type="service" id="sonata.page.manager.site"/>
             <argument type="service" id="sonata.page.manager.page"/>
             <argument type="service" id="sonata.page.manager.snapshot"/>
@@ -70,15 +70,15 @@
             <argument type="service" id="sonata.page.cms.snapshot"/>
         </service>
         <service id="Sonata\PageBundle\Command\MigrateBlockNameSettingCommand" class="Sonata\PageBundle\Command\MigrateBlockNameSettingCommand" public="true">
-            <tag name="console.command"/>
+            <tag name="console.command" command="sonata:page:migrate-block-setting"/>
             <argument type="service" id="doctrine.orm.entity_manager"/>
         </service>
         <service id="Sonata\PageBundle\Command\MigrateToJsonTypeCommand" class="Sonata\PageBundle\Command\MigrateToJsonTypeCommand" public="true">
-            <tag name="console.command"/>
+            <tag name="console.command" command="sonata:page:migrate-block-json"/>
             <argument type="service" id="doctrine.orm.entity_manager"/>
         </service>
         <service id="Sonata\PageBundle\Command\RenderBlockCommand" class="Sonata\PageBundle\Command\RenderBlockCommand" public="true">
-            <tag name="console.command"/>
+            <tag name="console.command" command="sonata:page:render-block"/>
             <argument type="service" id="sonata.page.manager.site"/>
             <argument type="service" id="sonata.page.manager.page"/>
             <argument type="service" id="sonata.page.manager.snapshot"/>
@@ -87,12 +87,11 @@
             <argument type="service" id="sonata.page.kernel.exception_listener"/>
             <argument type="service" id="sonata.notification.backend"/>
             <argument type="service" id="sonata.notification.backend.runtime"/>
-            <argument type="service" id="sonata.page.cms.snapshot"/>
             <argument type="service" id="sonata.block.context_manager"/>
             <argument type="service" id="sonata.block.renderer"/>
         </service>
         <service id="Sonata\PageBundle\Command\UpdateCoreRoutesCommand" class="Sonata\PageBundle\Command\UpdateCoreRoutesCommand" public="true">
-            <tag name="console.command"/>
+            <tag name="console.command" command="sonata:page:update-core-routes"/>
             <argument type="service" id="sonata.page.manager.site"/>
             <argument type="service" id="sonata.page.manager.page"/>
             <argument type="service" id="sonata.page.manager.snapshot"/>

--- a/src/Resources/config/service_locator.xml
+++ b/src/Resources/config/service_locator.xml
@@ -4,5 +4,8 @@
         <service id="sonata.cms_manager.service_locator" class="Symfony\Component\DependencyInjection\ServiceLocator">
             <tag name="container.service_locator"/>
         </service>
+        <service id="sonata.command.container.service_subscriber" class="Symfony\Component\DependencyInjection\ServiceLocator">
+            <tag name="container.service_subscriber"/>
+        </service>
     </services>
 </container>

--- a/src/Resources/config/service_locator.xml
+++ b/src/Resources/config/service_locator.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="sonata.cms_manager.service_locator" class="Symfony\Component\DependencyInjection\ServiceLocator">
+            <tag name="container.service_locator"/>
+        </service>
+    </services>
+</container>

--- a/src/SonataPageBundle.php
+++ b/src/SonataPageBundle.php
@@ -16,6 +16,7 @@ namespace Sonata\PageBundle;
 use Sonata\CoreBundle\Form\FormHelper;
 use Sonata\PageBundle\DependencyInjection\Compiler\CacheCompilerPass;
 use Sonata\PageBundle\DependencyInjection\Compiler\CmfRouterCompilerPass;
+use Sonata\PageBundle\DependencyInjection\Compiler\CmsManagerServiceLocatorCompilerPass;
 use Sonata\PageBundle\DependencyInjection\Compiler\GlobalVariablesCompilerPass;
 use Sonata\PageBundle\DependencyInjection\Compiler\PageServiceCompilerPass;
 use Sonata\PageBundle\DependencyInjection\Compiler\TwigStringExtensionCompilerPass;
@@ -49,6 +50,7 @@ class SonataPageBundle extends Bundle
         $container->addCompilerPass(new PageServiceCompilerPass());
         $container->addCompilerPass(new CmfRouterCompilerPass());
         $container->addCompilerPass(new TwigStringExtensionCompilerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1);
+        $container->addCompilerPass(new CmsManagerServiceLocatorCompilerPass());
     }
 
     public function boot(): void

--- a/tests/Command/BaseCommandTest.php
+++ b/tests/Command/BaseCommandTest.php
@@ -48,8 +48,6 @@ final class BaseCommandTest extends TestCase
         $input = $this->createMock(InputInterface::class);
         $siteManager = $this->createMock(SiteManager::class);
 
-        $this->command->method('getSiteManager')->willReturn($siteManager);
-
         $input->expects(static::exactly(3))->method('getOption')->with('site')->willReturnOnConsecutiveCalls(
             ['all'],
             ['10'],

--- a/tests/Command/CloneSiteCommandTest.php
+++ b/tests/Command/CloneSiteCommandTest.php
@@ -17,13 +17,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Sonata\BlockBundle\Model\BlockManagerInterface;
-use Sonata\NotificationBundle\Backend\MessageManagerBackend;
-use Sonata\NotificationBundle\Backend\RuntimeBackend;
-use Sonata\PageBundle\CmsManager\CmsPageManager;
 use Sonata\PageBundle\Command\CloneSiteCommand;
-use Sonata\PageBundle\Entity\BlockInteractor;
-use Sonata\PageBundle\Entity\SnapshotManager;
-use Sonata\PageBundle\Listener\ExceptionListener;
 use Sonata\PageBundle\Model\PageBlockInterface;
 use Sonata\PageBundle\Model\PageInterface;
 use Sonata\PageBundle\Model\PageManagerInterface;
@@ -31,71 +25,46 @@ use Sonata\PageBundle\Model\SiteInterface;
 use Sonata\PageBundle\Model\SiteManagerInterface;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ServiceLocator;
 
 /**
  * @author Christian Gripp <mail@core23.de>
  */
 final class CloneSiteCommandTest extends TestCase
 {
-    /** @var Stub&BlockInteractor */
-    protected $blockInteractor;
-
-    /** @var Stub&SnapshotManager */
-    protected $snapshotManager;
-
-    /** @var Stub&CmsPageManager */
-    protected $cmsPageManager;
-
-    /** @var Stub&ExceptionListener */
-    protected $exceptionListener;
-
-    /** @var Stub&MessageManagerBackend */
-    protected $backend;
-
-    /** @var Stub&RuntimeBackend */
-    protected $backendRuntime;
-    /**
-     * @var Application
-     */
+    /** @var Application */
     private $application;
 
-    /**
-     * @var Stub&SiteManagerInterface
-     */
+    /** @var Stub&SiteManagerInterface */
     private $siteManager;
 
-    /**
-     * @var MockObject&PageManagerInterface
-     */
+    /** @var MockObject&PageManagerInterface */
     private $pageManager;
 
-    /**
-     * @var MockObject&BlockManagerInterface
-     */
+    /** @var MockObject&BlockManagerInterface */
     private $blockManager;
+
+    /** @var MockObject|ServiceLocator */
+    private $locator;
 
     protected function setUp(): void
     {
+        $this->locator = $this->createMock(ServiceLocator::class);
         $this->siteManager = $this->createStub(SiteManagerInterface::class);
         $this->pageManager = $this->createMock(PageManagerInterface::class);
         $this->blockManager = $this->createMock(BlockManagerInterface::class);
-        $this->blockInteractor = $this->createStub(BlockInteractor::class);
-        $this->snapshotManager = $this->createStub(SnapshotManager::class);
-        $this->cmsPageManager = $this->createStub(CmsPageManager::class);
-        $this->exceptionListener = $this->createStub(ExceptionListener::class);
-        $this->backend = $this->createStub(MessageManagerBackend::class);
-        $this->backendRuntime = $this->createStub(RuntimeBackend::class);
 
-        $command = new CloneSiteCommand(
-            $this->siteManager,
-            $this->pageManager,
-            $this->snapshotManager,
-            $this->blockManager,
-            $this->cmsPageManager,
-            $this->exceptionListener,
-            $this->backend,
-            $this->backendRuntime
-        );
+        $this->locator
+            ->method('__invoke')
+            ->withConsecutive(
+                ['sonata.page.manager.site'],
+                ['sonata.page.manager.page'],
+                ['sonata.page.manager.block']
+            )
+            ->willReturnOnConsecutiveCalls($this->siteManager, $this->pageManager, $this->blockManager);
+
+        $command = new CloneSiteCommand($this->locator);
+        $command->setName('sonata:page:clone-site');
 
         $this->application = new Application();
         $this->application->add($command);

--- a/tests/Command/CreateSiteCommandTest.php
+++ b/tests/Command/CreateSiteCommandTest.php
@@ -14,46 +14,23 @@ declare(strict_types=1);
 namespace Sonata\PageBundle\Tests\Command;
 
 use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
-use Sonata\BlockBundle\Model\BlockManagerInterface;
-use Sonata\NotificationBundle\Backend\MessageManagerBackend;
-use Sonata\NotificationBundle\Backend\RuntimeBackend;
-use Sonata\PageBundle\CmsManager\CmsPageManager;
 use Sonata\PageBundle\Command\CreateSiteCommand;
-use Sonata\PageBundle\Entity\BlockInteractor;
-use Sonata\PageBundle\Entity\SnapshotManager;
-use Sonata\PageBundle\Listener\ExceptionListener;
-use Sonata\PageBundle\Model\PageManagerInterface;
 use Sonata\PageBundle\Model\SiteManagerInterface;
 use Sonata\PageBundle\Tests\Model\Site;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ServiceLocator;
 
 /**
  * @author Ahmet Akbana <ahmetakbana@gmail.com>
  */
 final class CreateSiteCommandTest extends TestCase
 {
-    /** @var Stub&BlockInteractor */
-    protected $blockInteractor;
-
-    /** @var Stub&SnapshotManager */
-    protected $snapshotManager;
-
-    /** @var Stub&CmsPageManager */
-    protected $cmsPageManager;
-
-    /** @var Stub&ExceptionListener */
-    protected $exceptionListener;
-
-    /** @var Stub&MessageManagerBackend */
-    protected $backend;
-
-    /** @var Stub&RuntimeBackend */
-    protected $backendRuntime;
+    /** @var MockObject|ServiceLocator */
+    private $locator;
 
     /** @var Application */
     private $application;
@@ -61,34 +38,18 @@ final class CreateSiteCommandTest extends TestCase
     /** @var MockObject&SiteManagerInterface */
     private $siteManager;
 
-    /** @var MockObject&PageManagerInterface */
-    private $pageManager;
-
-    /** @var MockObject&BlockManagerInterface */
-    private $blockManager;
-
     protected function setUp(): void
     {
+        $this->locator = $this->createMock(ServiceLocator::class);
         $this->siteManager = $this->createMock(SiteManagerInterface::class);
-        $this->pageManager = $this->createMock(PageManagerInterface::class);
-        $this->blockManager = $this->createMock(BlockManagerInterface::class);
-        $this->blockInteractor = $this->createStub(BlockInteractor::class);
-        $this->snapshotManager = $this->createStub(SnapshotManager::class);
-        $this->cmsPageManager = $this->createStub(CmsPageManager::class);
-        $this->exceptionListener = $this->createStub(ExceptionListener::class);
-        $this->backend = $this->createStub(MessageManagerBackend::class);
-        $this->backendRuntime = $this->createStub(RuntimeBackend::class);
 
-        $command = new CreateSiteCommand(
-            $this->siteManager,
-            $this->pageManager,
-            $this->snapshotManager,
-            $this->blockManager,
-            $this->cmsPageManager,
-            $this->exceptionListener,
-            $this->backend,
-            $this->backendRuntime
-        );
+        $this->locator
+            ->method('__invoke')
+            ->with('sonata.page.manager.site')
+            ->willReturn($this->siteManager);
+
+        $command = new CreateSiteCommand($this->locator);
+        $command->setName('sonata:page:create-site');
 
         $this->application = new Application();
         $this->application->add($command);

--- a/tests/Command/CreateSiteCommandTest.php
+++ b/tests/Command/CreateSiteCommandTest.php
@@ -14,40 +14,81 @@ declare(strict_types=1);
 namespace Sonata\PageBundle\Tests\Command;
 
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
+use Sonata\BlockBundle\Model\BlockManagerInterface;
+use Sonata\NotificationBundle\Backend\MessageManagerBackend;
+use Sonata\NotificationBundle\Backend\RuntimeBackend;
+use Sonata\PageBundle\CmsManager\CmsPageManager;
 use Sonata\PageBundle\Command\CreateSiteCommand;
+use Sonata\PageBundle\Entity\BlockInteractor;
+use Sonata\PageBundle\Entity\SnapshotManager;
+use Sonata\PageBundle\Listener\ExceptionListener;
+use Sonata\PageBundle\Model\PageManagerInterface;
 use Sonata\PageBundle\Model\SiteManagerInterface;
 use Sonata\PageBundle\Tests\Model\Site;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Tester\CommandTester;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * @author Ahmet Akbana <ahmetakbana@gmail.com>
  */
 final class CreateSiteCommandTest extends TestCase
 {
-    /**
-     * @var Application
-     */
+    /** @var Stub&BlockInteractor */
+    protected $blockInteractor;
+
+    /** @var Stub&SnapshotManager */
+    protected $snapshotManager;
+
+    /** @var Stub&CmsPageManager */
+    protected $cmsPageManager;
+
+    /** @var Stub&ExceptionListener */
+    protected $exceptionListener;
+
+    /** @var Stub&MessageManagerBackend */
+    protected $backend;
+
+    /** @var Stub&RuntimeBackend */
+    protected $backendRuntime;
+
+    /** @var Application */
     private $application;
 
-    /**
-     * @var MockObject&SiteManagerInterface
-     */
+    /** @var MockObject&SiteManagerInterface */
     private $siteManager;
+
+    /** @var MockObject&PageManagerInterface */
+    private $pageManager;
+
+    /** @var MockObject&BlockManagerInterface */
+    private $blockManager;
 
     protected function setUp(): void
     {
         $this->siteManager = $this->createMock(SiteManagerInterface::class);
+        $this->pageManager = $this->createMock(PageManagerInterface::class);
+        $this->blockManager = $this->createMock(BlockManagerInterface::class);
+        $this->blockInteractor = $this->createStub(BlockInteractor::class);
+        $this->snapshotManager = $this->createStub(SnapshotManager::class);
+        $this->cmsPageManager = $this->createStub(CmsPageManager::class);
+        $this->exceptionListener = $this->createStub(ExceptionListener::class);
+        $this->backend = $this->createStub(MessageManagerBackend::class);
+        $this->backendRuntime = $this->createStub(RuntimeBackend::class);
 
-        $container = $this->createStub(ContainerInterface::class);
-        $container->method('get')->with('sonata.page.manager.site')->willReturn($this->siteManager);
-
-        $command = new CreateSiteCommand();
-        $command->setContainer($container);
+        $command = new CreateSiteCommand(
+            $this->siteManager,
+            $this->pageManager,
+            $this->snapshotManager,
+            $this->blockManager,
+            $this->cmsPageManager,
+            $this->exceptionListener,
+            $this->backend,
+            $this->backendRuntime
+        );
 
         $this->application = new Application();
         $this->application->add($command);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because `4.x` will be compatible with Symfony 5.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes https://github.com/sonata-project/SonataPageBundle/issues/1420

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataPageBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed

- Removed usage of deprecated `ContainerAwareCommand` class
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
