### PR TITLE
Create test for templateManager

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "sonata-project/doctrine-orm-admin-bundle": "^3.19",
         "sonata-project/form-extensions": "^0.1.1 || ^1.4",
         "sonata-project/notification-bundle": "^3.8",
-        "sonata-project/seo-bundle": "^2.11",
+        "sonata-project/seo-bundle": "^2.14",
         "sonata-project/twig-extensions": "^0.1.1 || ^1.3",
         "symfony-cmf/routing-bundle": "^2.1",
         "symfony/config": "^4.4",

--- a/src/Resources/views/layout.html.twig
+++ b/src/Resources/views/layout.html.twig
@@ -13,12 +13,12 @@ file that was distributed with this source code.
 {% block sonata_page_container %}
     <div class="container">
         <div class="content">
-            <div class="row page-header" id="header">
+            <div class="row page-header">
                 {{ sonata_page_render_container('header', 'global') }}
             </div>
 
             {% block sonata_page_breadcrumb %}
-                <div class="row" id="breadcrumb">
+                <div class="row page-breadcrumb">
                     {{ sonata_block_render_event('breadcrumb', { 'context': 'page', 'current_uri': app.request.requestUri }) }}
                 </div>
             {% endblock %}
@@ -32,7 +32,7 @@ file that was distributed with this source code.
                 </div>
             {% endif %}
 
-            <div class="row" id="content">
+            <div class="row">
                 {% block page_content %}
                     {% if content is defined %}
                         {{ content|raw }}
@@ -58,7 +58,7 @@ file that was distributed with this source code.
             {% endif %}
         </div>
 
-        <footer class="row" id="footer">
+        <footer class="row">
             {{ sonata_page_render_container('footer', 'global') }}
         </footer>
     </div>

--- a/src/Resources/views/layout.html.twig
+++ b/src/Resources/views/layout.html.twig
@@ -13,12 +13,12 @@ file that was distributed with this source code.
 {% block sonata_page_container %}
     <div class="container">
         <div class="content">
-            <div class="row page-header">
+            <div class="row page-header" id="header">
                 {{ sonata_page_render_container('header', 'global') }}
             </div>
 
             {% block sonata_page_breadcrumb %}
-                <div class="row">
+                <div class="row" id="breadcrumb">
                     {{ sonata_block_render_event('breadcrumb', { 'context': 'page', 'current_uri': app.request.requestUri }) }}
                 </div>
             {% endblock %}
@@ -32,7 +32,7 @@ file that was distributed with this source code.
                 </div>
             {% endif %}
 
-            <div class="row">
+            <div class="row" id="content">
                 {% block page_content %}
                     {% if content is defined %}
                         {{ content|raw }}
@@ -58,7 +58,7 @@ file that was distributed with this source code.
             {% endif %}
         </div>
 
-        <footer class="row">
+        <footer class="row" id="footer">
             {{ sonata_page_render_container('footer', 'global') }}
         </footer>
     </div>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Cover templateManager

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because in 4.x the page content is not rendered, and I need to understand first how it was working, something was changed or removed in 4.x that I can't identify.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Issue #1497


<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataPageBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
