### PR TITLE
Mark classes as final

### DIFF
--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -1,6 +1,10 @@
 UPGRADE FROM 3.x to 4.0
 =======================
 
+## Final classes
+
+All classes that were marked as final in 3.x are now marked final in 4.0.
+
 ## Deprecations
 
 All the deprecated code introduced on 3.x is removed on 4.0.

--- a/src/Admin/BlockAdmin.php
+++ b/src/Admin/BlockAdmin.php
@@ -32,10 +32,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  * Admin class for the Block model.
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class BlockAdmin extends BaseBlockAdmin
+final class BlockAdmin extends BaseBlockAdmin
 {
     /**
      * @var array

--- a/src/Admin/Extension/CreateSnapshotAdminExtension.php
+++ b/src/Admin/Extension/CreateSnapshotAdminExtension.php
@@ -19,10 +19,7 @@ use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\PageBundle\Model\PageInterface;
 use Sonata\PageBundle\Service\Contract\CreateSnapshotByPageInterface;
 
-/**
- * @final since sonata-project/page-bundle 3.26
- */
-class CreateSnapshotAdminExtension extends AbstractAdminExtension
+final class CreateSnapshotAdminExtension extends AbstractAdminExtension
 {
     protected CreateSnapshotByPageInterface $createSnapshotByPage;
 

--- a/src/Admin/PageAdmin.php
+++ b/src/Admin/PageAdmin.php
@@ -39,10 +39,8 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
  * Admin definition for the Page class.
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class PageAdmin extends AbstractAdmin
+final class PageAdmin extends AbstractAdmin
 {
     protected $classnameLabel = 'Page';
 

--- a/src/Admin/SharedBlockAdmin.php
+++ b/src/Admin/SharedBlockAdmin.php
@@ -26,10 +26,8 @@ use Sonata\PageBundle\Mapper\PageFormMapper;
  * Admin class for shared Block model.
  *
  * @author Romain Mouillard <romain.mouillard@gmail.com>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class SharedBlockAdmin extends BaseBlockAdmin
+final class SharedBlockAdmin extends BaseBlockAdmin
 {
     /**
      * @var string

--- a/src/Admin/SiteAdmin.php
+++ b/src/Admin/SiteAdmin.php
@@ -28,10 +28,8 @@ use Symfony\Component\Form\Extension\Core\Type\TextareaType;
  * Admin definition for the Site class.
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class SiteAdmin extends AbstractAdmin
+final class SiteAdmin extends AbstractAdmin
 {
     protected $classnameLabel = 'Site';
 

--- a/src/Admin/SnapshotAdmin.php
+++ b/src/Admin/SnapshotAdmin.php
@@ -23,10 +23,8 @@ use Sonata\Form\Type\DateTimePickerType;
  * Admin definition for the Snapshot class.
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class SnapshotAdmin extends AbstractAdmin
+final class SnapshotAdmin extends AbstractAdmin
 {
     protected $classnameLabel = 'Snapshot';
 

--- a/src/Block/BlockContextManager.php
+++ b/src/Block/BlockContextManager.php
@@ -22,10 +22,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  *
  * @psalm-suppress InvalidExtendClass
  * @phpstan-ignore-next-line
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class BlockContextManager extends BaseBlockContextManager
+final class BlockContextManager extends BaseBlockContextManager
 {
     protected function configureSettings(OptionsResolver $optionsResolver, BlockInterface $block): void
     {

--- a/src/Block/BreadcrumbBlockService.php
+++ b/src/Block/BreadcrumbBlockService.php
@@ -27,10 +27,8 @@ use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
  * BlockService for homepage breadcrumb.
  *
  * @author Sylvain Deloux <sylvain.deloux@ekino.com>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class BreadcrumbBlockService extends BaseBreadcrumbMenuBlockService
+final class BreadcrumbBlockService extends BaseBreadcrumbMenuBlockService
 {
     /**
      * @var CmsManagerSelectorInterface

--- a/src/CmsManager/CmsManagerSelector.php
+++ b/src/CmsManager/CmsManagerSelector.php
@@ -27,15 +27,13 @@ use Symfony\Component\Security\Http\Logout\LogoutHandlerInterface;
  *   - sonata.page.cms.snapshot if the user is a standard user.
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class CmsManagerSelector implements CmsManagerSelectorInterface, LogoutHandlerInterface
+final class CmsManagerSelector implements CmsManagerSelectorInterface, LogoutHandlerInterface
 {
     /**
      * @var ContainerInterface
      */
-    protected $container;
+    private $container;
 
     /**
      * @psalm-suppress ContainerDependency

--- a/src/CmsManager/CmsPageManager.php
+++ b/src/CmsManager/CmsPageManager.php
@@ -24,10 +24,8 @@ use Sonata\PageBundle\Model\SiteInterface;
  * The CmsPageManager class is in charge of retrieving the correct page (cms page or action page).
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class CmsPageManager extends BaseCmsPageManager
+final class CmsPageManager extends BaseCmsPageManager
 {
     /**
      * @var BlockInteractorInterface

--- a/src/CmsManager/CmsSnapshotManager.php
+++ b/src/CmsManager/CmsSnapshotManager.php
@@ -26,10 +26,8 @@ use Sonata\PageBundle\Model\TransformerInterface;
  * The CmsSnapshotManager class is in charge of retrieving the correct page (cms page or action page).
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class CmsSnapshotManager extends BaseCmsPageManager
+final class CmsSnapshotManager extends BaseCmsPageManager
 {
     /**
      * @var SnapshotManagerInterface

--- a/src/CmsManager/DecoratorStrategy.php
+++ b/src/CmsManager/DecoratorStrategy.php
@@ -22,25 +22,23 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
  * on the current request.
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class DecoratorStrategy implements DecoratorStrategyInterface
+final class DecoratorStrategy implements DecoratorStrategyInterface
 {
     /**
      * @var array
      */
-    protected $ignoreRoutes;
+    private $ignoreRoutes;
 
     /**
      * @var array
      */
-    protected $ignoreRoutePatterns;
+    private $ignoreRoutePatterns;
 
     /**
      * @var array
      */
-    protected $ignoreUriPatterns;
+    private $ignoreUriPatterns;
 
     public function __construct(array $ignoreRoutes, array $ignoreRoutePatterns, array $ignoreUriPatterns)
     {

--- a/src/Command/CleanupSnapshotsCommand.php
+++ b/src/Command/CleanupSnapshotsCommand.php
@@ -20,10 +20,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Cleanups the deprecated snapshots.
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class CleanupSnapshotsCommand extends BaseCommand
+final class CleanupSnapshotsCommand extends BaseCommand
 {
     protected static $defaultName = 'sonata:page:cleanup-snapshots';
 

--- a/src/Command/CreateSiteCommand.php
+++ b/src/Command/CreateSiteCommand.php
@@ -23,10 +23,8 @@ use Symfony\Component\Console\Question\Question;
  * Create a site.
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class CreateSiteCommand extends BaseCommand
+final class CreateSiteCommand extends BaseCommand
 {
     public function configure(): void
     {

--- a/src/Command/CreateSnapshotsCommand.php
+++ b/src/Command/CreateSnapshotsCommand.php
@@ -23,10 +23,8 @@ use Symfony\Component\Console\Output\OutputInterface;
  * Create snapshots for a site.
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class CreateSnapshotsCommand extends BaseCommand
+final class CreateSnapshotsCommand extends BaseCommand
 {
     protected static $defaultName = 'sonata:page:create-snapshots';
 

--- a/src/Command/DumpPageCommand.php
+++ b/src/Command/DumpPageCommand.php
@@ -23,13 +23,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * Migrates the name setting of all blocks into a code setting.
  *
- * @final since sonata-project/page-bundle 3.26
- *
  * NEXT_MAJOR: Remove this class
  *
  * @deprecated since 3.27, and it will be removed in 4.0.
  */
-class DumpPageCommand extends BaseCommand
+final class DumpPageCommand extends BaseCommand
 {
     public function configure(): void
     {

--- a/src/Command/MigrateBlockNameSettingCommand.php
+++ b/src/Command/MigrateBlockNameSettingCommand.php
@@ -22,10 +22,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Migrates the name setting of all blocks into a code setting.
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class MigrateBlockNameSettingCommand extends BaseCommand
+final class MigrateBlockNameSettingCommand extends BaseCommand
 {
     public const CONTAINER_TYPE = 'sonata.page.block.container';
 

--- a/src/Command/MigrateToJsonTypeCommand.php
+++ b/src/Command/MigrateToJsonTypeCommand.php
@@ -17,10 +17,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-/**
- * @final since sonata-project/page-bundle 3.26
- */
-class MigrateToJsonTypeCommand extends BaseCommand
+final class MigrateToJsonTypeCommand extends BaseCommand
 {
     public function configure(): void
     {

--- a/src/Command/RenderBlockCommand.php
+++ b/src/Command/RenderBlockCommand.php
@@ -22,13 +22,11 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * Migrates the name setting of all blocks into a code setting.
  *
- * @final since sonata-project/page-bundle 3.26
- *
  * NEXT_MAJOR: Remove this class
  *
  * @deprecated since 3.27, and it will be removed in 4.0.
  */
-class RenderBlockCommand extends BaseCommand
+final class RenderBlockCommand extends BaseCommand
 {
     public function configure(): void
     {

--- a/src/Command/UpdateCoreRoutesCommand.php
+++ b/src/Command/UpdateCoreRoutesCommand.php
@@ -24,10 +24,8 @@ use Symfony\Component\Console\Output\OutputInterface;
  * Update core routes by reading routing information.
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class UpdateCoreRoutesCommand extends BaseCommand
+final class UpdateCoreRoutesCommand extends BaseCommand
 {
     public function configure(): void
     {

--- a/src/Controller/AjaxController.php
+++ b/src/Controller/AjaxController.php
@@ -25,25 +25,23 @@ use Symfony\Component\HttpFoundation\Response;
  * Render a block in ajax.
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class AjaxController
+final class AjaxController
 {
     /**
      * @var CmsManagerSelectorInterface
      */
-    protected $cmsManagerSelector;
+    private $cmsManagerSelector;
 
     /**
      * @var BlockRendererInterface
      */
-    protected $blockRenderer;
+    private $blockRenderer;
 
     /**
      * @var BlockContextManagerInterface
      */
-    protected $contextManager;
+    private $contextManager;
 
     /**
      * @param CmsManagerSelectorInterface  $cmsManagerSelector CMS Manager selector

--- a/src/Controller/BlockAdminController.php
+++ b/src/Controller/BlockAdminController.php
@@ -25,10 +25,8 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
  * Block Admin Controller.
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class BlockAdminController extends Controller
+final class BlockAdminController extends Controller
 {
     /**
      * @throws AccessDeniedException

--- a/src/Controller/BlockController.php
+++ b/src/Controller/BlockController.php
@@ -20,10 +20,8 @@ use Symfony\Component\HttpFoundation\Response;
  * Block controller.
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class BlockController extends Controller
+final class BlockController extends Controller
 {
     /**
      * @return Response

--- a/src/Controller/PageAdminController.php
+++ b/src/Controller/PageAdminController.php
@@ -26,10 +26,8 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
  * Page Admin Controller.
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class PageAdminController extends Controller
+final class PageAdminController extends Controller
 {
     /**
      * @throws AccessDeniedException

--- a/src/Controller/PageController.php
+++ b/src/Controller/PageController.php
@@ -28,10 +28,8 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
  * Page controller.
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class PageController extends Controller
+final class PageController extends Controller
 {
     /**
      * @throws AccessDeniedException

--- a/src/Controller/SiteAdminController.php
+++ b/src/Controller/SiteAdminController.php
@@ -23,10 +23,8 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
  * Site Admin controller.
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class SiteAdminController extends Controller
+final class SiteAdminController extends Controller
 {
     /**
      * @throws NotFoundHttpException

--- a/src/Controller/SnapshotAdminController.php
+++ b/src/Controller/SnapshotAdminController.php
@@ -23,10 +23,8 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
  * Snapshot Admin Controller.
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class SnapshotAdminController extends Controller
+final class SnapshotAdminController extends Controller
 {
     public function createAction(?Request $request = null)
     {

--- a/src/DependencyInjection/Compiler/GlobalVariablesCompilerPass.php
+++ b/src/DependencyInjection/Compiler/GlobalVariablesCompilerPass.php
@@ -21,10 +21,8 @@ use Symfony\Component\DependencyInjection\Reference;
  * GlobalVariablesCompilerPass.
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class GlobalVariablesCompilerPass implements CompilerPassInterface
+final class GlobalVariablesCompilerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {

--- a/src/DependencyInjection/Compiler/PageServiceCompilerPass.php
+++ b/src/DependencyInjection/Compiler/PageServiceCompilerPass.php
@@ -21,20 +21,18 @@ use Symfony\Component\DependencyInjection\Reference;
  * Inject page services into page service manager.
  *
  * @author Olivier Paradis <paradis@ekino.com>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class PageServiceCompilerPass implements CompilerPassInterface
+final class PageServiceCompilerPass implements CompilerPassInterface
 {
     /**
      * @var string
      */
-    protected $manager = 'sonata.page.page_service_manager';
+    private $manager = 'sonata.page.page_service_manager';
 
     /**
      * @var string
      */
-    protected $tagName = 'sonata.page';
+    private $tagName = 'sonata.page';
 
     public function process(ContainerBuilder $container): void
     {

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -26,10 +26,8 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
  * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html#cookbook-bundles-extension-config-class}
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class Configuration implements ConfigurationInterface
+final class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder()
     {
@@ -315,7 +313,7 @@ EOF;
         return $treeBuilder;
     }
 
-    protected function getDeprecationMessage($message, $version): array
+    private function getDeprecationMessage($message, $version): array
     {
         if (method_exists(BaseNode::class, 'getDeprecation')) {
             return [

--- a/src/Entity/BlockInteractor.php
+++ b/src/Entity/BlockInteractor.php
@@ -23,25 +23,23 @@ use Sonata\PageBundle\Model\PageInterface;
  * This class interacts with blocks.
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class BlockInteractor implements BlockInteractorInterface
+final class BlockInteractor implements BlockInteractorInterface
 {
     /**
      * @var bool[]
      */
-    protected $pageBlocksLoaded = [];
+    private $pageBlocksLoaded = [];
 
     /**
      * @var ManagerRegistry
      */
-    protected $registry;
+    private $registry;
 
     /**
      * @var ManagerInterface
      */
-    protected $blockManager;
+    private $blockManager;
 
     /**
      * @param ManagerRegistry  $registry     Doctrine registry

--- a/src/Entity/BlockManager.php
+++ b/src/Entity/BlockManager.php
@@ -20,10 +20,8 @@ use Sonata\PageBundle\Model\BlockManagerInterface;
  * This class manages BlockInterface persistency with the Doctrine ORM.
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class BlockManager extends BaseEntityManager implements BlockManagerInterface
+final class BlockManager extends BaseEntityManager implements BlockManagerInterface
 {
     public function save($entity, $andFlush = true)
     {

--- a/src/Entity/PageManager.php
+++ b/src/Entity/PageManager.php
@@ -24,10 +24,8 @@ use Sonata\PageBundle\Model\SiteInterface;
  * This class manages PageInterface persistency with the Doctrine ORM.
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class PageManager extends BaseEntityManager implements PageManagerInterface
+final class PageManager extends BaseEntityManager implements PageManagerInterface
 {
     /**
      * @var array

--- a/src/Entity/SiteManager.php
+++ b/src/Entity/SiteManager.php
@@ -20,10 +20,8 @@ use Sonata\PageBundle\Model\SiteManagerInterface;
  * This class manages SiteInterface persistency with the Doctrine ORM.
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class SiteManager extends BaseEntityManager implements SiteManagerInterface
+final class SiteManager extends BaseEntityManager implements SiteManagerInterface
 {
     public function save($entity, $andFlush = true)
     {

--- a/src/Entity/SnapshotManager.php
+++ b/src/Entity/SnapshotManager.php
@@ -27,10 +27,8 @@ use Sonata\PageBundle\Model\TransformerInterface;
  * This class manages SnapshotInterface persistency with the Doctrine ORM.
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class SnapshotManager extends BaseEntityManager implements SnapshotManagerInterface
+final class SnapshotManager extends BaseEntityManager implements SnapshotManagerInterface
 {
     /**
      * @var array
@@ -285,7 +283,7 @@ class SnapshotManager extends BaseEntityManager implements SnapshotManagerInterf
         throw new \RuntimeException(sprintf('The %s database platform has not been tested yet. Please report us if it works and feel free to create a pull request to handle it ;-)', $platform));
     }
 
-    final public function createSnapshotPageProxy(TransformerInterface $transformer, SnapshotInterface $snapshot)
+    public function createSnapshotPageProxy(TransformerInterface $transformer, SnapshotInterface $snapshot)
     {
         return $this->snapshotPageProxyFactory
             ->create($this, $transformer, $snapshot);

--- a/src/Entity/Transformer.php
+++ b/src/Entity/Transformer.php
@@ -27,35 +27,33 @@ use Sonata\PageBundle\Model\TransformerInterface;
 
 /**
  * This class transform a SnapshotInterface into PageInterface.
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class Transformer implements TransformerInterface
+final class Transformer implements TransformerInterface
 {
     /**
      * @var SnapshotManagerInterface
      */
-    protected $snapshotManager;
+    private $snapshotManager;
 
     /**
      * @var PageManagerInterface
      */
-    protected $pageManager;
+    private $pageManager;
 
     /**
      * @var ManagerInterface
      */
-    protected $blockManager;
+    private $blockManager;
 
     /**
      * @var BlockInterface[]
      */
-    protected $children = [];
+    private $children = [];
 
     /**
      * @var ManagerRegistry
      */
-    protected $registry;
+    private $registry;
 
     public function __construct(SnapshotManagerInterface $snapshotManager, PageManagerInterface $pageManager, ManagerInterface $blockManager, ManagerRegistry $registry)
     {
@@ -238,7 +236,7 @@ class Transformer implements TransformerInterface
     /**
      * @return array
      */
-    protected function fixPageContent(array $content)
+    private function fixPageContent(array $content)
     {
         if (!\array_key_exists('title', $content)) {
             $content['title'] = null;
@@ -250,7 +248,7 @@ class Transformer implements TransformerInterface
     /**
      * @return array
      */
-    protected function fixBlockContent(array $content)
+    private function fixBlockContent(array $content)
     {
         if (!\array_key_exists('name', $content)) {
             $content['name'] = null;
@@ -262,7 +260,7 @@ class Transformer implements TransformerInterface
     /**
      * @return array
      */
-    protected function createBlocks(BlockInterface $block)
+    private function createBlocks(BlockInterface $block)
     {
         $content = [];
         $content['id'] = $block->getId();

--- a/src/Exception/InternalErrorException.php
+++ b/src/Exception/InternalErrorException.php
@@ -17,9 +17,7 @@ namespace Sonata\PageBundle\Exception;
  * Exception used to raise an internal error.
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class InternalErrorException extends \RuntimeException
+final class InternalErrorException extends \RuntimeException
 {
 }

--- a/src/Exception/PageNotFoundException.php
+++ b/src/Exception/PageNotFoundException.php
@@ -19,9 +19,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  * Exception used to handle a page not found situation.
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class PageNotFoundException extends NotFoundHttpException
+final class PageNotFoundException extends NotFoundHttpException
 {
 }

--- a/src/Form/Type/CreateSnapshotType.php
+++ b/src/Form/Type/CreateSnapshotType.php
@@ -20,10 +20,8 @@ use Symfony\Component\Form\FormBuilderInterface;
  * Select a Page.
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class CreateSnapshotType extends AbstractType
+final class CreateSnapshotType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/src/Form/Type/PageSelectorType.php
+++ b/src/Form/Type/PageSelectorType.php
@@ -26,10 +26,8 @@ use Symfony\Component\OptionsResolver\OptionsResolverInterface;
  * Select a page.
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class PageSelectorType extends AbstractType
+final class PageSelectorType extends AbstractType
 {
     /**
      * @var PageManagerInterface

--- a/src/Form/Type/PageTypeChoiceType.php
+++ b/src/Form/Type/PageTypeChoiceType.php
@@ -23,10 +23,8 @@ use Symfony\Component\OptionsResolver\OptionsResolverInterface;
  * Select a page type.
  *
  * @author Olivier Paradis <paradis.olivier@gmail.com>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class PageTypeChoiceType extends AbstractType
+final class PageTypeChoiceType extends AbstractType
 {
     /**
      * @var PageServiceManagerInterface

--- a/src/Form/Type/TemplateChoiceType.php
+++ b/src/Form/Type/TemplateChoiceType.php
@@ -23,10 +23,8 @@ use Symfony\Component\OptionsResolver\OptionsResolverInterface;
  * Select a template.
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class TemplateChoiceType extends AbstractType
+final class TemplateChoiceType extends AbstractType
 {
     /**
      * @var TemplateManagerInterface

--- a/src/Generator/Mustache.php
+++ b/src/Generator/Mustache.php
@@ -18,13 +18,11 @@ namespace Sonata\PageBundle\Generator;
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  *
- * @final since sonata-project/page-bundle 3.26
- *
  * @deprecated since 3.27, and it will be removed in 4.0.
  *
  * NEXT_MAJOR: Remove this class.
  */
-class Mustache
+final class Mustache
 {
     public function __construct()
     {

--- a/src/Listener/RequestListener.php
+++ b/src/Listener/RequestListener.php
@@ -27,25 +27,23 @@ use Symfony\Component\HttpKernel\Event\GetResponseEvent;
  * cms manager upon user permission.
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class RequestListener
+final class RequestListener
 {
     /**
      * @var CmsManagerSelectorInterface
      */
-    protected $cmsSelector;
+    private $cmsSelector;
 
     /**
      * @var SiteSelectorInterface
      */
-    protected $siteSelector;
+    private $siteSelector;
 
     /**
      * @var DecoratorStrategyInterface
      */
-    protected $decoratorStrategy;
+    private $decoratorStrategy;
 
     /**
      * @param CmsManagerSelectorInterface $cmsSelector       Cms manager selector

--- a/src/Model/PageManagerInterface.php
+++ b/src/Model/PageManagerInterface.php
@@ -38,5 +38,10 @@ interface PageManagerInterface extends ManagerInterface
      */
     public function loadPages(SiteInterface $site);
 
+    /**
+     * @return PageInterface[]
+     */
+    public function getHybridPages(SiteInterface $site);
+
     public function fixUrl(PageInterface $page);
 }

--- a/src/Model/SnapshotPageProxy.php
+++ b/src/Model/SnapshotPageProxy.php
@@ -17,10 +17,8 @@ namespace Sonata\PageBundle\Model;
  * SnapshotPageProxy.
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class SnapshotPageProxy implements SnapshotPageProxyInterface
+final class SnapshotPageProxy implements SnapshotPageProxyInterface
 {
     /**
      * @var SnapshotManagerInterface

--- a/src/Model/Template.php
+++ b/src/Model/Template.php
@@ -14,13 +14,9 @@ declare(strict_types=1);
 namespace Sonata\PageBundle\Model;
 
 /**
- * Template.
- *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class Template
+final class Template
 {
     public const TYPE_STATIC = 1;
 
@@ -28,17 +24,17 @@ class Template
     /**
      * @var string
      */
-    protected $path;
+    private $path;
 
     /**
      * @var string
      */
-    protected $name;
+    private $name;
 
     /**
      * @var array
      */
-    protected $containers;
+    private $containers;
 
     /**
      * @param string $name
@@ -109,7 +105,7 @@ class Template
     /**
      * @return array
      */
-    protected function normalize(array $meta)
+    private function normalize(array $meta)
     {
         return [
             'name' => $meta['name'] ?? 'n/a',

--- a/src/Page/PageServiceManager.php
+++ b/src/Page/PageServiceManager.php
@@ -26,25 +26,23 @@ use Symfony\Component\Routing\RouterInterface;
  * to handle the page rendering but it may also implement an alternate rendering method.
  *
  * @author Olivier Paradis <paradis.olivier@gmail.com>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class PageServiceManager implements PageServiceManagerInterface
+final class PageServiceManager implements PageServiceManagerInterface
 {
     /**
      * @var PageServiceInterface[]
      */
-    protected $services = [];
+    private $services = [];
 
     /**
      * @var PageServiceInterface|null
      */
-    protected $default;
+    private $default;
 
     /**
      * @var RouterInterface
      */
-    protected $router;
+    private $router;
 
     /**
      * @param RouterInterface $router Router
@@ -109,7 +107,7 @@ class PageServiceManager implements PageServiceManagerInterface
      *
      * @return Response
      */
-    protected function createResponse(PageInterface $page)
+    private function createResponse(PageInterface $page)
     {
         if ($page->getTarget()) {
             $page->addHeader('Location', $this->router->generate($page->getTarget()));

--- a/src/Page/Service/DefaultPageService.php
+++ b/src/Page/Service/DefaultPageService.php
@@ -25,10 +25,8 @@ use Symfony\Component\HttpFoundation\Response;
  * Note: this service is backward-compatible and functions like the old page renderer class.
  *
  * @author Olivier Paradis <paradis.olivier@gmail.com>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class DefaultPageService extends BasePageService
+final class DefaultPageService extends BasePageService
 {
     /**
      * @var TemplateManagerInterface

--- a/src/Request/RequestFactory.php
+++ b/src/Request/RequestFactory.php
@@ -15,10 +15,7 @@ namespace Sonata\PageBundle\Request;
 
 use Symfony\Component\HttpFoundation\Request;
 
-/**
- * @final since sonata-project/page-bundle 3.26
- */
-class RequestFactory
+final class RequestFactory
 {
     private static $types = [
         'host' => Request::class,

--- a/src/Request/SiteRequest.php
+++ b/src/Request/SiteRequest.php
@@ -16,13 +16,9 @@ namespace Sonata\PageBundle\Request;
 use Symfony\Component\HttpFoundation\Request as BaseRequest;
 
 /**
- * SiteRequest.
- *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class SiteRequest extends BaseRequest implements SiteRequestInterface
+final class SiteRequest extends BaseRequest implements SiteRequestInterface
 {
     public function setPathInfo($pathInfo): void
     {

--- a/src/Request/SiteRequestContext.php
+++ b/src/Request/SiteRequestContext.php
@@ -18,13 +18,9 @@ use Sonata\PageBundle\Site\SiteSelectorInterface;
 use Symfony\Component\Routing\RequestContext;
 
 /**
- * SiteRequestContext.
- *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class SiteRequestContext extends RequestContext implements SiteRequestContextInterface
+final class SiteRequestContext extends RequestContext implements SiteRequestContextInterface
 {
     /**
      * @var SiteSelectorInterface
@@ -73,12 +69,12 @@ class SiteRequestContext extends RequestContext implements SiteRequestContextInt
         return parent::getBaseUrl();
     }
 
-    final public function setSite(SiteInterface $site): void
+    public function setSite(SiteInterface $site): void
     {
         $this->site = $site;
     }
 
-    final public function getSite()
+    public function getSite()
     {
         if (!$this->site instanceof SiteInterface) {
             $this->site = $this->selector->retrieve();

--- a/src/Route/CmsPageRouter.php
+++ b/src/Route/CmsPageRouter.php
@@ -29,30 +29,27 @@ use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Routing\RouterInterface;
 
-/**
- * @final since sonata-project/page-bundle 3.26
- */
-class CmsPageRouter implements ChainedRouterInterface
+final class CmsPageRouter implements ChainedRouterInterface
 {
     /**
      * @var RequestContext
      */
-    protected $context;
+    private $context;
 
     /**
      * @var CmsManagerSelectorInterface
      */
-    protected $cmsSelector;
+    private $cmsSelector;
 
     /**
      * @var SiteSelectorInterface
      */
-    protected $siteSelector;
+    private $siteSelector;
 
     /**
      * @var RouterInterface
      */
-    protected $router;
+    private $router;
 
     /**
      * @param CmsManagerSelectorInterface $cmsSelector  Cms manager selector
@@ -180,7 +177,7 @@ class CmsPageRouter implements ChainedRouterInterface
      *
      * @return string
      */
-    protected function generateFromPage(PageInterface $page, array $parameters = [], $referenceType = self::ABSOLUTE_PATH)
+    private function generateFromPage(PageInterface $page, array $parameters = [], $referenceType = self::ABSOLUTE_PATH)
     {
         // hybrid pages use, by definition, the default routing mechanism
         if ($page->isHybrid()) {
@@ -225,7 +222,7 @@ class CmsPageRouter implements ChainedRouterInterface
      *
      * @return string
      */
-    protected function generateFromPageSlug(array $parameters = [], $referenceType = self::ABSOLUTE_PATH)
+    private function generateFromPageSlug(array $parameters = [], $referenceType = self::ABSOLUTE_PATH)
     {
         if (!isset($parameters['path'])) {
             throw new \RuntimeException('Please provide a `path` parameters');
@@ -248,7 +245,7 @@ class CmsPageRouter implements ChainedRouterInterface
      *
      * @return string
      */
-    protected function decorateUrl($url, array $parameters = [], $referenceType = self::ABSOLUTE_PATH)
+    private function decorateUrl($url, array $parameters = [], $referenceType = self::ABSOLUTE_PATH)
     {
         if (!$this->context) {
             throw new \RuntimeException('No context associated to the CmsPageRouter');
@@ -288,7 +285,7 @@ class CmsPageRouter implements ChainedRouterInterface
      *
      * @return string The relative target path
      */
-    protected function getRelativePath($basePath, $targetPath)
+    private function getRelativePath($basePath, $targetPath)
     {
         return UrlGenerator::getRelativePath($basePath, $targetPath);
     }
@@ -302,7 +299,7 @@ class CmsPageRouter implements ChainedRouterInterface
      *
      * @return \Sonata\PageBundle\Model\PageInterface|null
      */
-    protected function getPageByPageAlias($alias)
+    private function getPageByPageAlias($alias)
     {
         $site = $this->siteSelector->retrieve();
 
@@ -320,7 +317,7 @@ class CmsPageRouter implements ChainedRouterInterface
      *
      * @return string
      */
-    protected function getUrlFromPage(PageInterface $page)
+    private function getUrlFromPage(PageInterface $page)
     {
         return $page->getCustomUrl() ?: $page->getUrl();
     }
@@ -332,7 +329,7 @@ class CmsPageRouter implements ChainedRouterInterface
      *
      * @return bool
      */
-    protected function isPageAlias($name)
+    private function isPageAlias($name)
     {
         return \is_string($name) && '_page_alias_' === substr($name, 0, 12);
     }
@@ -344,7 +341,7 @@ class CmsPageRouter implements ChainedRouterInterface
      *
      * @return bool
      */
-    protected function isPageSlug($name)
+    private function isPageSlug($name)
     {
         return \is_string($name) && PageInterface::PAGE_ROUTE_CMS_NAME === $name;
     }

--- a/src/Route/RoutePageGenerator.php
+++ b/src/Route/RoutePageGenerator.php
@@ -25,30 +25,28 @@ use Symfony\Component\Routing\RouterInterface;
  * This is the page generator service from existing routes.
  *
  * @author Vincent Composieux <vincent.composieux@gmail.com>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class RoutePageGenerator
+final class RoutePageGenerator
 {
     /**
      * @var RouterInterface
      */
-    protected $router;
+    private $router;
 
     /**
      * @var PageManagerInterface
      */
-    protected $pageManager;
+    private $pageManager;
 
     /**
      * @var DecoratorStrategyInterface
      */
-    protected $decoratorStrategy;
+    private $decoratorStrategy;
 
     /**
      * @var ExceptionListener
      */
-    protected $exceptionListener;
+    private $exceptionListener;
 
     /**
      * @param RouterInterface            $router            A Symfony router service
@@ -239,7 +237,7 @@ MSG
      * @param OutputInterface|null $output  A Symfony console output instance
      * @param string               $message A string message to output
      */
-    protected function writeln(?OutputInterface $output, $message): void
+    private function writeln(?OutputInterface $output, $message): void
     {
         if ($output instanceof OutputInterface) {
             $output->writeln($message);

--- a/src/Service/CreateSnapshotService.php
+++ b/src/Service/CreateSnapshotService.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\PageBundle\Service;
 
+use Sonata\Doctrine\Entity\BaseEntityManager;
 use Sonata\PageBundle\Model\PageInterface;
 use Sonata\PageBundle\Model\PageManagerInterface;
 use Sonata\PageBundle\Model\SiteInterface;
@@ -42,18 +43,19 @@ final class CreateSnapshotService implements CreateSnapshotBySiteInterface, Crea
 
     public function createBySite(SiteInterface $site): void
     {
-        $entityManager = $this->snapshotManager->getEntityManager();
         $pages = $this->pageManager->findBy(['site' => $site->getId()]);
 
-        // start a transaction
-        $entityManager->beginTransaction();
+        if ($this->snapshotManager instanceof BaseEntityManager) {
+            $this->snapshotManager->getEntityManager()->beginTransaction();
+        }
 
         foreach ($pages as $page) {
             $this->createByPage($page);
         }
 
-        // commit the changes
-        $entityManager->commit();
+        if ($this->snapshotManager instanceof BaseEntityManager) {
+            $this->snapshotManager->getEntityManager()->beginTransaction();
+        }
     }
 
     public function createByPage(PageInterface $page): SnapshotInterface

--- a/src/Site/HostByLocaleSiteSelector.php
+++ b/src/Site/HostByLocaleSiteSelector.php
@@ -16,13 +16,9 @@ namespace Sonata\PageBundle\Site;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 
 /**
- * HostByLocaleSiteSelector.
- *
  * @author Rémi Marseille <marseille@ekino.com>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class HostByLocaleSiteSelector extends BaseSiteSelector
+final class HostByLocaleSiteSelector extends BaseSiteSelector
 {
     public function handleKernelRequest(GetResponseEvent $event): void
     {

--- a/src/Site/HostPathByLocaleSiteSelector.php
+++ b/src/Site/HostPathByLocaleSiteSelector.php
@@ -18,13 +18,9 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 
 /**
- * HostPathByLocaleSiteSelector.
- *
  * @author Rémi Marseille <marseille@ekino.com>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class HostPathByLocaleSiteSelector extends HostPathSiteSelector
+final class HostPathByLocaleSiteSelector extends HostPathSiteSelector
 {
     public function handleKernelRequest(GetResponseEvent $event): void
     {

--- a/src/Template/Matrix/Parser.php
+++ b/src/Template/Matrix/Parser.php
@@ -18,10 +18,8 @@ namespace Sonata\PageBundle\Template\Matrix;
  * computes string based template matrix to position/sise.
  *
  * @author Raphaël Benitte <raphael.benitte@fullsix.com>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class Parser
+final class Parser
 {
     /**
      * @param string $matrix

--- a/src/Twig/GlobalVariables.php
+++ b/src/Twig/GlobalVariables.php
@@ -18,18 +18,14 @@ use Sonata\PageBundle\Model\SiteInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * GlobalVariables.
- *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
- *
- * @final since sonata-project/page-bundle 3.26
  */
-class GlobalVariables
+final class GlobalVariables
 {
     /**
      * @var ContainerInterface
      */
-    protected $container;
+    private $container;
 
     /**
      * @psalm-suppress ContainerDependency

--- a/tests/Command/BaseCommandTest.php
+++ b/tests/Command/BaseCommandTest.php
@@ -15,7 +15,7 @@ namespace Sonata\PageBundle\Tests\Command;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\PageBundle\Command\BaseCommand;
-use Sonata\PageBundle\Entity\SiteManager;
+use Sonata\PageBundle\Model\SiteManagerInterface;
 use Symfony\Component\Console\Input\InputInterface;
 
 /**
@@ -48,7 +48,7 @@ final class BaseCommandTest extends TestCase
         $method->setAccessible(true);
 
         $input = $this->createMock(InputInterface::class);
-        $siteManager = $this->createMock(SiteManager::class);
+        $siteManager = $this->createMock(SiteManagerInterface::class);
 
         $this->command->method('getSiteManager')->willReturn($siteManager);
 

--- a/tests/Command/CreateBlockContainerCommandTest.php
+++ b/tests/Command/CreateBlockContainerCommandTest.php
@@ -16,10 +16,10 @@ namespace Sonata\PageBundle\Tests\Command;
 use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Sonata\PageBundle\Command\CreateBlockContainerCommand;
-use Sonata\PageBundle\Entity\BlockInteractor;
-use Sonata\PageBundle\Entity\BlockManager;
-use Sonata\PageBundle\Entity\PageManager;
+use Sonata\PageBundle\Model\BlockInteractorInterface;
+use Sonata\PageBundle\Model\BlockManagerInterface;
 use Sonata\PageBundle\Model\PageBlockInterface;
+use Sonata\PageBundle\Model\PageManagerInterface;
 use Sonata\PageBundle\Tests\Model\Page;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -33,17 +33,17 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 final class CreateBlockContainerCommandTest extends TestCase
 {
     /**
-     * @var Stub&BlockInteractor
+     * @var Stub&BlockInteractorInterface
      */
     protected $blockInteractor;
 
     /**
-     * @var Stub&PageManager
+     * @var Stub&PageManagerInterface
      */
     protected $pageManager;
 
     /**
-     * @var Stub&BlockManager
+     * @var Stub&BlockManagerInterface
      */
     protected $blockManager;
 
@@ -54,9 +54,9 @@ final class CreateBlockContainerCommandTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->blockInteractor = $this->createStub(BlockInteractor::class);
-        $this->pageManager = $this->createStub(PageManager::class);
-        $this->blockManager = $this->createStub(BlockManager::class);
+        $this->blockInteractor = $this->createStub(BlockInteractorInterface::class);
+        $this->pageManager = $this->createStub(PageManagerInterface::class);
+        $this->blockManager = $this->createStub(BlockManagerInterface::class);
         $this->container = $this->createStub(ContainerInterface::class);
 
         $this->container->method('get')->willReturnMap([

--- a/tests/Form/Type/TemplateChoiceTypeTest.php
+++ b/tests/Form/Type/TemplateChoiceTypeTest.php
@@ -47,7 +47,7 @@ final class TemplateChoiceTypeTest extends TestCase
     public function testGetOptions(): void
     {
         $this->manager->expects(static::atLeastOnce())->method('getAll')->willReturn([
-            'my_template' => $this->getMockTemplate('Template 1'),
+            'my_template' => $this->getTemplate('Template 1'),
         ]);
 
         $this->type->configureOptions(new OptionsResolver());
@@ -60,15 +60,8 @@ final class TemplateChoiceTypeTest extends TestCase
         );
     }
 
-    /**
-     * Returns the mock template.
-     */
-    protected function getMockTemplate(string $name, string $path = 'path/to/file'): MockObject
+    private function getTemplate(string $name, string $path = 'path/to/file'): Template
     {
-        $template = $this->createMock(Template::class);
-        $template->method('getName')->willReturn($name);
-        $template->method('getPath')->willReturn($path);
-
-        return $template;
+        return new Template($name, $path);
     }
 }

--- a/tests/Listener/ExceptionListenerTest.php
+++ b/tests/Listener/ExceptionListenerTest.php
@@ -104,7 +104,7 @@ final class ExceptionListenerTest extends TestCase
      */
     public function testInternalException(): void
     {
-        $exception = $this->createMock(InternalErrorException::class);
+        $exception = new InternalErrorException();
         $event = $this->getMockEvent($exception);
 
         $this->logger->expects(static::once())->method('error');

--- a/tests/Page/TemplateManagerTest.php
+++ b/tests/Page/TemplateManagerTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sonata\PageBundle\Tests\Page;
 
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sonata\PageBundle\Model\Template;
 use Sonata\PageBundle\Page\TemplateManager;
@@ -26,8 +25,7 @@ final class TemplateManagerTest extends TestCase
      */
     public function testAddSingleTemplate(): void
     {
-        /** @var Template|MockObject $template */
-        $template = $this->getMockTemplate('template');
+        $template = $this->getTemplate('template');
         $twig = $this->createMock(Environment::class);
         $manager = new TemplateManager($twig);
 
@@ -45,8 +43,8 @@ final class TemplateManagerTest extends TestCase
         $manager = new TemplateManager($twig);
 
         $templates = [
-            'test1' => $this->getMockTemplate('template'),
-            'test2' => $this->getMockTemplate('template'),
+            'test1' => $this->getTemplate('template'),
+            'test2' => $this->getTemplate('template'),
         ];
 
         $manager->setAll($templates);
@@ -74,7 +72,7 @@ final class TemplateManagerTest extends TestCase
      */
     public function testRenderResponse(): void
     {
-        $template = $this->getMockTemplate('template', 'path/to/template');
+        $template = $this->getTemplate('template', 'path/to/template');
 
         $twig = $this->createMock(Environment::class);
         $twig
@@ -120,7 +118,7 @@ final class TemplateManagerTest extends TestCase
             ->with(static::equalTo('path/to/default'))
             ->willReturn('response');
 
-        $template = $this->getMockTemplate('template', 'path/to/default');
+        $template = $this->getTemplate('template', 'path/to/default');
         $manager = new TemplateManager($twig);
         $manager->add('default', $template);
         $manager->setDefaultTemplateCode('default');
@@ -137,7 +135,7 @@ final class TemplateManagerTest extends TestCase
      */
     public function testRenderResponseWithDefaultParameters(): void
     {
-        $template = $this->getMockTemplate('template', 'path/to/template');
+        $template = $this->getTemplate('template', 'path/to/template');
 
         $twig = $this->createMock(Environment::class);
         $twig->expects(static::once())->method('render')
@@ -159,15 +157,8 @@ final class TemplateManagerTest extends TestCase
         );
     }
 
-    /**
-     * Returns the mock template.
-     */
-    protected function getMockTemplate(string $name, string $path = 'path/to/file'): MockObject
+    private function getTemplate(string $name, string $path = 'path/to/file'): Template
     {
-        $template = $this->createMock(Template::class);
-        $template->method('getName')->willReturn($name);
-        $template->method('getPath')->willReturn($path);
-
-        return $template;
+        return new Template($name, $path);
     }
 }

--- a/tests/Route/RoutePageGeneratorTest.php
+++ b/tests/Route/RoutePageGeneratorTest.php
@@ -17,8 +17,8 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Sonata\PageBundle\CmsManager\CmsManagerSelectorInterface;
 use Sonata\PageBundle\CmsManager\DecoratorStrategy;
-use Sonata\PageBundle\Entity\PageManager;
 use Sonata\PageBundle\Listener\ExceptionListener;
+use Sonata\PageBundle\Model\PageManagerInterface;
 use Sonata\PageBundle\Model\SiteInterface;
 use Sonata\PageBundle\Page\PageServiceManagerInterface;
 use Sonata\PageBundle\Route\RoutePageGenerator;
@@ -160,7 +160,7 @@ final class RoutePageGeneratorTest extends TestCase
     {
         $router = $this->getRouterMock();
 
-        $pageManager = $this->createMock(PageManager::class);
+        $pageManager = $this->createMock(PageManagerInterface::class);
         $pageManager->method('create')->willReturn(new Page());
 
         $hybridPageNotExists = new Page();

--- a/tests/Service/CleanupSnapshotServiceTest.php
+++ b/tests/Service/CleanupSnapshotServiceTest.php
@@ -13,12 +13,11 @@ declare(strict_types=1);
 
 namespace Sonata\PageBundle\Tests\Service;
 
-use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
-use Sonata\PageBundle\Entity\SnapshotManager;
 use Sonata\PageBundle\Model\PageInterface;
 use Sonata\PageBundle\Model\PageManagerInterface;
 use Sonata\PageBundle\Model\Site;
+use Sonata\PageBundle\Model\SnapshotManagerInterface;
 use Sonata\PageBundle\Service\CleanupSnapshotService;
 
 class CleanupSnapshotServiceTest extends TestCase
@@ -29,10 +28,7 @@ class CleanupSnapshotServiceTest extends TestCase
     public function testCallCleanupQuery(): void
     {
         //Mock
-        $snapshotManagerMock = $this->createMock(SnapshotManager::class);
-        $snapshotManagerMock
-            ->method('getEntityManager')
-            ->willReturn($this->createMock(EntityManagerInterface::class));
+        $snapshotManagerMock = $this->createMock(SnapshotManagerInterface::class);
 
         $snapshotManagerMock
             ->expects(static::once())

--- a/tests/Service/CreateSnapshotServiceTest.php
+++ b/tests/Service/CreateSnapshotServiceTest.php
@@ -13,13 +13,12 @@ declare(strict_types=1);
 
 namespace Sonata\PageBundle\Tests\Service;
 
-use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
-use Sonata\PageBundle\Entity\SnapshotManager;
 use Sonata\PageBundle\Model\PageInterface;
 use Sonata\PageBundle\Model\PageManagerInterface;
 use Sonata\PageBundle\Model\SiteInterface;
 use Sonata\PageBundle\Model\SnapshotInterface;
+use Sonata\PageBundle\Model\SnapshotManagerInterface;
 use Sonata\PageBundle\Model\TransformerInterface;
 use Sonata\PageBundle\Service\CreateSnapshotService;
 
@@ -28,10 +27,7 @@ final class CreateSnapshotServiceTest extends TestCase
     public function testCreateBySite(): void
     {
         //Mocks
-        $snapshotManagerMock = $this->createMock(SnapshotManager::class);
-        $snapshotManagerMock
-            ->method('getEntityManager')
-            ->willReturn($this->createMock(EntityManagerInterface::class));
+        $snapshotManagerMock = $this->createMock(SnapshotManagerInterface::class);
 
         $pageManagerMock = $this->createMock(PageManagerInterface::class);
         $pageManagerMock

--- a/tests/Site/BaseLocaleSiteSelectorTest.php
+++ b/tests/Site/BaseLocaleSiteSelectorTest.php
@@ -15,7 +15,6 @@ namespace Sonata\PageBundle\Tests\Site;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\PageBundle\Entity\BaseSite;
-use Sonata\PageBundle\Site\SiteSelectorInterface;
 
 /**
  * @author Rémi Marseille <marseille@ekino.com>
@@ -23,21 +22,6 @@ use Sonata\PageBundle\Site\SiteSelectorInterface;
 abstract class BaseLocaleSiteSelectorTest extends TestCase
 {
     /**
-     * @var SiteSelectorInterface
-     */
-    protected $siteSelector;
-
-    /**
-     * Cleanups the site selector.
-     */
-    protected function tearDown(): void
-    {
-        unset($this->siteSelector);
-    }
-
-    /**
-     * Gets fixtures of sites.
-     *
      * @return Site[]
      */
     protected function getSites(): array
@@ -59,14 +43,6 @@ abstract class BaseLocaleSiteSelectorTest extends TestCase
         $sites[1]->setLocale('en');
 
         return $sites;
-    }
-
-    /**
-     * Gets the site from site selector.
-     */
-    protected function getSite(): ?Site
-    {
-        return $this->siteSelector->retrieve();
     }
 }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC break.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

All classes that were marked as final are now final.