### PR TITLE
PageExtension without deprecated InitRuntimeInterface

### DIFF
--- a/src/Resources/config/twig.xml
+++ b/src/Resources/config/twig.xml
@@ -7,7 +7,7 @@
             <argument type="service" id="sonata.page.site.selector"/>
             <argument type="service" id="router"/>
             <argument type="service" id="sonata.block.templating.helper"/>
-            <argument type="service" id="twig.extension.httpkernel"/>
+            <argument type="service" id="request_stack"/>
             <argument>%sonata.page.hide_disabled_blocks%</argument>
         </service>
         <service id="sonata.page.twig.global" class="Sonata\PageBundle\Twig\GlobalVariables">

--- a/src/Twig/Extension/PageExtension.php
+++ b/src/Twig/Extension/PageExtension.php
@@ -33,10 +33,8 @@ use Twig\TwigFunction;
  * PageExtension.
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class PageExtension extends AbstractExtension
+final class PageExtension extends AbstractExtension
 {
     /**
      * @var CmsManagerSelectorInterface

--- a/src/Twig/Extension/PageExtension.php
+++ b/src/Twig/Extension/PageExtension.php
@@ -26,6 +26,9 @@ use Symfony\Component\HttpKernel\Controller\ControllerReference;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Twig\Environment;
+use Twig\Error\LoaderError;
+use Twig\Error\RuntimeError;
+use Twig\Error\SyntaxError;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -45,11 +48,6 @@ final class PageExtension extends AbstractExtension
      * @var SiteSelectorInterface
      */
     private $siteSelector;
-
-    /**
-     * @var array
-     */
-    private $resources;
 
     /**
      * @var RouterInterface
@@ -100,9 +98,11 @@ final class PageExtension extends AbstractExtension
     }
 
     /**
-     * @return string
+     * @throws LoaderError
+     * @throws RuntimeError
+     * @throws SyntaxError
      */
-    public function breadcrumb(Environment $twig, ?PageInterface $page = null, array $options = [])
+    public function breadcrumb(Environment $twig, ?PageInterface $page = null, array $options = []): string
     {
         if (!$page) {
             $page = $this->cmsManagerSelector->retrieve()->getCurrentPage();
@@ -140,7 +140,7 @@ final class PageExtension extends AbstractExtension
             }
         }
 
-        return $this->render($twig, $options['template'], [
+        return $twig->render($options['template'], [
             'page' => $page,
             'breadcrumbs' => $breadcrumbs,
             'options' => $options,
@@ -255,19 +255,5 @@ final class PageExtension extends AbstractExtension
         }
 
         return HttpKernelExtension::controller($controller, $attributes, $query);
-    }
-
-    /**
-     * @param string $template
-     *
-     * @return string
-     */
-    private function render(Environment $twig, $template, array $parameters = [])
-    {
-        if (!isset($this->resources[$template])) {
-            $this->resources[$template] = $twig->load($template);
-        }
-
-        return $this->resources[$template]->render($parameters);
     }
 }

--- a/src/Twig/Extension/PageExtension.php
+++ b/src/Twig/Extension/PageExtension.php
@@ -102,19 +102,9 @@ class PageExtension extends AbstractExtension
     }
 
     /**
-     * NEXT_MAJOR: remove this method.
-     *
-     * @deprecated since sonata-project/page-bundle 3.14, to be removed in version 4.0.
-     */
-    public function getName()
-    {
-        return 'sonata_page';
-    }
-
-    /**
      * @return string
      */
-    public function breadcrumb(Environment $env, ?PageInterface $page = null, array $options = [])
+    public function breadcrumb(Environment $twig, ?PageInterface $page = null, array $options = [])
     {
         if (!$page) {
             $page = $this->cmsManagerSelector->retrieve()->getCurrentPage();
@@ -152,7 +142,7 @@ class PageExtension extends AbstractExtension
             }
         }
 
-        return $this->render($env, $options['template'], [
+        return $this->render($twig, $options['template'], [
             'page' => $page,
             'breadcrumbs' => $breadcrumbs,
             'options' => $options,
@@ -274,10 +264,10 @@ class PageExtension extends AbstractExtension
      *
      * @return string
      */
-    private function render(Environment $env, $template, array $parameters = [])
+    private function render(Environment $twig, $template, array $parameters = [])
     {
         if (!isset($this->resources[$template])) {
-            $this->resources[$template] = $env->load($template);
+            $this->resources[$template] = $twig->load($template);
         }
 
         return $this->resources[$template]->render($parameters);

--- a/tests/Twig/Extension/PageExtensionTest.php
+++ b/tests/Twig/Extension/PageExtensionTest.php
@@ -93,19 +93,6 @@ final class PageExtensionTest extends TestCase
         $extension->controller('bar');
     }
 
-    public function testGetName(): void
-    {
-        $extension = new PageExtension(
-            $this->createMock(CmsManagerSelectorInterface::class),
-            $this->createMock(SiteSelectorInterface::class),
-            $this->createMock(RouterInterface::class),
-            $this->createMock(BlockHelper::class),
-            $this->getRequestStack(new Request())
-        );
-
-        static::assertSame('sonata_page', $extension->getName());
-    }
-
     protected function getRequestStack(Request $request): RequestStack
     {
         $stack = new RequestStack();

--- a/tests/Twig/Extension/PageExtensionTest.php
+++ b/tests/Twig/Extension/PageExtensionTest.php
@@ -110,6 +110,7 @@ final class PageExtensionTest extends TestCase
     {
         $stack = new RequestStack();
         $stack->push($request);
+
         return $stack;
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because i don't know if that would count as BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #{put_issue_number_here}.

it fixes:
> The "Sonata\PageBundle\Twig\Extension\PageExtension" class implements "Twig\Extension\InitRuntimeInterface" that is deprecated since Twig 2.7, to be removed in 3.0.

The Thing about `$env->getGlobals()['app']->getRequest()->getPathInfo();`, my gut is telling me that RequestStack would be cleaner, but that wouldn't be BC anymore if this one might be.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataPageBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- PageExtension doesn't need InitRuntimeInterface anymore
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
