### PR TITLE
Add test for Page render being an editor

### DIFF
--- a/tests/Functional/Admin/PageAdminTest.php
+++ b/tests/Functional/Admin/PageAdminTest.php
@@ -171,9 +171,19 @@ final class PageAdminTest extends WebTestCase
         yield 'Remove Snapshot Page' => ['/admin/tests/app/sonatapagesnapshot/1/delete', [], 'btn_delete'];
 
         // Block child pages
-        yield 'Create Block Page' => ['/admin/tests/app/sonatapagepage/1/sonatapageblock/create', [
-            'type' => 'sonata.block.service.text',
-        ], 'btn_create_and_list', []];
+        yield 'Create Block Page - Children Pages' => ['/admin/tests/app/sonatapagepage/1/sonatapageblock/create', [
+            'uniqid' => 'block',
+            'type' => 'sonata.page.block.children_pages',
+        ], 'btn_create_and_list', [
+            'block[name]' => 'Name',
+            'block[enabled]' => 1,
+            'block[settings][title]' => 'Title',
+            'block[settings][translation_domain]' => 'SonataPageBundle',
+            'block[settings][icon]' => 'fa fa-home',
+            'block[settings][current]' => 1,
+            'block[settings][pageId]' => 1,
+            'block[settings][class]' => 'custom_class',
+        ]];
 
         yield 'Edit Block Page' => ['/admin/tests/app/sonatapageblock/1/edit', [], 'btn_update_and_list', []];
         yield 'Remove Block Page' => ['/admin/tests/app/sonatapageblock/1/delete', [], 'btn_delete'];

--- a/tests/Functional/Admin/SharedBlockAdminTest.php
+++ b/tests/Functional/Admin/SharedBlockAdminTest.php
@@ -144,20 +144,6 @@ final class SharedBlockAdminTest extends WebTestCase
         ]];
 
         // Blocks From SonataPageBundle
-        yield 'Create Shared Block - Children Pages' => ['/admin/tests/app/sonatapageblock/shared/create', [
-            'uniqid' => 'shared_block',
-            'type' => 'sonata.page.block.children_pages',
-        ], 'btn_create_and_list', [
-            'shared_block[name]' => 'Name',
-            'shared_block[enabled]' => 1,
-            'shared_block[settings][title]' => 'Title',
-            'shared_block[settings][translation_domain]' => 'SonataPageBundle',
-            'shared_block[settings][icon]' => 'fa fa-home',
-            'shared_block[settings][current]' => 1,
-            // 'shared_block[settings][pageId]' => 1,
-            'shared_block[settings][class]' => 'custom_class',
-        ]];
-
         yield 'Create Shared Block - Page Container' => ['/admin/tests/app/sonatapageblock/shared/create', [
             'uniqid' => 'shared_block',
             'type' => 'sonata.page.block.container',

--- a/tests/Functional/Frontend/PageTest.php
+++ b/tests/Functional/Frontend/PageTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\PageBundle\Tests\Frontend;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Sonata\PageBundle\Tests\App\AppKernel;
+use Sonata\PageBundle\Tests\App\Entity\SonataPageBlock;
+use Sonata\PageBundle\Tests\App\Entity\SonataPagePage;
+use Sonata\PageBundle\Tests\App\Entity\SonataPageSite;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\BrowserKit\AbstractBrowser;
+use Symfony\Component\BrowserKit\Cookie;
+use Symfony\Component\HttpFoundation\Session\SessionFactoryInterface;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+final class PageTest extends WebTestCase
+{
+    public function testPageRenderFromPageWhenUserIsAnEditor(): void
+    {
+        $client = self::createClient();
+
+        $this->prepareData();
+
+        $client->request('GET', '/');
+
+        self::assertResponseStatusCodeSame(404);
+
+        $this->becomeEditor($client);
+
+        $client->request('GET', '/');
+
+        self::assertResponseIsSuccessful();
+    }
+
+    /**
+     * @return class-string<KernelInterface>
+     */
+    protected static function getKernelClass(): string
+    {
+        return AppKernel::class;
+    }
+
+    /**
+     * @psalm-suppress UndefinedPropertyFetch
+     */
+    private function prepareData(): void
+    {
+        // TODO: Simplify this when dropping support for Symfony 4.
+        // @phpstan-ignore-next-line
+        $container = method_exists($this, 'getContainer') ? self::getContainer() : self::$container;
+        $manager = $container->get('doctrine.orm.entity_manager');
+        \assert($manager instanceof EntityManagerInterface);
+
+        $site = new SonataPageSite();
+        $site->setName('name');
+        $site->setHost('localhost');
+        $site->setEnabled(true);
+
+        $page = new SonataPagePage();
+        $page->setName('name');
+        $page->setUrl('/');
+        $page->setTemplateCode('default');
+        $page->setEnabled(true);
+        $page->setSite($site);
+
+        $containerBlock = new SonataPageBlock();
+        $containerBlock->setType('sonata.page.block.container');
+        $containerBlock->setSetting('code', 'content');
+        $containerBlock->setEnabled(true);
+        $containerBlock->setPage($page);
+
+        $manager->persist($site);
+        $manager->persist($page);
+        $manager->persist($containerBlock);
+
+        $manager->flush();
+    }
+
+    /**
+     * Normally this would happen via an interactive login.
+     * Part of this logic is also copied from AbstractBrowser::loginUser().
+     *
+     * @psalm-suppress UndefinedPropertyFetch
+     */
+    private function becomeEditor(AbstractBrowser $client): void
+    {
+        // TODO: Simplify this when dropping support for Symfony 4.
+        // @phpstan-ignore-next-line
+        $container = method_exists($this, 'getContainer') ? self::getContainer() : self::$container;
+
+        // TODO: Simplify this when dropping support for Symfony 4.
+        if ($container->has('session.factory')) {
+            $sessionFactory = $container->get('session.factory');
+            \assert($sessionFactory instanceof SessionFactoryInterface);
+
+            $session = $sessionFactory->createSession();
+        } else {
+            $session = $container->get('session');
+            \assert($session instanceof SessionInterface);
+        }
+
+        $session->set('sonata/page/isEditor', true);
+        $session->save();
+
+        $domains = array_unique(array_map(
+            static fn (Cookie $cookie) => $cookie->getName() === $session->getName() ? $cookie->getDomain() : '',
+            $client->getCookieJar()->all()
+        ));
+        $domains = [] !== $domains ? $domains : [''];
+
+        foreach ($domains as $domain) {
+            $cookie = new Cookie($session->getName(), $session->getId(), null, null, $domain);
+            $client->getCookieJar()->set($cookie);
+        }
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
Adding more tests, those ones are the first that do not modify coverage, but still are useful tests, and will improve in next PRs, trying to render all kind of block types.