### PR TITLE
Remove deprecated getConnection

### DIFF
--- a/src/Entity/SnapshotManager.php
+++ b/src/Entity/SnapshotManager.php
@@ -106,7 +106,7 @@ class SnapshotManager extends BaseEntityManager implements SnapshotManagerInterf
             implode(',', $pageIds)
         );
 
-        $this->getConnection()->query($sql);
+        $this->getEntityManager()->getConnection()->executeQuery($sql);
     }
 
     public function findEnableSnapshot(array $criteria)
@@ -230,10 +230,10 @@ class SnapshotManager extends BaseEntityManager implements SnapshotManagerInterf
         }
 
         $tableName = $this->getTableName();
-        $platform = $this->getConnection()->getDatabasePlatform()->getName();
+        $platform = $this->getEntityManager()->getConnection()->getDatabasePlatform()->getName();
 
         if ('mysql' === $platform) {
-            return $this->getConnection()->exec(sprintf(
+            return $this->getEntityManager()->getConnection()->executeStatement(sprintf(
                 'DELETE FROM %s
                 WHERE
                     page_id = %d
@@ -259,7 +259,7 @@ class SnapshotManager extends BaseEntityManager implements SnapshotManagerInterf
         }
 
         if ('oracle' === $platform) {
-            return $this->getConnection()->exec(sprintf(
+            return $this->getEntityManager()->getConnection()->executeStatement(sprintf(
                 'DELETE FROM %s
                 WHERE
                     page_id = %d

--- a/tests/Entity/SnapshotManagerTest.php
+++ b/tests/Entity/SnapshotManagerTest.php
@@ -116,7 +116,7 @@ final class SnapshotManagerTest extends TestCase
         $connection = $this->createMock(Connection::class);
         $connection
             ->expects(static::once())
-            ->method('query')
+            ->method('executeQuery')
             ->with(sprintf(
                 "UPDATE page_snapshot SET publication_date_end = '%s' WHERE id NOT IN(123) AND page_id IN (456) and publication_date_end IS NULL",
                 $date->format('Y-m-d H:i:s')
@@ -165,7 +165,7 @@ final class SnapshotManagerTest extends TestCase
     public function testEnableSnapshotsWhenNoSnapshots(): void
     {
         $connection = $this->createMock(Connection::class);
-        $connection->expects(static::never())->method('query');
+        $connection->expects(static::never())->method('executeQuery');
 
         $em = $this->createMock(EntityManagerInterface::class);
         $em->expects(static::never())->method('persist');


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Remove deprecated getConnection #1417

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because "BaseEntityManager::getConnection" method is deprecated since sonata-project/sonata-doctrine-extensions 1.15 and we need to update the code for the next major

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1417

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataPageBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added

### Changed

### Deprecated

### Removed
- Removed usage of deprecated `BaseEntityManager::getConnection` class

### Fixed

### Security
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
