### PR TITLE
Add more tests

### DIFF
--- a/tests/Functional/Admin/BlockAdminTest.php
+++ b/tests/Functional/Admin/BlockAdminTest.php
@@ -82,6 +82,36 @@ final class BlockAdminTest extends WebTestCase
     }
 
     /**
+     * @dataProvider provideBatchActionsCases
+     */
+    public function testBatchActions(string $action): void
+    {
+        $client = self::createClient();
+
+        $this->prepareData();
+
+        $client->request('GET', '/admin/tests/app/sonatapageblock/list');
+        $client->submitForm('OK', [
+            'all_elements' => true,
+            'action' => $action,
+        ]);
+        $client->submitForm('Yes, execute');
+        $client->followRedirect();
+
+        self::assertResponseIsSuccessful();
+    }
+
+    /**
+     * @return iterable<array<string>>
+     *
+     * @phpstan-return iterable<array{0: string}>
+     */
+    public static function provideBatchActionsCases(): iterable
+    {
+        yield 'Delete Blocks' => ['delete'];
+    }
+
+    /**
      * @return class-string<KernelInterface>
      */
     protected static function getKernelClass(): string

--- a/tests/Functional/Admin/PageAdminTest.php
+++ b/tests/Functional/Admin/PageAdminTest.php
@@ -174,6 +174,39 @@ final class PageAdminTest extends WebTestCase
     }
 
     /**
+     * @dataProvider provideBatchActionsCases
+     */
+    public function testBatchActions(string $action): void
+    {
+        $client = self::createClient();
+
+        $this->prepareData();
+
+        $client->request('GET', '/admin/tests/app/sonatapagepage/list', ['filter' => [
+            'name' => ['value' => 'name'],
+        ]]);
+        $client->submitForm('OK', [
+            'all_elements' => true,
+            'action' => $action,
+        ]);
+        $client->submitForm('Yes, execute');
+        $client->followRedirect();
+
+        self::assertResponseIsSuccessful();
+    }
+
+    /**
+     * @return iterable<array<string>>
+     *
+     * @phpstan-return iterable<array{0: string}>
+     */
+    public static function provideBatchActionsCases(): iterable
+    {
+        yield 'Delete Pages' => ['delete'];
+        yield 'Create Snaphosts' => ['snapshot'];
+    }
+
+    /**
      * @return class-string<KernelInterface>
      */
     protected static function getKernelClass(): string

--- a/tests/Functional/Admin/SharedBlockAdminTest.php
+++ b/tests/Functional/Admin/SharedBlockAdminTest.php
@@ -191,6 +191,36 @@ final class SharedBlockAdminTest extends WebTestCase
     }
 
     /**
+     * @dataProvider provideBatchActionsCases
+     */
+    public function testBatchActions(string $action): void
+    {
+        $client = self::createClient();
+
+        $this->prepareData();
+
+        $client->request('GET', '/admin/tests/app/sonatapageblock/shared/list');
+        $client->submitForm('OK', [
+            'all_elements' => true,
+            'action' => $action,
+        ]);
+        $client->submitForm('Yes, execute');
+        $client->followRedirect();
+
+        self::assertResponseIsSuccessful();
+    }
+
+    /**
+     * @return iterable<array<string>>
+     *
+     * @phpstan-return iterable<array{0: string}>
+     */
+    public static function provideBatchActionsCases(): iterable
+    {
+        yield 'Delete Shared Blocks' => ['delete'];
+    }
+
+    /**
      * @return class-string<KernelInterface>
      */
     protected static function getKernelClass(): string

--- a/tests/Functional/Admin/SiteAdminTest.php
+++ b/tests/Functional/Admin/SiteAdminTest.php
@@ -49,7 +49,7 @@ final class SiteAdminTest extends WebTestCase
         yield 'Edit Site' => ['/admin/tests/app/sonatapagesite/1/edit'];
         yield 'Show Page' => ['/admin/tests/app/sonatapagesite/1/show'];
         yield 'Remove Site' => ['/admin/tests/app/sonatapagesite/1/delete'];
-        yield 'Snaphosts Site' => ['/admin/tests/app/sonatapagesite/1/snapshots'];
+        yield 'Create Snaphosts Site' => ['/admin/tests/app/sonatapagesite/1/snapshots'];
     }
 
     /**
@@ -87,6 +87,37 @@ final class SiteAdminTest extends WebTestCase
 
         yield 'Edit Site' => ['/admin/tests/app/sonatapagesite/1/edit', [], 'btn_update_and_list', []];
         yield 'Remove Site' => ['/admin/tests/app/sonatapagesite/1/delete', [], 'btn_delete'];
+        yield 'Create Snaphosts Site' => ['/admin/tests/app/sonatapagesite/1/snapshots', [], 'create'];
+    }
+
+    /**
+     * @dataProvider provideBatchActionsCases
+     */
+    public function testBatchActions(string $action): void
+    {
+        $client = self::createClient();
+
+        $this->prepareData();
+
+        $client->request('GET', '/admin/tests/app/sonatapagesite/list');
+        $client->submitForm('OK', [
+            'all_elements' => true,
+            'action' => $action,
+        ]);
+        $client->submitForm('Yes, execute');
+        $client->followRedirect();
+
+        self::assertResponseIsSuccessful();
+    }
+
+    /**
+     * @return iterable<array<string>>
+     *
+     * @phpstan-return iterable<array{0: string}>
+     */
+    public static function provideBatchActionsCases(): iterable
+    {
+        yield 'Delete Sites' => ['delete'];
     }
 
     /**

--- a/tests/Functional/Admin/SnapshotAdminTest.php
+++ b/tests/Functional/Admin/SnapshotAdminTest.php
@@ -100,6 +100,37 @@ final class SnapshotAdminTest extends WebTestCase
     }
 
     /**
+     * @dataProvider provideBatchActionsCases
+     */
+    public function testBatchActions(string $action): void
+    {
+        $client = self::createClient();
+
+        $this->prepareData();
+
+        $client->request('GET', '/admin/tests/app/sonatapagesnapshot/list');
+        $client->submitForm('OK', [
+            'all_elements' => true,
+            'action' => $action,
+        ]);
+        $client->submitForm('Yes, execute');
+        $client->followRedirect();
+
+        self::assertResponseIsSuccessful();
+    }
+
+    /**
+     * @return iterable<array<string>>
+     *
+     * @phpstan-return iterable<array{0: string}>
+     */
+    public static function provideBatchActionsCases(): iterable
+    {
+        yield 'Delete Snapshots' => ['delete'];
+        yield 'Toggle Snapshots' => ['toggle_enabled'];
+    }
+
+    /**
      * @return class-string<KernelInterface>
      */
     protected static function getKernelClass(): string


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
More testing. This one adds batch action tests, which are not included on other bundles, we could add those to bundles like, Media, User, Classification.