### PR TITLE
Remove more deprecated code

### DIFF
--- a/src/Entity/SnapshotManager.php
+++ b/src/Entity/SnapshotManager.php
@@ -19,7 +19,6 @@ use Sonata\Doctrine\Entity\BaseEntityManager;
 use Sonata\PageBundle\Model\PageInterface;
 use Sonata\PageBundle\Model\SnapshotInterface;
 use Sonata\PageBundle\Model\SnapshotManagerInterface;
-use Sonata\PageBundle\Model\SnapshotPageProxy;
 use Sonata\PageBundle\Model\SnapshotPageProxyFactoryInterface;
 use Sonata\PageBundle\Model\SnapshotPageProxyInterface;
 use Sonata\PageBundle\Model\TransformerInterface;
@@ -122,45 +121,6 @@ final class SnapshotManager extends BaseEntityManager implements SnapshotManager
         $query->setParameters($parameters);
 
         return $query->getQuery()->getOneOrNullResult();
-    }
-
-    /**
-     * return a page with the given routeName.
-     *
-     * @param string $routeName
-     *
-     * @return PageInterface|false
-     *
-     * @deprecated since sonata-project/page-bundle 3.2, to be removed in 4.0
-     */
-    public function getPageByName($routeName)
-    {
-        @trigger_error(
-            'The '.__METHOD__.' method is deprecated since version 3.2 and will be removed in 4.0.',
-            \E_USER_DEPRECATED
-        );
-
-        $snapshots = $this->getEntityManager()->createQueryBuilder()
-            ->select('s')
-            ->from($this->class, 's')
-            ->where('s.routeName = :routeName')
-            ->setParameters([
-                'routeName' => $routeName,
-            ])
-            ->getQuery()
-            ->execute();
-
-        $snapshot = \count($snapshots) > 0 ? $snapshots[0] : false;
-
-        if ($snapshot) {
-            /**
-             * @phpstan-ignore-next-line
-             * @psalm-suppress TooFewArguments
-             */
-            return new SnapshotPageProxy($this, $snapshot);
-        }
-
-        return false;
     }
 
     public function cleanup(PageInterface $page, $keep)

--- a/src/Model/Page.php
+++ b/src/Model/Page.php
@@ -124,11 +124,6 @@ abstract class Page implements PageInterface
     protected $blocks;
 
     /**
-     * @deprecated This property is deprecated since sonata-project/page-bundle 2.4 and will be removed in 4.0
-     */
-    protected $sources;
-
-    /**
      * @var PageInterface|null
      */
     protected $parent;

--- a/src/Model/Snapshot.php
+++ b/src/Model/Snapshot.php
@@ -106,11 +106,6 @@ abstract class Snapshot implements SnapshotInterface
     protected $parentId;
 
     /**
-     * @deprecated since sonata-project/page-bundle 2.4 and will be removed in 4.0
-     */
-    protected $sources;
-
-    /**
      * @var SiteInterface|null
      */
     protected $site;


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because the code is deprecated and is BC break to remove it.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

While doing PHPStan level 6 I found some deprecated code that was not remove because it was not using the NEXT_MAJOR comment.