### PR TITLE
Use DateTimeInterface instead of DateTime

### DIFF
--- a/src/Command/CreateSiteCommand.php
+++ b/src/Command/CreateSiteCommand.php
@@ -103,8 +103,8 @@ EOT
         $site->setLocale('-' === $values['locale'] ? null : $values['locale']);
         $site->setEnabled(\in_array($values['enabled'], ['true', 1, '1'], true));
 
-        $info_enabledFrom = $site->getEnabledFrom() instanceof \DateTime ? $site->getEnabledFrom()->format('r') : 'ALWAYS';
-        $info_enabledTo = $site->getEnabledTo() instanceof \DateTime ? $site->getEnabledTo()->format('r') : 'ALWAYS';
+        $info_enabledFrom = $site->getEnabledFrom() instanceof \DateTimeInterface ? $site->getEnabledFrom()->format('r') : 'ALWAYS';
+        $info_enabledTo = $site->getEnabledTo() instanceof \DateTimeInterface ? $site->getEnabledTo()->format('r') : 'ALWAYS';
 
         $output->writeln(
             <<<INFO

--- a/src/Entity/SnapshotManager.php
+++ b/src/Entity/SnapshotManager.php
@@ -48,7 +48,7 @@ final class SnapshotManager extends BaseEntityManager implements SnapshotManager
         $this->snapshotPageProxyFactory = $snapshotPageProxyFactory;
     }
 
-    public function enableSnapshots(array $snapshots, ?\DateTime $date = null): void
+    public function enableSnapshots(array $snapshots, ?\DateTimeInterface $date = null): void
     {
         if (0 === \count($snapshots)) {
             return;

--- a/src/Model/Page.php
+++ b/src/Model/Page.php
@@ -29,12 +29,12 @@ abstract class Page implements PageInterface
     protected $id;
 
     /**
-     * @var \DateTime
+     * @var \DateTimeInterface|null
      */
     protected $createdAt;
 
     /**
-     * @var \DateTime
+     * @var \DateTimeInterface|null
      */
     protected $updatedAt;
 
@@ -373,7 +373,7 @@ abstract class Page implements PageInterface
         return $this->headers;
     }
 
-    public function setCreatedAt(?\DateTime $createdAt = null): void
+    public function setCreatedAt(?\DateTimeInterface $createdAt = null): void
     {
         $this->createdAt = $createdAt;
     }
@@ -383,7 +383,7 @@ abstract class Page implements PageInterface
         return $this->createdAt;
     }
 
-    public function setUpdatedAt(?\DateTime $updatedAt = null): void
+    public function setUpdatedAt(?\DateTimeInterface $updatedAt = null): void
     {
         $this->updatedAt = $updatedAt;
     }

--- a/src/Model/PageInterface.php
+++ b/src/Model/PageInterface.php
@@ -163,23 +163,17 @@ interface PageInterface
      */
     public function getStylesheet();
 
-    /**
-     * @param \DateTime $createdAt
-     */
-    public function setCreatedAt(?\DateTime $createdAt = null);
+    public function setCreatedAt(?\DateTimeInterface $createdAt = null);
 
     /**
-     * @return \DateTime $createdAt
+     * @return \DateTimeInterface|null
      */
     public function getCreatedAt();
 
-    /**
-     * @param \DateTime $updatedAt
-     */
-    public function setUpdatedAt(?\DateTime $updatedAt = null);
+    public function setUpdatedAt(?\DateTimeInterface $updatedAt = null);
 
     /**
-     * @return \DateTime $updatedAt
+     * @return \DateTimeInterface|null
      */
     public function getUpdatedAt();
 

--- a/src/Model/Site.php
+++ b/src/Model/Site.php
@@ -31,12 +31,12 @@ abstract class Site implements SiteInterface
     protected $enabled;
 
     /**
-     * @var \DateTime
+     * @var \DateTimeInterface|null
      */
     protected $createdAt;
 
     /**
-     * @var \DateTime
+     * @var \DateTimeInterface|null
      */
     protected $updatedAt;
 
@@ -56,12 +56,12 @@ abstract class Site implements SiteInterface
     protected $relativePath;
 
     /**
-     * @var \DateTime|null
+     * @var \DateTimeInterface|null
      */
     protected $enabledFrom;
 
     /**
-     * @var \DateTime|null
+     * @var \DateTimeInterface|null
      */
     protected $enabledTo;
 
