### PR TITLE
Avoid SonataBlockBundle deprecations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "doctrine/doctrine-bundle": "^2.5",
         "doctrine/persistence": "^2.1 || ^3.0",
         "sonata-project/admin-bundle": "^4.15",
-        "sonata-project/block-bundle": "^4.11",
+        "sonata-project/block-bundle": "^4.16",
         "sonata-project/doctrine-extensions": "^1.8",
         "sonata-project/doctrine-orm-admin-bundle": "^4.0",
         "sonata-project/form-extensions": "^1.4",

--- a/src/CmsManager/CmsSnapshotManager.php
+++ b/src/CmsManager/CmsSnapshotManager.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\PageBundle\CmsManager;
 
-use Sonata\BlockBundle\Util\RecursiveBlockIterator;
+use Sonata\BlockBundle\Util\RecursiveBlockIteratorIterator;
 use Sonata\PageBundle\Exception\PageNotFoundException;
 use Sonata\PageBundle\Model\PageBlockInterface;
 use Sonata\PageBundle\Model\PageInterface;
@@ -149,9 +149,9 @@ final class CmsSnapshotManager extends BaseCmsPageManager
      */
     private function loadBlocks(PageInterface $page): void
     {
-        $i = new \RecursiveIteratorIterator(new RecursiveBlockIterator($page->getBlocks()), \RecursiveIteratorIterator::SELF_FIRST);
+        $iterator = new RecursiveBlockIteratorIterator($page->getBlocks());
 
-        foreach ($i as $block) {
+        foreach ($iterator as $block) {
             $this->blocks[$block->getId()] = $block;
         }
     }

--- a/src/Entity/BlockInteractor.php
+++ b/src/Entity/BlockInteractor.php
@@ -148,7 +148,7 @@ final class BlockInteractor implements BlockInteractorInterface
                 continue;
             }
 
-            $blocks[$block->getParent()->getId()]->addChildren($block);
+            $blocks[$block->getParent()->getId()]->addChild($block);
         }
 
         $this->pageBlocksLoaded[$page->getId()] = true;

--- a/src/Entity/PageManager.php
+++ b/src/Entity/PageManager.php
@@ -132,7 +132,7 @@ final class PageManager extends BaseEntityManager implements PageManagerInterfac
                 continue;
             }
 
-            $pages[$parent->getId()]->addChildren($page);
+            $pages[$parent->getId()]->addChild($page);
         }
 
         return $pages;

--- a/src/Entity/Transformer.php
+++ b/src/Entity/Transformer.php
@@ -167,7 +167,7 @@ final class Transformer implements TransformerInterface
         $block->setUpdatedAt($updatedAt);
 
         foreach ($content['blocks'] as $child) {
-            $block->addChildren($this->loadBlock($child, $page));
+            $block->addChild($this->loadBlock($child, $page));
         }
 
         return $block;

--- a/src/Model/Block.php
+++ b/src/Model/Block.php
@@ -28,14 +28,14 @@ abstract class Block extends BaseBlock implements PageBlockInterface
      */
     protected $page;
 
-    public function addChildren(BlockInterface $children): void
+    public function addChild(BlockInterface $child): void
     {
-        $this->children[] = $children;
+        $this->children[] = $child;
 
-        $children->setParent($this);
+        $child->setParent($this);
 
-        if ($children instanceof PageBlockInterface) {
-            $children->setPage($this->getPage());
+        if ($child instanceof PageBlockInterface) {
+            $child->setPage($this->getPage());
         }
     }
 

--- a/src/Model/Page.php
+++ b/src/Model/Page.php
@@ -393,11 +393,11 @@ abstract class Page implements PageInterface
         return $this->updatedAt;
     }
 
-    public function addChildren(PageInterface $children): void
+    public function addChild(PageInterface $child): void
     {
-        $this->children[] = $children;
+        $this->children[] = $child;
 
-        $children->setParent($this);
+        $child->setParent($this);
     }
 
     public function getChildren()

--- a/src/Model/PageInterface.php
+++ b/src/Model/PageInterface.php
@@ -184,9 +184,9 @@ interface PageInterface
     public function getUpdatedAt();
 
     /**
-     * @param PageInterface $children
+     * @param PageInterface $child
      */
