### PR TITLE
Move from protected to private when possible

### DIFF
--- a/src/Admin/BlockAdmin.php
+++ b/src/Admin/BlockAdmin.php
@@ -34,9 +34,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 final class BlockAdmin extends BaseBlockAdmin
 {
-    protected array $blocks;
-
     protected $classnameLabel = 'Block';
+    private array $blocks;
 
     public function __construct(array $blocks = [])
     {

--- a/src/Admin/Extension/CreateSnapshotAdminExtension.php
+++ b/src/Admin/Extension/CreateSnapshotAdminExtension.php
@@ -24,7 +24,7 @@ use Sonata\PageBundle\Service\Contract\CreateSnapshotByPageInterface;
  */
 final class CreateSnapshotAdminExtension extends AbstractAdminExtension
 {
-    protected CreateSnapshotByPageInterface $createSnapshotByPage;
+    private CreateSnapshotByPageInterface $createSnapshotByPage;
 
     public function __construct(CreateSnapshotByPageInterface $createSnapshotByPage)
     {

--- a/src/Admin/PageAdmin.php
+++ b/src/Admin/PageAdmin.php
@@ -45,11 +45,21 @@ final class PageAdmin extends AbstractAdmin
 {
     protected $classnameLabel = 'Page';
 
-    protected ?PageManagerInterface $pageManager = null;
+    private ?PageManagerInterface $pageManager = null;
 
-    protected ?SiteManagerInterface $siteManager = null;
+    private ?SiteManagerInterface $siteManager = null;
 
-    public function configureRoutes(RouteCollectionInterface $collection): void
+    public function setPageManager(PageManagerInterface $pageManager): void
+    {
+        $this->pageManager = $pageManager;
+    }
+
+    public function setSiteManager(SiteManagerInterface $siteManager): void
+    {
+        $this->siteManager = $siteManager;
+    }
+
+    protected function configureRoutes(RouteCollectionInterface $collection): void
     {
         $collection->add('compose', '{id}/compose', [
             'id' => null,
@@ -61,65 +71,14 @@ final class PageAdmin extends AbstractAdmin
         $collection->add('tree', 'tree');
     }
 
-    public function preUpdate($object): void
+    protected function preUpdate($object): void
     {
         $object->setEdited(true);
     }
 
-    public function prePersist($object): void
+    protected function prePersist($object): void
     {
         $object->setEdited(true);
-    }
-
-    public function setPageManager(PageManagerInterface $pageManager): void
-    {
-        $this->pageManager = $pageManager;
-    }
-
-    /**
-     * @throws \RuntimeException
-     *
-     * @return SiteInterface|bool
-     */
-    public function getSite()
-    {
-        if (!$this->hasRequest()) {
-            return false;
-        }
-
-        $siteId = null;
-
-        if ('POST' === $this->getRequest()->getMethod()) {
-            $values = $this->getRequest()->get($this->getUniqid());
-            $siteId = $values['site'] ?? null;
-        }
-
-        $siteId ??= $this->getRequest()->get('siteId');
-
-        if ($siteId) {
-            $site = $this->siteManager->findOneBy(['id' => $siteId]);
-
-            if (!$site) {
-                throw new \RuntimeException('Unable to find the site with id='.$this->getRequest()->get('siteId'));
-            }
-
-            return $site;
-        }
-
-        return false;
-    }
-
-    public function setSiteManager(SiteManagerInterface $siteManager): void
-    {
-        $this->siteManager = $siteManager;
-    }
-
-    /**
-     * @return SiteInterface[]
-     */
-    public function getSites()
-    {
-        return $this->siteManager->findBy([]);
     }
 
     protected function getAccessMapping(): array
@@ -416,5 +375,38 @@ final class PageAdmin extends AbstractAdmin
                 // throw $e;
             }
         }
+    }
+
+    /**
+     * @throws \RuntimeException
+     *
+     * @return SiteInterface|bool
+     */
+    private function getSite()
+    {
+        if (!$this->hasRequest()) {
+            return false;
+        }
+
+        $siteId = null;
+
+        if ('POST' === $this->getRequest()->getMethod()) {
+            $values = $this->getRequest()->get($this->getUniqid());
+            $siteId = $values['site'] ?? null;
+        }
+
+        $siteId ??= $this->getRequest()->get('siteId');
+
+        if ($siteId) {
+            $site = $this->siteManager->findOneBy(['id' => $siteId]);
+
+            if (!$site) {
+                throw new \RuntimeException('Unable to find the site with id='.$this->getRequest()->get('siteId'));
+            }
+
+            return $site;
+        }
+
+        return false;
     }
 }

--- a/src/Admin/SiteAdmin.php
+++ b/src/Admin/SiteAdmin.php
@@ -34,7 +34,7 @@ final class SiteAdmin extends AbstractAdmin
 {
     protected $classnameLabel = 'Site';
 
-    protected RoutePageGenerator $routePageGenerator;
+    private RoutePageGenerator $routePageGenerator;
 
     public function __construct(RoutePageGenerator $routePageGenerator)
     {

--- a/src/Block/SharedBlockBlockService.php
+++ b/src/Block/SharedBlockBlockService.php
@@ -136,7 +136,7 @@ final class SharedBlockBlockService extends AbstractBlockService implements Edit
         $block->setSetting('blockId', \is_object($block->getSetting('blockId')) ? $block->getSetting('blockId')->getId() : null);
     }
 
-    protected function getBlockBuilder(): FormBuilderInterface
+    private function getBlockBuilder(): FormBuilderInterface
     {
         $fieldDescription = $this->sharedBlockAdmin->createFieldDescription('block', [
             'translation_domain' => 'SonataPageBundle',

--- a/src/CmsManager/CmsPageManager.php
+++ b/src/CmsManager/CmsPageManager.php
@@ -27,16 +27,16 @@ use Sonata\PageBundle\Model\SiteInterface;
  */
 final class CmsPageManager extends BaseCmsPageManager
 {
-    protected BlockInteractorInterface $blockInteractor;
+    private BlockInteractorInterface $blockInteractor;
 
-    protected PageManagerInterface $pageManager;
+    private PageManagerInterface $pageManager;
 
-    protected array $pageReferences = [];
+    private array $pageReferences = [];
 
     /**
      * @var PageInterface[]
      */
-    protected array $pages = [];
+    private array $pages = [];
 
     public function __construct(PageManagerInterface $pageManager, BlockInteractorInterface $blockInteractor)
     {

--- a/src/CmsManager/CmsSnapshotManager.php
+++ b/src/CmsManager/CmsSnapshotManager.php
@@ -28,16 +28,16 @@ use Sonata\PageBundle\Model\TransformerInterface;
  */
 final class CmsSnapshotManager extends BaseCmsPageManager
 {
-    protected SnapshotManagerInterface $snapshotManager;
+    private SnapshotManagerInterface $snapshotManager;
 
-    protected TransformerInterface $transformer;
+    private TransformerInterface $transformer;
 
-    protected array $pageReferences = [];
+    private array $pageReferences = [];
 
     /**
      * @var PageInterface[]
      */
-    protected array $pages = [];
+    private array $pages = [];
 
     public function __construct(SnapshotManagerInterface $snapshotManager, TransformerInterface $transformer)
     {

--- a/src/Entity/PageManager.php
+++ b/src/Entity/PageManager.php
@@ -29,9 +29,9 @@ use Sonata\PageBundle\Model\SiteInterface;
  */
 final class PageManager extends BaseEntityManager implements PageManagerInterface
 {
-    protected array $pageDefaults;
+    private array $pageDefaults;
 
-    protected array $defaults;
+    private array $defaults;
 
     /**
      * @param string $class

--- a/src/Entity/SnapshotManager.php
+++ b/src/Entity/SnapshotManager.php
@@ -32,9 +32,7 @@ use Sonata\PageBundle\Model\TransformerInterface;
  */
 final class SnapshotManager extends BaseEntityManager implements SnapshotManagerInterface
 {
-    protected array $children = [];
-
-    protected SnapshotPageProxyFactoryInterface $snapshotPageProxyFactory;
+    private SnapshotPageProxyFactoryInterface $snapshotPageProxyFactory;
 
     /**
      * @param string          $class    Namespace of entity class

--- a/src/Form/Type/PageSelectorType.php
+++ b/src/Form/Type/PageSelectorType.php
@@ -28,7 +28,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 final class PageSelectorType extends AbstractType
 {
-    protected PageManagerInterface $manager;
+    private PageManagerInterface $manager;
 
     public function __construct(PageManagerInterface $manager)
     {

--- a/src/Form/Type/PageTypeChoiceType.php
+++ b/src/Form/Type/PageTypeChoiceType.php
@@ -25,7 +25,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 final class PageTypeChoiceType extends AbstractType
 {
-    protected PageServiceManagerInterface $manager;
+    private PageServiceManagerInterface $manager;
 
     public function __construct(PageServiceManagerInterface $manager)
     {

--- a/src/Form/Type/TemplateChoiceType.php
+++ b/src/Form/Type/TemplateChoiceType.php
@@ -25,7 +25,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 final class TemplateChoiceType extends AbstractType
 {
-    protected TemplateManagerInterface $manager;
+    private TemplateManagerInterface $manager;
 
     public function __construct(TemplateManagerInterface $manager)
     {

--- a/src/Page/Service/DefaultPageService.php
+++ b/src/Page/Service/DefaultPageService.php
@@ -28,9 +28,9 @@ use Symfony\Component\HttpFoundation\Response;
  */
 final class DefaultPageService extends BasePageService
 {
-    protected TemplateManagerInterface $templateManager;
+    private TemplateManagerInterface $templateManager;
 
-    protected ?SeoPageInterface $seoPage;
+    private ?SeoPageInterface $seoPage;
 
     /**
      * @param string                   $name            Page service name
@@ -55,7 +55,7 @@ final class DefaultPageService extends BasePageService
     /**
      * Updates the SEO page values for given page instance.
      */
-    protected function updateSeoPage(PageInterface $page): void
+    private function updateSeoPage(PageInterface $page): void
     {
         if (!$this->seoPage) {
             return;

--- a/src/Request/SiteRequestContext.php
+++ b/src/Request/SiteRequestContext.php
@@ -22,7 +22,7 @@ use Symfony\Component\Routing\RequestContext;
  */
 final class SiteRequestContext extends RequestContext implements SiteRequestContextInterface
 {
-    protected SiteSelectorInterface $selector;
+    private SiteSelectorInterface $selector;
 
     private ?SiteInterface $site = null;
 

--- a/src/Validator/UniqueUrlValidator.php
+++ b/src/Validator/UniqueUrlValidator.php
@@ -23,7 +23,7 @@ use Symfony\Component\Validator\Exception\UnexpectedValueException;
 
 final class UniqueUrlValidator extends ConstraintValidator
 {
-    protected PageManagerInterface $manager;
+    private PageManagerInterface $manager;
 
     public function __construct(PageManagerInterface $manager)
     {

--- a/tests/Block/PageListBlockServiceTest.php
+++ b/tests/Block/PageListBlockServiceTest.php
@@ -29,7 +29,7 @@ final class PageListBlockServiceTest extends BlockServiceTestCase
     /**
      * @var PageManagerInterface&MockObject
      */
-    protected $pageManager;
+    private $pageManager;
 
     protected function setUp(): void
     {

--- a/tests/CmsManager/CmsPageManagerTest.php
+++ b/tests/CmsManager/CmsPageManagerTest.php
@@ -269,7 +269,7 @@ final class CmsPageManagerTest extends TestCase
      *
      * @return MockObject&BlockInteractorInterface
      */
-    protected function getMockBlockInteractor(): BlockInteractorInterface
+    private function getMockBlockInteractor(): BlockInteractorInterface
     {
         $callback = static function ($options) {
             $block = new CmsBlock();

--- a/tests/CmsManager/CmsSnapshotManagerTest.php
+++ b/tests/CmsManager/CmsSnapshotManagerTest.php
@@ -17,7 +17,6 @@ use PHPUnit\Framework\TestCase;
 use Sonata\PageBundle\CmsManager\CmsSnapshotManager;
 use Sonata\PageBundle\Exception\PageNotFoundException;
 use Sonata\PageBundle\Model\Block;
-use Sonata\PageBundle\Model\BlockInteractorInterface;
 use Sonata\PageBundle\Model\PageBlockInterface;
 use Sonata\PageBundle\Model\SiteInterface;
 use Sonata\PageBundle\Model\SnapshotInterface;
@@ -44,20 +43,17 @@ final class SnapshotBlock extends Block
 
 final class CmsSnapshotManagerTest extends TestCase
 {
-    protected CmsSnapshotManager $manager;
+    private CmsSnapshotManager $manager;
 
-    protected $blockInteractor;
+    private $snapshotManager;
 
-    protected $snapshotManager;
-
-    protected $transformer;
+    private $transformer;
 
     /**
      * Setup manager object to test.
      */
     protected function setUp(): void
     {
-        $this->blockInteractor = $this->getMockBlockInteractor();
         $this->snapshotManager = $this->createMock(SnapshotManagerInterface::class);
         $this->transformer = $this->createMock(TransformerInterface::class);
         $this->manager = new CmsSnapshotManager($this->snapshotManager, $this->transformer);
@@ -138,25 +134,5 @@ final class CmsSnapshotManagerTest extends TestCase
         static::assertInstanceOf(SnapshotPageProxyInterface::class, $page);
         static::assertInstanceOf(PageBlockInterface::class, $this->manager->getBlock(1));
         static::assertInstanceOf(PageBlockInterface::class, $this->manager->getBlock(2));
-    }
-
-    /**
-     * Returns a mock block interactor.
-     */
-    protected function getMockBlockInteractor(): BlockInteractorInterface
-    {
-        $callback = static function ($options) {
-            $block = new SnapshotBlock();
-            $block->setSettings($options);
-
-            return $block;
-        };
-
-        $blockInteractor = $this->createMock(BlockInteractorInterface::class);
-        $blockInteractor
-            ->method('createNewContainer')
-            ->willReturnCallback($callback);
-
-        return $blockInteractor;
     }
 }

--- a/tests/Entity/BlockInteractorTest.php
+++ b/tests/Entity/BlockInteractorTest.php
@@ -26,9 +26,9 @@ final class BlockInteractorTest extends KernelTestCase
     /**
      * @var EntityManagerInterface
      */
-    protected $entityManager;
+    private $entityManager;
 
-    protected BlockInteractor $blockInteractor;
+    private BlockInteractor $blockInteractor;
 
     protected function setUp(): void
     {

--- a/tests/Form/Type/PageSelectorTypeTest.php
+++ b/tests/Form/Type/PageSelectorTypeTest.php
@@ -22,9 +22,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 final class PageSelectorTypeTest extends TestCase
 {
-    protected $pages;
+    private $pages;
 
-    protected $site;
+    private $site;
 
     protected function setUp(): void
     {

--- a/tests/Form/Type/TemplateChoiceTypeTest.php
+++ b/tests/Form/Type/TemplateChoiceTypeTest.php
@@ -25,9 +25,9 @@ final class TemplateChoiceTypeTest extends TestCase
     /**
      * @var MockObject&TemplateManagerInterface
      */
-    protected $manager;
+    private $manager;
 
-    protected TemplateChoiceType $type;
+    private TemplateChoiceType $type;
 
     /**
      * setup each unit test.

--- a/tests/Functional/Snapshot/SnapshotManagerTest.php
+++ b/tests/Functional/Snapshot/SnapshotManagerTest.php
@@ -29,12 +29,12 @@ final class SnapshotManagerTest extends KernelTestCase
     /**
      * @var EntityManager|null
      */
-    protected $entityManager;
+    private $entityManager;
 
     /**
      * @var SnapshotManager
      */
-    protected $snapshotManager;
+    private $snapshotManager;
 
     protected function setUp(): void
     {

--- a/tests/Listener/ExceptionListenerTest.php
+++ b/tests/Listener/ExceptionListenerTest.php
@@ -191,7 +191,7 @@ final class ExceptionListenerTest extends TestCase
     /**
      * Returns a mocked event with given content data.
      */
-    protected function getMockEvent(\Exception $exception): ExceptionEvent
+    private function getMockEvent(\Exception $exception): ExceptionEvent
     {
         $kernel = $this->createMock(HttpKernelInterface::class);
         $request = new Request();

--- a/tests/Listener/ResponseListenerTest.php
+++ b/tests/Listener/ResponseListenerTest.php
@@ -179,7 +179,7 @@ final class ResponseListenerTest extends TestCase
     /**
      * Returns a mocked event with given content data.
      */
-    protected function getMockEvent(string $content): ResponseEvent
+    private function getMockEvent(string $content): ResponseEvent
     {
         $kernel = $this->createMock(HttpKernelInterface::class);
         $request = new Request();

--- a/tests/Page/PageServiceManagerTest.php
+++ b/tests/Page/PageServiceManagerTest.php
@@ -22,7 +22,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 final class PageServiceManagerTest extends TestCase
 {
-    protected PageServiceManager $manager;
+    private PageServiceManager $manager;
 
     protected function setUp(): void
     {

--- a/tests/Page/Service/DefaultPageServiceTest.php
+++ b/tests/Page/Service/DefaultPageServiceTest.php
@@ -27,14 +27,14 @@ final class DefaultPageServiceTest extends TestCase
     /**
      * @var MockObject&TemplateManagerInterface
      */
-    protected $templateManager;
+    private $templateManager;
 
     /**
      * @var MockObject&SeoPageInterface
      */
-    protected $seoPage;
+    private $seoPage;
 
-    protected DefaultPageService $service;
+    private DefaultPageService $service;
 
     protected function setUp(): void
     {

--- a/tests/Resources/XliffTest.php
+++ b/tests/Resources/XliffTest.php
@@ -19,12 +19,12 @@ use Symfony\Component\Translation\Loader\XliffFileLoader;
 
 final class XliffTest extends TestCase
 {
-    protected XliffFileLoader $loader;
+    private XliffFileLoader $loader;
 
     /**
      * @var string[]
      */
-    protected array $errors = [];
+    private array $errors = [];
 
     protected function setUp(): void
     {
@@ -60,7 +60,7 @@ final class XliffTest extends TestCase
     /**
      * @param string $file The path to the xliff file
      */
-    protected function validateXliff($file): void
+    private function validateXliff($file): void
     {
         try {
             $this->loader->load($file, 'en');
@@ -73,7 +73,7 @@ final class XliffTest extends TestCase
     /**
      * @param string $path The path to lookup for Xliff file
      */
-    protected function validatePath($path): void
+    private function validatePath($path): void
     {
         $files = glob(sprintf('%s/*.xliff', $path));
 

--- a/tests/Route/CmsPageRouterTest.php
+++ b/tests/Route/CmsPageRouterTest.php
@@ -33,19 +33,19 @@ final class CmsPageRouterTest extends TestCase
     /**
      * @var MockObject&CmsManagerSelectorInterface
      */
-    protected $cmsSelector;
+    private $cmsSelector;
 
     /**
      * @var MockObject&SiteSelectorInterface
      */
-    protected $siteSelector;
+    private $siteSelector;
 
     /**
      * @var MockObject&RouterInterface
      */
-    protected $defaultRouter;
+    private $defaultRouter;
 
-    protected CmsPageRouter $router;
+    private CmsPageRouter $router;
 
     /**
      * Setup test object with its dependencies.

--- a/tests/Route/RoutePageGeneratorTest.php
+++ b/tests/Route/RoutePageGeneratorTest.php
@@ -35,7 +35,7 @@ use Twig\Environment;
  */
 final class RoutePageGeneratorTest extends TestCase
 {
-    protected RoutePageGenerator $routePageGenerator;
+    private RoutePageGenerator $routePageGenerator;
 
     /**
      * Set up dependencies.
@@ -112,7 +112,7 @@ final class RoutePageGeneratorTest extends TestCase
     /**
      * Returns a mock of a site model.
      */
-    protected function getSiteMock(): SiteInterface
+    private function getSiteMock(): SiteInterface
     {
         $site = $this->createMock(SiteInterface::class);
         $site->method('getHost')->willReturn('sonata-project.org');
@@ -124,7 +124,7 @@ final class RoutePageGeneratorTest extends TestCase
     /**
      * Returns a mock of Symfony router.
      */
-    protected function getRouterMock(): RouterInterface
+    private function getRouterMock(): RouterInterface
     {
         $collection = new RouteCollection();
         $collection->add('route1', new Route('first_custom_route'));
@@ -153,7 +153,7 @@ final class RoutePageGeneratorTest extends TestCase
     /**
      * Returns Sonata route page generator service.
      */
-    protected function getRoutePageGenerator(): RoutePageGenerator
+    private function getRoutePageGenerator(): RoutePageGenerator
     {
         $router = $this->getRouterMock();
 

--- a/tests/Site/HostPathSiteSelectorTest.php
+++ b/tests/Site/HostPathSiteSelectorTest.php
@@ -99,7 +99,7 @@ final class HostPathSiteSelectorTest extends TestCase
     /**
      * Perform the actual handleKernelSiteRequest method test.
      */
-    protected function performHandleKernelRequestTest($url): array
+    private function performHandleKernelRequestTest($url): array
     {
         $kernel = $this->createMock(HttpKernelInterface::class);
         $request = SiteRequest::create($url);

--- a/tests/Twig/Extension/PageExtensionTest.php
+++ b/tests/Twig/Extension/PageExtensionTest.php
@@ -93,7 +93,7 @@ final class PageExtensionTest extends TestCase
         $extension->controller('bar');
     }
 
-    protected function getRequestStack(Request $request): RequestStack
+    private function getRequestStack(Request $request): RequestStack
     {
         $stack = new RequestStack();
         $stack->push($request);

--- a/tests/Validator/UniqueUrlValidatorTest.php
+++ b/tests/Validator/UniqueUrlValidatorTest.php
@@ -29,7 +29,7 @@ final class UniqueUrlValidatorTest extends ConstraintValidatorTestCase
     /**
      * @var MockObject&PageManagerInterface
      */
-    protected $manager;
+    private $manager;
 
     protected function setUp(): void
     {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC break.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Since a lot of classes are final now, it makes no sense in a lot of cases to use protected, better use private and have the benefits of it (unused code removal, less extension points, etc...).

This is a first iteration, we might try to reduce further visibility of public / protected remaining things.

I saw some of this while doing PHPStan level 6.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataPageBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Changed visibility for most protected properties / methods to private, since classes are final.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
