### PR TITLE
Change sonata.templating by twig where it's possible

### DIFF
--- a/src/Block/ChildrenPagesBlockService.php
+++ b/src/Block/ChildrenPagesBlockService.php
@@ -15,7 +15,7 @@ namespace Sonata\PageBundle\Block;
 
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BlockContextInterface;
-use Sonata\BlockBundle\Block\Service\AbstractAdminBlockService;
+use Sonata\BlockBundle\Block\Service\AbstractBlockService;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\Form\Type\ImmutableArrayType;
 use Sonata\PageBundle\CmsManager\CmsManagerSelectorInterface;
@@ -26,33 +26,22 @@ use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Templating\EngineInterface;
+use Twig\Environment;
 
 /**
  * Render children pages.
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class ChildrenPagesBlockService extends AbstractAdminBlockService
+final class ChildrenPagesBlockService extends AbstractBlockService
 {
-    /**
-     * @var SiteSelectorInterface
-     */
-    protected $siteSelector;
+    private SiteSelectorInterface $siteSelector;
 
-    /**
-     * @var CmsManagerSelectorInterface
-     */
-    protected $cmsManagerSelector;
+    private CmsManagerSelectorInterface $cmsManagerSelector;
 
-    /**
-     * @param string $name
-     */
-    public function __construct($name, EngineInterface $templating, SiteSelectorInterface $siteSelector, CmsManagerSelectorInterface $cmsManagerSelector)
+    public function __construct(Environment $twig, SiteSelectorInterface $siteSelector, CmsManagerSelectorInterface $cmsManagerSelector)
     {
-        parent::__construct($name, $templating);
+        parent::__construct($twig);
 
         $this->siteSelector = $siteSelector;
         $this->cmsManagerSelector = $cmsManagerSelector;
@@ -122,7 +111,7 @@ class ChildrenPagesBlockService extends AbstractAdminBlockService
         ]);
     }
 
-    public function getName()
+    public function getName(): string
     {
         return 'Children Page (core)';
     }

