### PR TITLE
remove symfony/debug dependency

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,7 +30,6 @@ jobs:
         strategy:
             matrix:
                 php-version:
-                    - '7.3'
                     - '7.4'
                     - '8.0'
                 dependencies: [highest]
@@ -38,7 +37,7 @@ jobs:
                 symfony-require: ['']
                 variant: [normal]
                 include:
-                    - php-version: '7.3'
+                    - php-version: '7.4'
                       dependencies: lowest
                       allowed-to-fail: false
                       variant: normal

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,6 @@
         "symfony-cmf/routing-bundle": "^2.1",
         "symfony/config": "^4.4",
         "symfony/console": "^4.4",
-        "symfony/debug": "^4.4",
         "symfony/dependency-injection": "^4.4.3",
         "symfony/form": "^4.4",
         "symfony/http-foundation": "^4.4",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "homepage": "https://docs.sonata-project.org/projects/SonataPageBundle",
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "cocur/slugify": "^3.0 || ^4.0",
         "doctrine/doctrine-bundle": "^1.12.3 || ^2.0",
         "doctrine/persistence": "^1.3.4 || ^2.0",

--- a/docs/reference/multisite.rst
+++ b/docs/reference/multisite.rst
@@ -67,7 +67,7 @@ To do so, open ``index.php`` file and change the following parts::
     // public/index.php
 
     use App\Kernel;
-    use Symfony\Component\Debug\Debug;
+    use Symfony\Component\ErrorHandler\Debug;
     use Sonata\PageBundle\Request\RequestFactory; # before: use Symfony\Component\HttpFoundation\Request;
 
     require dirname(__DIR__).'/config/bootstrap.php';
@@ -114,7 +114,7 @@ To do so, open ``index.php`` file and change the following parts::
     // public/index.php
 
     use App\Kernel;
-    use Symfony\Component\Debug\Debug;
+    use Symfony\Component\ErrorHandler\Debug;
     use Sonata\PageBundle\Request\RequestFactory; # before: use Symfony\Component\HttpFoundation\Request;
 
     require dirname(__DIR__).'/config/bootstrap.php';

--- a/src/Listener/ExceptionListener.php
+++ b/src/Listener/ExceptionListener.php
@@ -20,7 +20,7 @@ use Sonata\PageBundle\Exception\InternalErrorException;
 use Sonata\PageBundle\Page\PageServiceManagerInterface;
 use Sonata\PageBundle\Site\SiteSelectorInterface;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Templating\EngineInterface;
@@ -154,9 +154,9 @@ class ExceptionListener
      *
      * @throws \Exception
      */
-    public function onKernelException(GetResponseForExceptionEvent $event)
+    public function onKernelException(ExceptionEvent $event): void
     {
-        if ($event->getException() instanceof NotFoundHttpException && $this->cmsManagerSelector->isEditor()) {
+        if ($event->getThrowable() instanceof NotFoundHttpException && $this->cmsManagerSelector->isEditor()) {
             $pathInfo = $event->getRequest()->getPathInfo();
 
             // can only create a CMS page, so the '_route' must be null
@@ -176,7 +176,7 @@ class ExceptionListener
             }
         }
 
-        if ($event->getException() instanceof InternalErrorException) {
+        if ($event->getThrowable() instanceof InternalErrorException) {
             $this->handleInternalError($event);
         } else {
             $this->handleNativeError($event);
@@ -186,18 +186,18 @@ class ExceptionListener
     /**
      * Handles an internal error.
      */
-    private function handleInternalError(GetResponseForExceptionEvent $event)
+    private function handleInternalError(ExceptionEvent $event): void
     {
         if (false === $this->debug) {
-            $this->logger->error($event->getException()->getMessage(), [
-                'exception' => $event->getException(),
+            $this->logger->error($event->getThrowable()->getMessage(), [
+                'exception' => $event->getThrowable(),
             ]);
 
             return;
         }
 
         $content = $this->templating->render('@SonataPage/internal_error.html.twig', [
-            'exception' => $event->getException(),
+            'exception' => $event->getThrowable(),
         ]);
 
         $event->setResponse(new Response($content, 500));
@@ -206,7 +206,7 @@ class ExceptionListener
     /**
      * Handles a native error.
      */
-    private function handleNativeError(GetResponseForExceptionEvent $event)
+    private function handleNativeError(ExceptionEvent $event): void
     {
         if (true === $this->debug) {
             return;
@@ -218,7 +218,7 @@ class ExceptionListener
 
         $this->status = true;
 
-        $exception = $event->getException();
+        $exception = $event->getThrowable();
         $statusCode = $exception instanceof HttpExceptionInterface ? $exception->getStatusCode() : 500;
 
         $cmsManager = $this->cmsManagerSelector->retrieve();
@@ -257,7 +257,7 @@ class ExceptionListener
         } catch (\Exception $e) {
             $this->logException($exception, $e);
 
-            $event->setException($e);
+            $event->setThrowable($e);
             $this->handleInternalError($event);
 
             return;

--- a/src/Listener/ExceptionListener.php
+++ b/src/Listener/ExceptionListener.php
@@ -154,7 +154,7 @@ class ExceptionListener
      *
      * @throws \Exception
      */
-    public function onKernelException(ExceptionEvent $event): void
+    public function onKernelException(ExceptionEvent $event)
     {
         if ($event->getThrowable() instanceof NotFoundHttpException && $this->cmsManagerSelector->isEditor()) {
             $pathInfo = $event->getRequest()->getPathInfo();
@@ -186,7 +186,7 @@ class ExceptionListener
     /**
      * Handles an internal error.
      */
-    private function handleInternalError(ExceptionEvent $event): void
+    private function handleInternalError(ExceptionEvent $event)
     {
         if (false === $this->debug) {
             $this->logger->error($event->getThrowable()->getMessage(), [
@@ -206,7 +206,7 @@ class ExceptionListener
     /**
      * Handles a native error.
      */
-    private function handleNativeError(ExceptionEvent $event): void
+    private function handleNativeError(ExceptionEvent $event)
     {
         if (true === $this->debug) {
             return;

--- a/tests/Listener/ExceptionListenerTest.php
+++ b/tests/Listener/ExceptionListenerTest.php
@@ -27,7 +27,7 @@ use Sonata\PageBundle\Page\PageServiceManagerInterface;
 use Sonata\PageBundle\Site\SiteSelectorInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Templating\EngineInterface;
@@ -194,11 +194,11 @@ final class ExceptionListenerTest extends TestCase
     /**
      * Returns a mocked event with given content data.
      */
-    protected function getMockEvent(\Exception $exception): GetResponseForExceptionEvent
+    protected function getMockEvent(\Exception $exception): ExceptionEvent
     {
         $kernel = $this->createMock(HttpKernelInterface::class);
         $request = new Request();
 
-        return new GetResponseForExceptionEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST, $exception);
+        return new ExceptionEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST, $exception);
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

This should fix this deprecation:
> The "Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent::getException()" method is deprecated

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because it may be BC even if it is deprecation removal.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataPageBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Remove `symfony/debug` dependency as it is deprecated.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
