### PR TITLE
More Deprecation for Cache removal

### DIFF
--- a/src/Cache/BlockEsiCache.php
+++ b/src/Cache/BlockEsiCache.php
@@ -35,6 +35,7 @@ use Symfony\Component\Routing\RouterInterface;
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  *
  * @final since sonata-project/page-bundle 3.26
+ * @deprecated since sonata-project/page-bundle 3.27.0
  */
 class BlockEsiCache extends VarnishCache
 {

--- a/src/Cache/BlockEsiCache.php
+++ b/src/Cache/BlockEsiCache.php
@@ -35,6 +35,7 @@ use Symfony\Component\Routing\RouterInterface;
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  *
  * @final since sonata-project/page-bundle 3.26
+ *
  * @deprecated since sonata-project/page-bundle 3.27.0
  */
 class BlockEsiCache extends VarnishCache

--- a/src/Cache/BlockJsCache.php
+++ b/src/Cache/BlockJsCache.php
@@ -31,6 +31,7 @@ use Symfony\Component\Routing\RouterInterface;
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  *
  * @final since sonata-project/page-bundle 3.26
+ *
  * @deprecated since sonata-project/page-bundle 3.27.0
  */
 class BlockJsCache implements CacheAdapterInterface

--- a/src/Cache/BlockJsCache.php
+++ b/src/Cache/BlockJsCache.php
@@ -31,6 +31,7 @@ use Symfony\Component\Routing\RouterInterface;
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  *
  * @final since sonata-project/page-bundle 3.26
+ * @deprecated since sonata-project/page-bundle 3.27.0
  */
 class BlockJsCache implements CacheAdapterInterface
 {

--- a/src/Cache/BlockSsiCache.php
+++ b/src/Cache/BlockSsiCache.php
@@ -34,6 +34,7 @@ use Symfony\Component\Routing\RouterInterface;
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  *
  * @final since sonata-project/page-bundle 3.26
+ * @deprecated since sonata-project/page-bundle 3.27.0
  */
 class BlockSsiCache extends SsiCache
 {

--- a/src/Cache/BlockSsiCache.php
+++ b/src/Cache/BlockSsiCache.php
@@ -34,6 +34,7 @@ use Symfony\Component\Routing\RouterInterface;
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  *
  * @final since sonata-project/page-bundle 3.26
+ *
  * @deprecated since sonata-project/page-bundle 3.27.0
  */
 class BlockSsiCache extends SsiCache

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -15,6 +15,7 @@ namespace Sonata\PageBundle\DependencyInjection;
 
 use Sonata\PageBundle\Model\Template;
 use Sonata\PageBundle\Template\Matrix\Parser;
+use Symfony\Component\Config\Definition\BaseNode;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
@@ -148,6 +149,12 @@ EOF;
 
             ->arrayNode('cache_invalidation')
                 ->addDefaultsIfNotSet()
+                ->setDeprecated(
+                    ...$this->getDeprecationMessage(
+                        'The "cache_invalidation" option is deprecated since sonata-project/page-bundle 3.27.0 and will be removed in 4.0',
+                        '3.27'
+                    )
+                )
                 ->children()
                     ->scalarNode('service')->defaultValue('sonata.cache.invalidation.simple')->end()
                     ->scalarNode('recorder')->defaultValue('sonata.cache.recorder')->end()
@@ -317,6 +324,12 @@ EOF;
             ->end()
 
             ->arrayNode('caches')
+                ->setDeprecated(
+                    ...$this->getDeprecationMessage(
+                        'The "caches" option is deprecated since sonata-project/page-bundle 3.27.0 and will be removed in 4.0',
+                        '3.27'
+                    )
+                )
                 ->children()
                     ->arrayNode('esi')
                         ->children()
@@ -372,8 +385,28 @@ EOF;
             ->end()
             ->booleanNode('cache')
                 ->defaultValue(true)
+                ->setDeprecated(
+                    ...$this->getDeprecationMessage(
+                    'The "cache" option is deprecated since sonata-project/page-bundle 3.27.0 and will be removed in 4.0',
+                    '3.27'
+                    )
+                )
             ->end();
 
         return $treeBuilder;
+    }
+
+    protected function getDeprecationMessage($message, $version): array
+    {
+        // @phpstan-ignore-next-line
+        if (method_exists(BaseNode::class, 'getDeprecation')) {
+            return [
+                'sonata-project/page-bundle',
+                $version,
+                $message
+            ];
+        }
+
+        return [$message];
     }
 }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -398,7 +398,6 @@ EOF;
 
     protected function getDeprecationMessage($message, $version): array
     {
-        // @phpstan-ignore-next-line
         if (method_exists(BaseNode::class, 'getDeprecation')) {
             return [
                 'sonata-project/page-bundle',

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -387,8 +387,8 @@ EOF;
                 ->defaultValue(true)
                 ->setDeprecated(
                     ...$this->getDeprecationMessage(
-                    'The "cache" option is deprecated since sonata-project/page-bundle 3.27.0 and will be removed in 4.0',
-                    '3.27'
+                        'The "cache" option is deprecated since sonata-project/page-bundle 3.27.0 and will be removed in 4.0',
+                        '3.27'
                     )
                 )
             ->end();
@@ -403,7 +403,7 @@ EOF;
             return [
                 'sonata-project/page-bundle',
                 $version,
-                $message
+                $message,
             ];
         }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because the new deprecation should be BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #{put_issue_number_here}.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataPageBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecated `BlockEsiCache`, `BlockJsCache` and `BlockSsiCache`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