--- a/src/Block/ContainerBlockService.php
+++ b/src/Block/ContainerBlockService.php
@@ -26,10 +26,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  *
  * @psalm-suppress InvalidExtendClass
  * @phpstan-ignore-next-line
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class ContainerBlockService extends BaseContainerBlockService
+final class ContainerBlockService extends BaseContainerBlockService
 {
     public function configureSettings(OptionsResolver $resolver): void
     {

--- a/src/Block/PageListBlockService.php
+++ b/src/Block/PageListBlockService.php
@@ -15,34 +15,25 @@ namespace Sonata\PageBundle\Block;
 
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BlockContextInterface;
-use Sonata\BlockBundle\Block\Service\AbstractAdminBlockService;
+use Sonata\BlockBundle\Block\Service\AbstractBlockService;
 use Sonata\BlockBundle\Meta\Metadata;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\Form\Type\ImmutableArrayType;
 use Sonata\PageBundle\Model\PageInterface;
 use Sonata\PageBundle\Model\PageManagerInterface;
-use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Twig\Environment;
 
-/**
- * @final since sonata-project/page-bundle 3.26
- */
-class PageListBlockService extends AbstractAdminBlockService
+final class PageListBlockService extends AbstractBlockService
 {
-    /**
-     * @var PageManagerInterface
-     */
-    protected $pageManager;
+    private PageManagerInterface $pageManager;
 
-    /**
-     * @param string $name
-     */
-    public function __construct($name, EngineInterface $templating, PageManagerInterface $pageManager)
+    public function __construct(Environment $twig, PageManagerInterface $pageManager)
     {
-        parent::__construct($name, $templating);
+        parent::__construct($twig);
 
         $this->pageManager = $pageManager;
     }

--- a/src/Block/SharedBlockBlockService.php
+++ b/src/Block/SharedBlockBlockService.php
@@ -17,55 +17,40 @@ use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Form\Type\ModelListType;
 use Sonata\BlockBundle\Block\BlockContextInterface;
-use Sonata\BlockBundle\Block\Service\AbstractAdminBlockService;
+use Sonata\BlockBundle\Block\Service\AbstractBlockService;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\Doctrine\Model\ManagerInterface;
 use Sonata\Form\Type\ImmutableArrayType;
 use Sonata\Form\Validator\ErrorElement;
 use Sonata\PageBundle\Admin\SharedBlockAdmin;
 use Sonata\PageBundle\Model\Block;
-use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\Form\FormBuilder;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Templating\EngineInterface;
 use Symfony\Component\Validator\Constraints\NotBlank;
+use Twig\Environment;
 
 /**
  * Render a shared block.
  *
  * @author Romain Mouillard <romain.mouillard@gmail.com>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class SharedBlockBlockService extends AbstractAdminBlockService
+final class SharedBlockBlockService extends AbstractBlockService
 {
-    /**
-     * @var SharedBlockAdmin
-     */
-    private $sharedBlockAdmin;
+    private SharedBlockAdmin $sharedBlockAdmin;
 
-    /**
-     * @var ContainerInterface
-     */
-    private $container;
+    private ContainerBuilder $container;
 
-    /**
-     * @var ManagerInterface
-     */
-    private $blockManager;
+    private ManagerInterface $blockManager;
 
-    /**
-     * @param string $name
-     *
-     * @psalm-suppress ContainerDependency
-     */
-    public function __construct($name, EngineInterface $templating, ContainerInterface $container, ManagerInterface $blockManager)
+    public function __construct(Environment $twig, ContainerBuilder $container, ManagerInterface $blockManager, SharedBlockAdmin $sharedBlockAdmin)
     {
-        $this->name = $name;
-        $this->templating = $templating;
+        parent::__construct($twig);
+
         $this->container = $container;
         $this->blockManager = $blockManager;
+        $this->sharedBlockAdmin = $sharedBlockAdmin;
     }
 
     public function execute(BlockContextInterface $blockContext, ?Response $response = null)
@@ -141,10 +126,7 @@ class SharedBlockBlockService extends AbstractAdminBlockService
         $block->setSetting('blockId', \is_object($block->getSetting('blockId')) ? $block->getSetting('blockId')->getId() : null);
     }
 
-    /**
-     * @return SharedBlockAdmin
-     */
-    protected function getSharedBlockAdmin()
+    protected function getSharedBlockAdmin(): SharedBlockAdmin
     {
         if (!$this->sharedBlockAdmin) {
             $this->sharedBlockAdmin = $this->container->get('sonata.page.admin.shared_block');
@@ -153,10 +135,7 @@ class SharedBlockBlockService extends AbstractAdminBlockService
         return $this->sharedBlockAdmin;
     }
 
-    /**
-     * @return FormBuilder
-     */
-    protected function getBlockBuilder(FormMapper $form)
+    protected function getBlockBuilder(FormMapper $form): FormBuilderInterface
     {
         // simulate an association ...
         $fieldDescription = $this->getSharedBlockAdmin()->getModelManager()->getNewFieldDescriptionInstance($this->sharedBlockAdmin->getClass(), 'block', [

--- a/src/Listener/ResponseListener.php
+++ b/src/Listener/ResponseListener.php
@@ -17,51 +17,34 @@ use Sonata\PageBundle\CmsManager\CmsManagerSelectorInterface;
 use Sonata\PageBundle\CmsManager\DecoratorStrategyInterface;
 use Sonata\PageBundle\Exception\InternalErrorException;
 use Sonata\PageBundle\Page\PageServiceManagerInterface;
-use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Twig\Environment;
 
 /**
  * This class redirect the onCoreResponse event to the correct
  * cms manager upon user permission.
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class ResponseListener
+final class ResponseListener
 {
-    /**
-     * @var CmsManagerSelectorInterface
-     */
-    protected $cmsSelector;
+    private CmsManagerSelectorInterface $cmsSelector;
 
-    /**
-     * @var PageServiceManagerInterface
-     */
-    protected $pageServiceManager;
+    private PageServiceManagerInterface $pageServiceManager;
 
-    /**
-     * @var DecoratorStrategyInterface
-     */
-    protected $decoratorStrategy;
+    private DecoratorStrategyInterface $decoratorStrategy;
 
-    /**
-     * @var EngineInterface
-     */
-    protected $templating;
+    private Environment $twig;
 
-    /**
-     * @var bool
-     */
-    private $skipRedirection;
+    private bool $skipRedirection;
 
     /**
      * @param CmsManagerSelectorInterface $cmsSelector        CMS manager selector
      * @param PageServiceManagerInterface $pageServiceManager Page service manager
      * @param DecoratorStrategyInterface  $decoratorStrategy  Decorator strategy
-     * @param EngineInterface             $templating         The template engine
+     * @param Environment                 $twig               Twig engine
      * @param bool                        $skipRedirection    To skip the redirection by configuration
      *
      * NEXT_MAJOR: Remove default value for $skipRedirection
@@ -70,13 +53,13 @@ class ResponseListener
         CmsManagerSelectorInterface $cmsSelector,
         PageServiceManagerInterface $pageServiceManager,
         DecoratorStrategyInterface $decoratorStrategy,
-        EngineInterface $templating,
-        $skipRedirection = false
+        Environment $twig,
+        bool $skipRedirection
     ) {
         $this->cmsSelector = $cmsSelector;
         $this->pageServiceManager = $pageServiceManager;
         $this->decoratorStrategy = $decoratorStrategy;
-        $this->templating = $templating;
+        $this->twig = $twig;
         $this->skipRedirection = $skipRedirection;
     }
 
@@ -109,7 +92,7 @@ class ResponseListener
             !$request->get('_sonata_page_skip') &&
             !$this->skipRedirection
         ) {
-            $response = new Response($this->templating->render('@SonataPage/Page/redirect.html.twig', [
+            $response = new Response($this->twig->render('@SonataPage/Page/redirect.html.twig', [
                 'response' => $response,
                 'page' => $page,
             ]));

--- a/src/Model/SnapshotChildrenCollection.php
+++ b/src/Model/SnapshotChildrenCollection.php
@@ -17,25 +17,17 @@ namespace Sonata\PageBundle\Model;
  * SnapshotChildrenCollection.
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class SnapshotChildrenCollection implements \Countable, \IteratorAggregate, \ArrayAccess
+final class SnapshotChildrenCollection implements \Countable, \IteratorAggregate, \ArrayAccess
 {
-    /**
-     * @var TransformerInterface
-     */
-    protected $transformer;
+    private TransformerInterface $transformer;
 
-    /**
-     * @var PageInterface
-     */
-    protected $page;
+    private PageInterface $page;
 
     /**
      * @var array
      */
-    protected $collection;
+    private $collection;
 
     public function __construct(TransformerInterface $transformer, PageInterface $page)
     {
@@ -43,18 +35,18 @@ class SnapshotChildrenCollection implements \Countable, \IteratorAggregate, \Arr
         $this->page = $page;
     }
 
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         $this->load();
 
-        return $this->collection->offsetUnset($offset);
+        $this->collection->offsetUnset($offset);
     }
 
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->load();
 
-        return $this->collection->offsetSet($offset, $value);
+        $this->collection->offsetSet($offset, $value);
     }
 
     public function offsetGet($offset)
@@ -64,21 +56,21 @@ class SnapshotChildrenCollection implements \Countable, \IteratorAggregate, \Arr
         return $this->collection->offsetGet($offset);
     }
 
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         $this->load();
 
         return $this->collection->offsetExists($offset);
     }
 
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         $this->load();
 
         return $this->collection->getIterator();
     }
 
-    public function count()
+    public function count(): int
     {
         $this->load();
 

--- a/src/Page/TemplateManagerInterface.php
+++ b/src/Page/TemplateManagerInterface.php
@@ -29,10 +29,8 @@ interface TemplateManagerInterface
      * @param string   $code       Template code
      * @param array    $parameters An array of view parameters
      * @param Response $response   Response to update
-     *
-     * @return Response
      */
-    public function renderResponse($code, array $parameters = [], ?Response $response = null);
+    public function renderResponse(string $code, array $parameters = [], ?Response $response = null): Response;
 
     /**
      * Adds a template.

--- a/src/Resources/config/block.xml
+++ b/src/Resources/config/block.xml
@@ -11,13 +11,11 @@
     <services>
         <service id="sonata.page.block.container" class="%sonata.page.block.container.class%">
             <tag name="sonata.block" context="internal"/>
-            <argument>sonata.page.block.container</argument>
-            <argument type="service" id="sonata.templating"/>
+            <argument type="service" id="twig"/>
         </service>
         <service id="sonata.page.block.children_pages" class="%sonata.page.block.children_pages.class%">
             <tag name="sonata.block"/>
-            <argument>sonata.page.block.children_pages</argument>
-            <argument type="service" id="sonata.templating"/>
+            <argument type="service" id="twig"/>
             <argument type="service" id="sonata.page.site.selector"/>
             <argument type="service" id="sonata.page.cms_manager_selector"/>
         </service>
@@ -42,15 +40,14 @@
         </service>
         <service id="sonata.page.block.shared_block" class="%sonata.page.block.shared_block.class%">
             <tag name="sonata.block"/>
-            <argument>sonata.page.block.shared_block</argument>
-            <argument type="service" id="sonata.templating"/>
+            <argument type="service" id="twig"/>
             <argument type="service" id="service_container"/>
             <argument type="service" id="sonata.page.manager.block"/>
+            <argument type="service" id="sonata.page.admin.shared_block"/>
         </service>
         <service id="sonata.page.block.pagelist" class="%sonata.page.block.pagelist.class%">
             <tag name="sonata.block"/>
-            <argument>sonata.page.block.pagelist</argument>
-            <argument type="service" id="sonata.templating"/>
+            <argument type="service" id="twig"/>
             <argument type="service" id="sonata.page.manager.page"/>
         </service>
     </services>

--- a/src/Resources/config/http_kernel.xml
+++ b/src/Resources/config/http_kernel.xml
@@ -7,7 +7,7 @@
             <argument type="service" id="sonata.page.site.selector"/>
             <argument type="service" id="sonata.page.cms_manager_selector"/>
             <argument>%kernel.debug%</argument>
-            <argument type="service" id="sonata.templating"/>
+            <argument type="service" id="twig"/>
             <argument type="service" id="sonata.page.page_service_manager"/>
             <argument type="service" id="sonata.page.decorator_strategy"/>
             <argument/>

--- a/src/Resources/config/page.xml
+++ b/src/Resources/config/page.xml
@@ -51,7 +51,7 @@
             <argument type="service" id="sonata.page.cms_manager_selector"/>
             <argument type="service" id="sonata.page.page_service_manager"/>
             <argument type="service" id="sonata.page.decorator_strategy"/>
-            <argument type="service" id="sonata.templating"/>
+            <argument type="service" id="twig"/>
             <argument>%sonata.page.skip_redirection%</argument>
         </service>
         <service id="sonata.page.request_listener" class="%sonata.page.request_listener.class%">
@@ -98,7 +98,7 @@
             <argument type="service" id="sonata.page.kernel.exception_listener"/>
         </service>
         <service id="sonata.page.template_manager" class="%sonata.page.template.manager.class%" public="true">
-            <argument type="service" id="sonata.templating"/>
+            <argument type="service" id="twig"/>
             <argument type="collection"/>
         </service>
         <service id="sonata.page.page_service_manager" class="%sonata.page.service.manager.class%" public="true">

--- a/tests/Listener/ExceptionListenerTest.php
+++ b/tests/Listener/ExceptionListenerTest.php
@@ -30,7 +30,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
-use Symfony\Component\Templating\EngineInterface;
+use Twig\Environment;
 
 final class ExceptionListenerTest extends TestCase
 {
@@ -40,9 +40,9 @@ final class ExceptionListenerTest extends TestCase
     private $siteSelector;
 
     /**
-     * @var MockObject&EngineInterface
+     * @var MockObject&Environment
      */
-    private $templating;
+    private $twig;
 
     /**
      * @var MockObject&DecoratorStrategyInterface
@@ -76,7 +76,7 @@ final class ExceptionListenerTest extends TestCase
     {
         // mock dependencies
         $this->siteSelector = $this->createMock(SiteSelectorInterface::class);
-        $this->templating = $this->createMock(EngineInterface::class);
+        $this->twig = $this->createMock(Environment::class);
         $this->decoratorStrategy = $this->createMock(DecoratorStrategyInterface::class);
         $this->pageServiceManager = $this->createMock(PageServiceManagerInterface::class);
         $this->cmsSelector = $this->createMock(CmsManagerSelectorInterface::class);
@@ -91,7 +91,7 @@ final class ExceptionListenerTest extends TestCase
             $this->siteSelector,
             $this->cmsSelector,
             false,
-            $this->templating,
+            $this->twig,
             $this->pageServiceManager,
             $this->decoratorStrategy,
             $errors,
@@ -126,8 +126,8 @@ final class ExceptionListenerTest extends TestCase
         // mocked decorator strategy should allow decorate
         $this->decoratorStrategy->expects(static::once())->method('isRouteUriDecorable')->willReturn(true);
 
-        // mock templating to expect a twig rendering
-        $this->templating->expects(static::once())->method('render')
+        // mock twig to expect a twig rendering
+        $this->twig->expects(static::once())->method('render')
              ->with(static::equalTo('@SonataPage/Page/create.html.twig'));
 
         $this->listener->onKernelException($event);

--- a/tests/Listener/ResponseListenerTest.php
+++ b/tests/Listener/ResponseListenerTest.php
@@ -22,11 +22,11 @@ use Sonata\PageBundle\Exception\InternalErrorException;
 use Sonata\PageBundle\Listener\ResponseListener;
 use Sonata\PageBundle\Model\PageInterface;
 use Sonata\PageBundle\Page\PageServiceManagerInterface;
-use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Twig\Environment;
 
 final class ResponseListenerTest extends TestCase
 {
@@ -51,9 +51,9 @@ final class ResponseListenerTest extends TestCase
     private $cmsSelector;
 
     /**
-     * @var MockObject&EngineInterface
+     * @var MockObject&Environment
      */
-    private $templating;
+    private $twig;
 
     /**
      * @var ResponseListener
@@ -70,13 +70,14 @@ final class ResponseListenerTest extends TestCase
         $this->cmsManager = $this->createMock(CmsManagerInterface::class);
         $this->cmsSelector = $this->createMock(CmsManagerSelectorInterface::class);
         $this->cmsSelector->expects(static::once())->method('retrieve')->willReturn($this->cmsManager);
-        $this->templating = $this->createMock(EngineInterface::class);
+        $this->twig = $this->createMock(Environment::class);
 
         $this->listener = new ResponseListener(
             $this->cmsSelector,
             $this->pageServiceManager,
             $this->decoratorStrategy,
-            $this->templating
+            $this->twig,
+            true
         );
     }
 

--- a/tests/Route/RoutePageGeneratorTest.php
+++ b/tests/Route/RoutePageGeneratorTest.php
@@ -14,16 +14,21 @@ declare(strict_types=1);
 namespace Sonata\PageBundle\Tests\Route;
 
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Sonata\PageBundle\CmsManager\CmsManagerSelectorInterface;
 use Sonata\PageBundle\CmsManager\DecoratorStrategy;
 use Sonata\PageBundle\Entity\PageManager;
 use Sonata\PageBundle\Listener\ExceptionListener;
 use Sonata\PageBundle\Model\SiteInterface;
+use Sonata\PageBundle\Page\PageServiceManagerInterface;
 use Sonata\PageBundle\Route\RoutePageGenerator;
+use Sonata\PageBundle\Site\SiteSelectorInterface;
 use Sonata\PageBundle\Tests\Model\Page;
 use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Routing\RouterInterface;
+use Twig\Environment;
 
 /**
  * @author Vincent Composieux <vincent.composieux@gmail.com>
@@ -179,8 +184,27 @@ final class RoutePageGeneratorTest extends TestCase
 
         $decoratorStrategy = new DecoratorStrategy([], [], []);
 
-        $exceptionListener = $this->createMock(ExceptionListener::class);
-        $exceptionListener->method('getHttpErrorCodes')->willReturn([404, 500]);
+        $siteSelector = $this->createMock(SiteSelectorInterface::class);
+        $cmsManagerSelector = $this->createMock(CmsManagerSelectorInterface::class);
+        $twig = $this->createMock(Environment::class);
+        $pageServiceManager = $this->createMock(PageServiceManagerInterface::class);
+        $logger = $this->createMock(LoggerInterface::class);
+
+        $errors = [
+            '404' => 'route_404',
+            '500' => 'route_500',
+        ];
+
+        $exceptionListener = new ExceptionListener(
+            $siteSelector,
+            $cmsManagerSelector,
+            true,
+            $twig,
+            $pageServiceManager,
+            $decoratorStrategy,
+            $errors,
+            $logger
+        );
 
         return new RoutePageGenerator($router, $pageManager, $decoratorStrategy, $exceptionListener);
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I'm targeting this branch, because [4.x](https://github.com/sonata-project/SonataPageBundle/tree/4.x) will be compatible with Symfony 5

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
