### PR TITLE
fix Cleanup Query if no snapshot to keep

### DIFF
--- a/src/Entity/SnapshotManager.php
+++ b/src/Entity/SnapshotManager.php
@@ -258,7 +258,7 @@ class SnapshotManager extends BaseEntityManager implements SnapshotManagerInterf
         $qb->delete()
             ->where($expr->eq('s.page', $page->getId()));
 
-        if (!empty($innerArray)) {
+        if ([] !== $innerArray) {
             $qb->andWhere($expr->notIn(
                 's.id',
                 $innerArray

--- a/src/Entity/SnapshotManager.php
+++ b/src/Entity/SnapshotManager.php
@@ -256,11 +256,14 @@ class SnapshotManager extends BaseEntityManager implements SnapshotManagerInterf
         $qb = $this->getRepository()->createQueryBuilder('s');
         $expr = $qb->expr();
         $qb->delete()
-            ->where($expr->eq('s.page', $page->getId()))
-            ->andWhere($expr->notIn(
+            ->where($expr->eq('s.page', $page->getId()));
+
+        if (!empty($innerArray)) {
+            $qb->andWhere($expr->notIn(
                 's.id',
                 $innerArray
             ));
+        }
 
         return $qb->getQuery()->execute();
     }

--- a/tests/Functional/Snapshot/SnapshotManagerTest.php
+++ b/tests/Functional/Snapshot/SnapshotManagerTest.php
@@ -180,6 +180,66 @@ final class SnapshotManagerTest extends KernelTestCase
         static::assertNull($repo->find(789));
     }
 
+    public function testCleanupAllPages(): void
+    {
+        $this->disableAutoIncrement(SonataPagePage::class);
+
+        // Try to write Doctrine Fixture?
+        $page = new SonataPagePage();
+        $page->setId(234);
+        $page->setName('Name 234');
+        $page->setEnabled(true);
+        $page->setTemplateCode('TemplateCode');
+        $page->setRouteName('/page234');
+
+        $this->entityManager->persist($page);
+        $this->entityManager->flush();
+
+        $page2 = new SonataPagePage();
+        $page2->setId(456);
+        $page2->setName('Name 456');
+        $page2->setEnabled(true);
+        $page2->setTemplateCode('TemplateCode');
+        $page2->setRouteName('/page456');
+
+        $this->entityManager->persist($page2);
+        $this->entityManager->flush();
+
+        $date = new \DateTime();
+
+        $this->disableAutoIncrement(SonataPageSnapshot::class);
+
+        $snapshot = new SonataPageSnapshot();
+        $snapshot->setId(123);
+        $snapshot->setPage($page2);
+        $snapshot->setEnabled(true);
+        $snapshot->setName('Name 123');
+        $snapshot->setRouteName('/snapshot123');
+        $snapshot->setPublicationDateEnd($date);
+        $this->entityManager->persist($snapshot);
+        $this->entityManager->flush();
+
+        // this should have no snapshot to keep, because the page doesn't have any
+        // but also no snapshot should be deleted
+        $this->snapshotManager->cleanup($page, 1);
+
+        // asking if entity manager contains entity isn't enough, see below
+        $repo = $this->entityManager->getRepository(SonataPageSnapshot::class);
+        $all = $repo->findAll();
+
+        // The Snapshot should still be there
+        static::assertCount(1, $all);
+        static::assertContains($snapshot, $all);
+
+        // object still exist in entityManager, that is by design
+        static::assertTrue($this->entityManager->contains($snapshot));
+
+        // EntityManager clear is brutal, can't use the entities anymore
+        $this->entityManager->clear();
+
+        static::assertNotNull($repo->find(123));
+    }
+
     public static function assertDateTimeEquals(\DateTime $expected, \DateTime $actual)
     {
         static::assertSame($expected->format('c'), $actual->format('c'));


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

The Query is faulty if there is no Snapshot to keep.
I should probably extend the Testcases for this too.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because it is a Bug Fix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1535.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataPageBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- SnapshotManager Cleanup Query if there are no Snapshots to keep
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->