### PR TITLE
Deprecate dump commands

### DIFF
--- a/src/Command/DumpPageCommand.php
+++ b/src/Command/DumpPageCommand.php
@@ -24,6 +24,10 @@ use Symfony\Component\Console\Output\OutputInterface;
  * Migrates the name setting of all blocks into a code setting.
  *
  * @final since sonata-project/page-bundle 3.26
+ *
+ * NEXT_MAJOR: Remove this class
+ *
+ * @deprecated since 3.27, and it will be removed in 4.0.
  */
 class DumpPageCommand extends BaseCommand
 {
@@ -103,5 +107,19 @@ HELP
         foreach ($block->getChildren() as $block) {
             $this->renderBlock($block, $output, $extended, $space + 1);
         }
+    }
+
+    public function run(InputInterface $input, OutputInterface $output)
+    {
+        @trigger_error(
+            sprintf(
+                'This %s is deprecated since sonata-project/page-bundle 3.27.0'.
+                ' and it will be removed in 4.0',
+                self::class
+            ),
+            \E_USER_DEPRECATED
+        );
+
+        return parent::run($input, $output);
     }
 }

--- a/src/Command/RenderBlockCommand.php
+++ b/src/Command/RenderBlockCommand.php
@@ -23,6 +23,10 @@ use Symfony\Component\HttpFoundation\Request;
  * Migrates the name setting of all blocks into a code setting.
  *
  * @final since sonata-project/page-bundle 3.26
+ *
+ * NEXT_MAJOR: Remove this class
+ *
+ * @deprecated since 3.27, and it will be removed in 4.0.
  */
 class RenderBlockCommand extends BaseCommand
 {
@@ -87,5 +91,19 @@ HELP
         $this->getContainer()->leaveScope('request');
 
         return 0;
+    }
+
+    public function run(InputInterface $input, OutputInterface $output)
+    {
+        @trigger_error(
+            sprintf(
+                'This %s is deprecated since sonata-project/page-bundle 3.27.0'.
+                ' and it will be removed in 4.0',
+                self::class
+            ),
+            \E_USER_DEPRECATED
+        );
+
+        return parent::run($input, $output);
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Deprecate dump commands

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because those commands are not final in this release

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataPageBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecated `DumpPageCommand::class`
- Deprecated `RenderBlockCommand::class`
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->

It's related with this PR: https://github.com/sonata-project/SonataPageBundle/pull/1460#issuecomment-1185559382

and it'll be necessary to remove #1420 