@@ -124,11 +124,11 @@ abstract class Site implements SiteInterface
     {
         $now = new \DateTime();
 
-        if ($this->getEnabledFrom() instanceof \DateTime && $this->getEnabledFrom()->format('U') > $now->format('U')) {
+        if ($this->getEnabledFrom() instanceof \DateTimeInterface && $this->getEnabledFrom()->format('U') > $now->format('U')) {
             return false;
         }
 
-        if ($this->getEnabledTo() instanceof \DateTime && $now->format('U') > $this->getEnabledTo()->format('U')) {
+        if ($this->getEnabledTo() instanceof \DateTimeInterface && $now->format('U') > $this->getEnabledTo()->format('U')) {
             return false;
         }
 
@@ -152,7 +152,7 @@ abstract class Site implements SiteInterface
         return 'localhost' === $this->getHost();
     }
 
-    public function setCreatedAt(?\DateTime $createdAt = null): void
+    public function setCreatedAt(?\DateTimeInterface $createdAt = null): void
     {
         $this->createdAt = $createdAt;
     }
@@ -162,7 +162,7 @@ abstract class Site implements SiteInterface
         return $this->createdAt;
     }
 
-    public function setUpdatedAt(?\DateTime $updatedAt = null): void
+    public function setUpdatedAt(?\DateTimeInterface $updatedAt = null): void
     {
         $this->updatedAt = $updatedAt;
     }
@@ -222,7 +222,7 @@ abstract class Site implements SiteInterface
         return $this->isDefault;
     }
 
-    public function setEnabledFrom(?\DateTime $enabledFrom = null): void
+    public function setEnabledFrom(?\DateTimeInterface $enabledFrom = null): void
     {
         $this->enabledFrom = $enabledFrom;
     }
@@ -232,7 +232,7 @@ abstract class Site implements SiteInterface
         return $this->enabledFrom;
     }
 
-    public function setEnabledTo(?\DateTime $enabledTo = null): void
+    public function setEnabledTo(?\DateTimeInterface $enabledTo = null): void
     {
         $this->enabledTo = $enabledTo;
     }

--- a/src/Model/SiteInterface.php
+++ b/src/Model/SiteInterface.php
@@ -58,18 +58,18 @@ interface SiteInterface
     public function setLocale($locale);
 
     /**
-     * @return \DateTime|null
+     * @return \DateTimeInterface|null
      */
     public function getEnabledFrom();
 
-    public function setEnabledFrom(?\DateTime $enabledFrom = null);
+    public function setEnabledFrom(?\DateTimeInterface $enabledFrom = null);
 
     /**
-     * @return \DateTime|null
+     * @return \DateTimeInterface|null
      */
     public function getEnabledTo();
 
-    public function setEnabledTo(?\DateTime $enabledTo = null);
+    public function setEnabledTo(?\DateTimeInterface $enabledTo = null);
 
     /**
      * @return bool
@@ -108,17 +108,17 @@ interface SiteInterface
      */
     public function isEnabled();
 
-    public function setCreatedAt(?\DateTime $createdAt = null);
+    public function setCreatedAt(?\DateTimeInterface $createdAt = null);
 
     /**
-     * @return \DateTime $createdAt
+     * @return \DateTimeInterface|null
      */
     public function getCreatedAt();
 
-    public function setUpdatedAt(?\DateTime $updatedAt = null);
+    public function setUpdatedAt(?\DateTimeInterface $updatedAt = null);
 
     /**
-     * @return \DateTime $updatedAt
+     * @return \DateTimeInterface|null
      */
     public function getUpdatedAt();
 

--- a/src/Model/Snapshot.php
+++ b/src/Model/Snapshot.php
@@ -21,12 +21,12 @@ namespace Sonata\PageBundle\Model;
 abstract class Snapshot implements SnapshotInterface
 {
     /**
-     * @var \DateTime
+     * @var \DateTimeInterface|null
      */
     protected $createdAt;
 
     /**
-     * @var \DateTime
+     * @var \DateTimeInterface|null
      */
     protected $updatedAt;
 
@@ -61,12 +61,12 @@ abstract class Snapshot implements SnapshotInterface
     protected $enabled;
 
     /**
-     * @var \DateTime|null
+     * @var \DateTimeInterface|null
      */
     protected $publicationDateStart;
 
     /**
-     * @var \DateTime|null
+     * @var \DateTimeInterface|null
      */
     protected $publicationDateEnd;
 
@@ -170,7 +170,7 @@ abstract class Snapshot implements SnapshotInterface
         return $this->name;
     }
 
-    public function setPublicationDateStart(?\DateTime $publicationDateStart = null): void
+    public function setPublicationDateStart(?\DateTimeInterface $publicationDateStart = null): void
     {
         $this->publicationDateStart = $publicationDateStart;
     }
@@ -180,7 +180,7 @@ abstract class Snapshot implements SnapshotInterface
         return $this->publicationDateStart;
     }
 
-    public function setPublicationDateEnd(?\DateTime $publicationDateEnd = null): void
+    public function setPublicationDateEnd(?\DateTimeInterface $publicationDateEnd = null): void
     {
         $this->publicationDateEnd = $publicationDateEnd;
     }
