### PR TITLE
Add tests for render page via Snapshot

### DIFF
--- a/src/Resources/views/PageAdmin/tree.html.twig
+++ b/src/Resources/views/PageAdmin/tree.html.twig
@@ -74,7 +74,7 @@ file that was distributed with this source code.
                                         {{ site.name }}
                                     </a>
                                 </li>
-                            {% endfor%}
+                            {% endfor %}
                         </ul>
                     </div>
                 </h1>

--- a/src/Route/CmsPageRouter.php
+++ b/src/Route/CmsPageRouter.php
@@ -162,7 +162,7 @@ final class CmsPageRouter implements ChainedRouterInterface
         $cms->setCurrentPage($page);
 
         return [
-            '_controller' => 'sonata.page.page_service_manager:execute',
+            '_controller' => 'sonata.page.page_service_manager::execute',
             '_route' => PageInterface::PAGE_ROUTE_CMS_NAME,
             'page' => $page,
             'path' => $pathinfo,

--- a/tests/Functional/Admin/SharedBlockAdminTest.php
+++ b/tests/Functional/Admin/SharedBlockAdminTest.php
@@ -82,7 +82,7 @@ final class SharedBlockAdminTest extends WebTestCase
     public static function provideFormUrlsCases(): iterable
     {
         // Blocks From SonataBlockBundle
-        yield 'Create Shared Block - Container' => ['/admin/tests/app/sonatapageblock/shared/create', [
+        yield 'Create Shared Block - Block Container' => ['/admin/tests/app/sonatapageblock/shared/create', [
             'uniqid' => 'shared_block',
             'type' => 'sonata.block.service.container',
         ], 'btn_create_and_list', [
@@ -156,6 +156,19 @@ final class SharedBlockAdminTest extends WebTestCase
             'shared_block[settings][current]' => 1,
             // 'shared_block[settings][pageId]' => 1,
             'shared_block[settings][class]' => 'custom_class',
+        ]];
+
+        yield 'Create Shared Block - Page Container' => ['/admin/tests/app/sonatapageblock/shared/create', [
+            'uniqid' => 'shared_block',
+            'type' => 'sonata.page.block.container',
+        ], 'btn_create_and_list', [
+            'shared_block[name]' => 'Name',
+            'shared_block[enabled]' => 1,
+            'shared_block[settings][code]' => 'code',
+            'shared_block[settings][layout]' => '{{ CONTENT }}',
+            'shared_block[settings][class]' => 'custom_class',
+            'shared_block[settings][template]' => '@SonataPage/Block/block_container.html.twig',
+            // 'shared_block[children]' => '',
         ]];
 
         // yield 'Create Shared Block - Breadcrumb' => ['/admin/tests/app/sonatapageblock/shared/create', [

--- a/tests/Functional/Frontend/ExceptionsTest.php
+++ b/tests/Functional/Frontend/ExceptionsTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Sonata\PageBundle\Tests\Frontend\Admin;
+namespace Sonata\PageBundle\Tests\Frontend;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Sonata\PageBundle\Tests\App\AppKernel;

--- a/tests/Functional/Frontend/SnapshotTest.php
+++ b/tests/Functional/Frontend/SnapshotTest.php
@@ -28,8 +28,13 @@ final class SnapshotTest extends WebTestCase
 
         $this->prepareData();
 
+        $client->request('GET', '/');
+
+        self::assertResponseStatusCodeSame(404);
+
         $client->request('GET', '/admin/tests/app/sonatapagesite/1/snapshots');
         $client->submitForm('create');
+
         $client->request('GET', '/');
 
         self::assertResponseIsSuccessful();

--- a/tests/Functional/Frontend/SnapshotTest.php
+++ b/tests/Functional/Frontend/SnapshotTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Sonata\PageBundle\Tests\Frontend;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Sonata\PageBundle\Model\TransformerInterface;
 use Sonata\PageBundle\Tests\App\AppKernel;
 use Sonata\PageBundle\Tests\App\Entity\SonataPagePage;
 use Sonata\PageBundle\Tests\App\Entity\SonataPageSite;

--- a/tests/Functional/Frontend/SnapshotTest.php
+++ b/tests/Functional/Frontend/SnapshotTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\PageBundle\Tests\Frontend;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Sonata\PageBundle\Model\TransformerInterface;
+use Sonata\PageBundle\Tests\App\AppKernel;
+use Sonata\PageBundle\Tests\App\Entity\SonataPagePage;
+use Sonata\PageBundle\Tests\App\Entity\SonataPageSite;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+final class SnapshotTest extends WebTestCase
+{
+    public function testPageRenderFromSnapshot(): void
+    {
+        $client = self::createClient();
+
+        $this->prepareData();
+
+        $client->request('GET', '/admin/tests/app/sonatapagesite/1/snapshots');
+        $client->submitForm('create');
+        $client->request('GET', '/');
+
+        self::assertResponseIsSuccessful();
+    }
+
+    /**
+     * @return class-string<KernelInterface>
+     */
+    protected static function getKernelClass(): string
+    {
+        return AppKernel::class;
+    }
+
+    /**
+     * @psalm-suppress UndefinedPropertyFetch
+     */
+    private function prepareData(): void
+    {
+        // TODO: Simplify this when dropping support for Symfony 4.
+        // @phpstan-ignore-next-line
+        $container = method_exists($this, 'getContainer') ? self::getContainer() : self::$container;
+        $manager = $container->get('doctrine.orm.entity_manager');
+        \assert($manager instanceof EntityManagerInterface);
+
+        $site = new SonataPageSite();
+        $site->setName('name');
+        $site->setHost('localhost');
+        $site->setEnabled(true);
+
+        $page = new SonataPagePage();
+        $page->setName('name');
+        $page->setUrl('/');
+        $page->setTemplateCode('default');
+        $page->setEnabled(true);
+        $page->setSite($site);
+
+        $manager->persist($site);
+        $manager->persist($page);
+
+        $manager->flush();
+    }
+}

--- a/tests/Functional/Frontend/SnapshotTest.php
+++ b/tests/Functional/Frontend/SnapshotTest.php
@@ -15,6 +15,7 @@ namespace Sonata\PageBundle\Tests\Frontend;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Sonata\PageBundle\Tests\App\AppKernel;
+use Sonata\PageBundle\Tests\App\Entity\SonataPageBlock;
 use Sonata\PageBundle\Tests\App\Entity\SonataPagePage;
 use Sonata\PageBundle\Tests\App\Entity\SonataPageSite;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
@@ -71,8 +72,15 @@ final class SnapshotTest extends WebTestCase
         $page->setEnabled(true);
         $page->setSite($site);
 
+        $containerBlock = new SonataPageBlock();
+        $containerBlock->setType('sonata.page.block.container');
+        $containerBlock->setSetting('code', 'content');
+        $containerBlock->setEnabled(true);
+        $containerBlock->setPage($page);
+
         $manager->persist($site);
         $manager->persist($page);
+        $manager->persist($containerBlock);
 
         $manager->flush();
     }

--- a/tests/Route/CmsPageRouterTest.php
+++ b/tests/Route/CmsPageRouterTest.php
@@ -104,7 +104,7 @@ final class CmsPageRouterTest extends TestCase
 
         $route = $this->router->match('/');
 
-        static::assertSame('sonata.page.page_service_manager:execute', $route['_controller']);
+        static::assertSame('sonata.page.page_service_manager::execute', $route['_controller']);
         static::assertSame('page_slug', $route['_route']);
     }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
Add initial test for display pages via snapshot, and fixed a bug that made impossible to render pages (at least on sf 6.1)