-    public function addChildren(self $children);
+    public function addChild(self $child);
 
     /**
      * @return Collection<array-key, PageInterface>

--- a/src/Model/SnapshotPageProxy.php
+++ b/src/Model/SnapshotPageProxy.php
@@ -86,9 +86,9 @@ final class SnapshotPageProxy implements SnapshotPageProxyInterface
         return $this->page;
     }
 
-    public function addChildren(PageInterface $children): void
+    public function addChild(PageInterface $child): void
     {
-        $this->getPage()->addChildren($children);
+        $this->getPage()->addChild($child);
     }
 
     public function setHeaders(array $headers = []): void

--- a/tests/CmsManager/CmsSnapshotManagerTest.php
+++ b/tests/CmsManager/CmsSnapshotManagerTest.php
@@ -14,16 +14,17 @@ declare(strict_types=1);
 namespace Sonata\PageBundle\Tests\CmsManager;
 
 use PHPUnit\Framework\TestCase;
-use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\PageBundle\CmsManager\CmsSnapshotManager;
 use Sonata\PageBundle\Exception\PageNotFoundException;
 use Sonata\PageBundle\Model\Block;
 use Sonata\PageBundle\Model\BlockInteractorInterface;
+use Sonata\PageBundle\Model\PageBlockInterface;
 use Sonata\PageBundle\Model\SiteInterface;
 use Sonata\PageBundle\Model\SnapshotInterface;
 use Sonata\PageBundle\Model\SnapshotManagerInterface;
 use Sonata\PageBundle\Model\SnapshotPageProxyInterface;
 use Sonata\PageBundle\Model\TransformerInterface;
+use Sonata\PageBundle\Tests\App\Entity\SonataPageBlock;
 use Sonata\PageBundle\Tests\Model\Page;
 
 final class SnapshotBlock extends Block
@@ -109,18 +110,16 @@ final class CmsSnapshotManagerTest extends TestCase
 
     public function testGetPageWithId(): void
     {
-        $cBlock = $this->createMock(BlockInterface::class);
-        $pBlock = $this->createMock(BlockInterface::class);
         $site = $this->createMock(SiteInterface::class);
         $page = $this->createMock(SnapshotPageProxyInterface::class);
         $snapshot = $this->createMock(SnapshotInterface::class);
 
-        $cBlock->method('hasChildren')->willReturn(false);
-        $cBlock->method('getId')->willReturn(2);
+        $cBlock = new SonataPageBlock();
+        $cBlock->setId(2);
 
-        $pBlock->method('getChildren')->willReturn([$cBlock]);
-        $pBlock->method('hasChildren')->willReturn(true);
-        $pBlock->method('getId')->willReturn(1);
+        $pBlock = new SonataPageBlock();
+        $pBlock->addChild($cBlock);
+        $pBlock->setId(1);
 
         $page->method('getBlocks')->willReturn([$pBlock]);
 
@@ -137,8 +136,8 @@ final class CmsSnapshotManagerTest extends TestCase
         $page = $this->manager->getPage($site, 1);
 
         static::assertInstanceOf(SnapshotPageProxyInterface::class, $page);
-        static::assertInstanceOf(BlockInterface::class, $this->manager->getBlock(1));
-        static::assertInstanceOf(BlockInterface::class, $this->manager->getBlock(2));
+        static::assertInstanceOf(PageBlockInterface::class, $this->manager->getBlock(1));
+        static::assertInstanceOf(PageBlockInterface::class, $this->manager->getBlock(2));
     }
 
     /**

--- a/tests/Entity/PageManagerTest.php
+++ b/tests/Entity/PageManagerTest.php
@@ -34,7 +34,7 @@ final class PageManagerTest extends TestCase
         $page2 = new Page();
         $page2->setName('Super! et toi ?');
 
-        $page1->addChildren($page2);
+        $page1->addChild($page2);
 
         $manager->fixUrl($page1);
 
@@ -43,7 +43,7 @@ final class PageManagerTest extends TestCase
 
         // if a parent page becomes a child page, then the slug and the url must be updated
         $parent = new Page();
-        $parent->addChildren($page1);
+        $parent->addChild($page1);
 
         $manager->fixUrl($parent);
 
@@ -83,8 +83,8 @@ final class PageManagerTest extends TestCase
         $child = new Page();
         $child->setName('foobar');
 
-        $bundle->addChildren($child);
-        $homepage->addChildren($bundle);
+        $bundle->addChild($child);
+        $homepage->addChild($bundle);
 
         $manager->fixUrl($child);
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this can only be applied to this branch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
