### PR TITLE
Remove target page code

### DIFF
--- a/src/Command/CloneSiteCommand.php
+++ b/src/Command/CloneSiteCommand.php
@@ -136,7 +136,14 @@ final class CloneSiteCommand extends BaseCommand
                 }
             }
 
+            //NEXT_MAJOR: Remove this target condition block.
             if ($page->getTarget()) {
+                @trigger_error(
+                    'target page is deprecate since sonata-project/page-bundle 3.27.0'.
+                    ', and it will be removed in 4.0',
+                    \E_USER_DEPRECATED
+                );
+
                 if (\array_key_exists($page->getTarget()->getId(), $pageClones)) {
                     $output->writeln(
                         sprintf(

--- a/src/Entity/Transformer.php
+++ b/src/Entity/Transformer.php
@@ -89,7 +89,13 @@ class Transformer implements TransformerInterface
             $snapshot->setParentId($page->getParent()->getId());
         }
 
+        //NEXT_MAJOR: Remove this "if" condition block.
         if ($page->getTarget()) {
+            @trigger_error(
+                'target page is deprecate since sonata-project/page-bundle 3.27.0'.
+                ', and it will be removed in 4.0',
+                \E_USER_DEPRECATED
+            );
             $snapshot->setTargetId($page->getTarget()->getId());
         }
 
@@ -108,7 +114,7 @@ class Transformer implements TransformerInterface
         $content['updated_at'] = $page->getUpdatedAt()->format('U');
         $content['slug'] = $page->getSlug();
         $content['parent_id'] = $page->getParent() ? $page->getParent()->getId() : null;
-        $content['target_id'] = $page->getTarget() ? $page->getTarget()->getId() : null;
+        $content['target_id'] = $page->getTarget() ? $page->getTarget()->getId() : null; //NEXT_MAJOR: Remove this line.
 
         $content['blocks'] = [];
         foreach ($page->getBlocks() as $block) {

--- a/src/Model/Page.php
+++ b/src/Model/Page.php
@@ -136,7 +136,11 @@ abstract class Page implements PageInterface
     protected $parents;
 
     /**
-     * @var PageInterface|null
+     * @var pageInterface|null
+     *
+     * NEXT_MAJOR: Remove this property
+     *
+     * @deprecated since 3.27 and it will be removed on 4.0
      */
     protected $target;
 
@@ -432,6 +436,12 @@ abstract class Page implements PageInterface
 
     public function getTarget()
     {
+        @trigger_error(
+            'target page is deprecate since sonata-project/page-bundle 3.27.0'.
+            ', and it will be removed in 4.0',
+            \E_USER_DEPRECATED
+        );
+
         return $this->target;
     }
 
@@ -447,6 +457,12 @@ abstract class Page implements PageInterface
      */
     public function setTarget(?PageInterface $target = null)
     {
+        @trigger_error(
+            'target page is deprecate since sonata-project/page-bundle 3.27.0'.
+            ', and it will be removed in 4.0',
+            \E_USER_DEPRECATED
+        );
+
         $this->target = $target;
     }
 

--- a/src/Model/PageInterface.php
+++ b/src/Model/PageInterface.php
@@ -201,12 +201,20 @@ interface PageInterface
     public function getBlocks();
 
     /**
-     * @param PageInterface|null $target
+     * @param pageInterface|null $target
+     *
+     * NEXT_MAJOR: Remove this method
+     *
+     * @deprecated since 3.27 and it will be removed on 4.0
      */
     public function setTarget(?self $target = null);
 
     /**
-     * @return PageInterface|null
+     * @return pageInterface|null
+     *
+     * NEXT_MAJOR: Remove this method
+     *
+     * @deprecated since 3.27 and it will be removed on 4.0
      */
     public function getTarget();
 

--- a/src/Model/Snapshot.php
+++ b/src/Model/Snapshot.php
@@ -112,11 +112,19 @@ abstract class Snapshot implements SnapshotInterface
 
     /**
      * @var PageInterface|null
+     *
+     * NEXT_MAJOR: Remove this method and remember to remove the field definition at "src/Resources/config/doctrine/BaseSnapshot.orm.xml"
+     *
+     * @deprecated since 3.27 and it will be removed on 4.0
      */
     protected $target;
 
     /**
      * @var int|null
+     *
+     * NEXT_MAJOR: Remove this method
+     *
+     * @deprecated since 3.27 and it will be removed on 4.0
      */
     protected $targetId;
 
@@ -296,6 +304,8 @@ abstract class Snapshot implements SnapshotInterface
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
      * @deprecated since sonata-project/page-bundle 2.4 and will be removed in 4.0
      */
     public function setSources($sources)
@@ -306,6 +316,8 @@ abstract class Snapshot implements SnapshotInterface
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
      * @deprecated since sonata-project/page-bundle 2.4 and will be removed in 4.0
      */
     public function getSource()
@@ -315,23 +327,67 @@ abstract class Snapshot implements SnapshotInterface
         return $this->sources;
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since 3.27 and it will be removed on 4.0
+     */
     public function setTarget($target)
     {
+        @trigger_error(
+            'target page is deprecate since sonata-project/page-bundle 3.27.0'.
+            ', and it will be removed in 4.0',
+            \E_USER_DEPRECATED
+        );
+
         $this->target = $target;
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since 3.27 and it will be removed on 4.0
+     */
     public function getTarget()
     {
+        @trigger_error(
+            'target page is deprecate since sonata-project/page-bundle 3.27.0'.
+            ', and it will be removed in 4.0',
+            \E_USER_DEPRECATED
+        );
+
         return $this->target;
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since 3.27 and it will be removed on 4.0
+     */
     public function setTargetId($targetId)
     {
+        @trigger_error(
+            'target page is deprecate since sonata-project/page-bundle 3.27.0'.
+            ', and it will be removed in 4.0',
+            \E_USER_DEPRECATED
+        );
+
         $this->targetId = $targetId;
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since 3.27 and it will be removed on 4.0
+     */
     public function getTargetId()
     {
+        @trigger_error(
+            'target page is deprecate since sonata-project/page-bundle 3.27.0'.
+            ', and it will be removed in 4.0',
+            \E_USER_DEPRECATED
+        );
+
         return $this->targetId;
     }
 

--- a/src/Model/SnapshotInterface.php
+++ b/src/Model/SnapshotInterface.php
@@ -18,13 +18,13 @@ namespace Sonata\PageBundle\Model;
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  *
- * @method int|null           getId()
- * @method int|null           getTargetId()
- * @method void               setTargetId(?int $targetId)
- * @method PageInterface|null getTarget()
- * @method void               setTarget(?PageInterface $target)
- * @method int|null           getParent()
- * @method void               setParentId(?int $parentId)
+ * @method int|null getId()
+ * @method int|null getTargetId()               NEXT_MAJOR: Remove this line.
+ * @method void     setTargetId(?int $targetId) NEXT_MAJOR: Remove this line.
+ * @method PageInterface|null getTarget(): NEXT_MAJOR: Remove this line.
+ * @method void     setTarget(?PageInterface $target) NEXT_MAJOR: Remove this line.
+ * @method int|null getParent()
+ * @method void     setParentId(?int $parentId)
  */
 interface SnapshotInterface
 {

--- a/src/Model/SnapshotPageProxy.php
+++ b/src/Model/SnapshotPageProxy.php
@@ -38,7 +38,11 @@ class SnapshotPageProxy implements SnapshotPageProxyInterface
     private $page;
 
     /**
-     * @var PageInterface|null
+     * @var pageInterface|null
+     *
+     * NEXT_MAJOR: Remove this method
+     *
+     * @deprecated since 3.27 and it will be removed on 4.0
      */
     private $target;
 
@@ -136,13 +140,35 @@ class SnapshotPageProxy implements SnapshotPageProxyInterface
         return $this->getPage()->getBlocks();
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since 3.27 and it will be removed on 4.0
+     */
     public function setTarget(?PageInterface $target = null)
     {
+        @trigger_error(
+            'target page is deprecate since sonata-project/page-bundle 3.27.0'.
+            ', and it will be removed in 4.0',
+            \E_USER_DEPRECATED
+        );
+
         $this->target = $target;
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since 3.27 and it will be removed on 4.0
+     */
     public function getTarget()
     {
+        @trigger_error(
+            'target page is deprecate since sonata-project/page-bundle 3.27.0'.
+            ', and it will be removed in 4.0',
+            \E_USER_DEPRECATED
+        );
+
         if (null === $this->target) {
             $content = $this->snapshot->getContent();
 

--- a/src/Page/PageServiceManager.php
+++ b/src/Page/PageServiceManager.php
@@ -108,10 +108,19 @@ class PageServiceManager implements PageServiceManagerInterface
      * Creates a base response for given page.
      *
      * @return Response
+     *
+     * @deprecated since 3.27, and it will be removed in 4.0.
+     *
+     * NEXT_MAJOR: Remove this method, and move the response for the method above.
      */
     protected function createResponse(PageInterface $page)
     {
         if ($page->getTarget()) {
+            @trigger_error(
+                'target page is deprecate since sonata-project/page-bundle 3.27.0'.
+                ', and it will be removed in 4.0',
+                \E_USER_DEPRECATED
+            );
             $page->addHeader('Location', $this->router->generate($page->getTarget()));
             $response = new Response('', 302, $page->getHeaders() ?: []);
         } else {

--- a/tests/Model/PageTest.php
+++ b/tests/Model/PageTest.php
@@ -159,6 +159,11 @@ final class PageTest extends TestCase
         static::assertFalse($page->hasRequestMethod('biloute'));
     }
 
+    /**
+     * NEXT_MAJOR: Remove legacy group.
+     *
+     * @group legacy
+     */
     public function testGetterSetter(): void
     {
         $page = new Page();
@@ -205,6 +210,7 @@ final class PageTest extends TestCase
 
         static::assertInstanceOf(SnapshotInterface::class, $page->getSnapshot());
 
+        //NEXT_MAJOR remove those target code.
         $page->setTarget($this->createMock(PageInterface::class));
         static::assertInstanceOf(PageInterface::class, $page->getTarget());
         $page->setTarget(null);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Remove old target page code

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because the target page need to be deprecated in 3.x first.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Issue #1481 .

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataPageBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecated target page code from `src/Command/CloneSiteCommand.php`
- Deprecated target page code from `src/Entity/Transformer.php`
- Deprecated `src/Model/Page::target` property
- Deprecated `src/Model/Page::getTarget()` method
- Deprecated `src/Model/Page::setTarget()` method
- Deprecated `src/Model/PageInterface::getTarget()` method
- Deprecated `src/Model/PageInterface::setTarget()` method
- Deprecated `src/Model/Snapshot::target` property
- Deprecated `src/Model/Snapshot::targetId` property
- Deprecated `src/Model/Snapshot::getTarget()` method
- Deprecated `src/Model/Snapshot::setTarget()` method
- Deprecated `src/Model/Snapshot::getTargetId()` method
- Deprecated `src/Model/Snapshot::setTargetId()` method
- Deprecated `src/Model/SnapshotPageProxy::target` property
- Deprecated `src/Model/SnapshotPageProxy::getTargetId()` method
- Deprecated `src/Model/SnapshotPageProxy::setTargetId()` method
- Deprecated `src/Page/PageServiceManager::createResponse()` method
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