@@ -190,7 +190,7 @@ abstract class Snapshot implements SnapshotInterface
         return $this->publicationDateEnd;
     }
 
-    public function setCreatedAt(?\DateTime $createdAt = null): void
+    public function setCreatedAt(?\DateTimeInterface $createdAt = null): void
     {
         $this->createdAt = $createdAt;
     }
@@ -200,7 +200,7 @@ abstract class Snapshot implements SnapshotInterface
         return $this->createdAt;
     }
 
-    public function setUpdatedAt(?\DateTime $updatedAt = null): void
+    public function setUpdatedAt(?\DateTimeInterface $updatedAt = null): void
     {
         $this->updatedAt = $updatedAt;
     }

--- a/src/Model/SnapshotInterface.php
+++ b/src/Model/SnapshotInterface.php
@@ -91,37 +91,31 @@ interface SnapshotInterface
      */
     public function getUrl();
 
-    public function setPublicationDateStart(?\DateTime $publicationDateStart = null);
+    public function setPublicationDateStart(?\DateTimeInterface $publicationDateStart = null);
 
     /**
-     * @return \DateTime|null $publicationDateStart
+     * @return \DateTimeInterface|null
      */
     public function getPublicationDateStart();
 
-    public function setPublicationDateEnd(?\DateTime $publicationDateEnd = null);
+    public function setPublicationDateEnd(?\DateTimeInterface $publicationDateEnd = null);
 
     /**
-     * @return \DateTime|null $publicationDateEnd
+     * @return \DateTimeInterface|null
      */
     public function getPublicationDateEnd();
 
-    /**
-     * @param \DateTime $createdAt
-     */
-    public function setCreatedAt(?\DateTime $createdAt = null);
+    public function setCreatedAt(?\DateTimeInterface $createdAt = null);
 
     /**
-     * @return \DateTime $createdAt
+     * @return \DateTimeInterface|null
      */
     public function getCreatedAt();
 
-    /**
-     * @param \DateTime $updatedAt
-     */
-    public function setUpdatedAt(?\DateTime $updatedAt = null);
+    public function setUpdatedAt(?\DateTimeInterface $updatedAt = null);
 
     /**
-     * @return \DateTime $updatedAt
+     * @return \DateTimeInterface|null
      */
     public function getUpdatedAt();
 

--- a/src/Model/SnapshotManagerInterface.php
+++ b/src/Model/SnapshotManagerInterface.php
@@ -30,10 +30,9 @@ interface SnapshotManagerInterface extends ManagerInterface
     public function findEnableSnapshot(array $criteria);
 
     /**
-     * @param array          $snapshots A snapshots array to enable
-     * @param \DateTime|null $date      A date instance
+     * @param array $snapshots A snapshots array to enable
      */
-    public function enableSnapshots(array $snapshots, ?\DateTime $date = null);
+    public function enableSnapshots(array $snapshots, ?\DateTimeInterface $date = null);
 
     public function createSnapshotPageProxy(TransformerInterface $transformer, SnapshotInterface $snapshot): SnapshotPageProxyInterface;
 

--- a/src/Model/SnapshotPageProxy.php
+++ b/src/Model/SnapshotPageProxy.php
@@ -353,7 +353,7 @@ final class SnapshotPageProxy implements SnapshotPageProxyInterface
         return $this->getPage()->setPageAlias($pageAlias);
     }
 
-    public function setCreatedAt(?\DateTime $createdAt = null): void
+    public function setCreatedAt(?\DateTimeInterface $createdAt = null): void
     {
         $this->getPage()->setCreatedAt($createdAt);
     }
@@ -363,7 +363,7 @@ final class SnapshotPageProxy implements SnapshotPageProxyInterface
         return $this->getPage()->getCreatedAt();
     }
 
-    public function setUpdatedAt(?\DateTime $updatedAt = null): void
+    public function setUpdatedAt(?\DateTimeInterface $updatedAt = null): void
     {
         $this->getPage()->setUpdatedAt($updatedAt);
     }

--- a/tests/Functional/Snapshot/SnapshotManagerTest.php
+++ b/tests/Functional/Snapshot/SnapshotManagerTest.php
@@ -181,7 +181,7 @@ final class SnapshotManagerTest extends KernelTestCase
         static::assertNull($repo->find(789));
     }
 
-    public static function assertDateTimeEquals(\DateTime $expected, \DateTime $actual)
+    public static function assertDateTimeEquals(\DateTimeInterface $expected, \DateTimeInterface $actual)
     {
         static::assertSame($expected->format('c'), $actual->format('c'));
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC break.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Doing the PHPStan level 6 I saw a lof of DateTime typing, changed all of them for the interface, so we can use immutable if we want later.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataPageBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Changed from `\DateTime` to `\DateTimeInterface` on all the codebase.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
