### PR TITLE
Remove BaseBlockAdmin getPersistentParameters

### DIFF
--- a/src/Admin/BaseBlockAdmin.php
+++ b/src/Admin/BaseBlockAdmin.php
@@ -179,17 +179,6 @@ abstract class BaseBlockAdmin extends AbstractAdmin
         $this->containerBlockTypes = $containerBlockTypes;
     }
 
-    public function getPersistentParameters(): array
-    {
-        if (!$this->hasRequest()) {
-            return [];
-        }
-
-        return [
-            'type' => $this->getRequest()->get('type'),
-        ];
-    }
-
     public function preBatchAction($actionName, ProxyQueryInterface $query, array &$idx, $allElements): void
     {
         $parent = $this->getParent();


### PR DESCRIPTION
configurePersistentParameters is already below, and it isn't in 3.x

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
