### PR TITLE
Fix block container children

### DIFF
--- a/src/Admin/BaseBlockAdmin.php
+++ b/src/Admin/BaseBlockAdmin.php
@@ -84,7 +84,11 @@ abstract class BaseBlockAdmin extends AbstractAdmin
 
     protected function alterNewInstance(object $object): void
     {
-        $object->setType($this->getPersistentParameter('type'));
+        $type = $this->getPersistentParameter('type');
+
+        if (null !== $type) {
+            $object->setType($type);
+        }
 
         $this->loadBlockDefaults($object);
     }

--- a/src/Admin/BlockAdmin.php
+++ b/src/Admin/BlockAdmin.php
@@ -95,10 +95,6 @@ final class BlockAdmin extends BaseBlockAdmin
         $collection->add('save_position', 'save-position');
         $collection->add('switch_parent', 'switch-parent');
         $collection->add('compose_preview', $this->getRouterIdParameter().'/compose-preview');
-
-        if (!$this->isChild()) {
-            $collection->remove('create');
-        }
     }
 
     protected function configureFormFields(FormMapper $form): void

--- a/tests/Functional/Admin/BlockAdminTest.php
+++ b/tests/Functional/Admin/BlockAdminTest.php
@@ -45,7 +45,13 @@ final class BlockAdminTest extends WebTestCase
      */
     public static function provideCrudUrlsCases(): iterable
     {
-        yield 'List Block' => ['/admin/tests/app/sonatapageblock/list'];
+        yield 'List Block' => ['/admin/tests/app/sonatapageblock/create'];
+        yield 'List Block types' => ['/admin/tests/app/sonatapageblock/create'];
+
+        yield 'Create Block' => ['/admin/tests/app/sonatapageblock/create', [
+            'type' => 'sonata.page.block.shared_block',
+        ]];
+
         yield 'Edit Block' => ['/admin/tests/app/sonatapageblock/1/edit'];
         yield 'Remove Block' => ['/admin/tests/app/sonatapageblock/1/delete'];
         yield 'Compose preview Block' => ['/admin/tests/app/sonatapageblock/3/compose-preview'];
@@ -77,6 +83,11 @@ final class BlockAdminTest extends WebTestCase
      */
     public static function provideFormUrlsCases(): iterable
     {
+        yield 'Create Block - Text' => ['/admin/tests/app/sonatapageblock/create', [
+            'uniqid' => 'block',
+            'type' => 'sonata.block.service.text',
+        ], 'btn_create_and_list', []];
+
         yield 'Edit Block' => ['/admin/tests/app/sonatapageblock/1/edit', [], 'btn_update_and_list', []];
         yield 'Remove Block' => ['/admin/tests/app/sonatapageblock/1/delete', [], 'btn_delete'];
     }

--- a/tests/Functional/Admin/SharedBlockAdminTest.php
+++ b/tests/Functional/Admin/SharedBlockAdminTest.php
@@ -44,15 +44,15 @@ final class SharedBlockAdminTest extends WebTestCase
      */
     public static function provideCrudUrlsCases(): iterable
     {
-        yield 'List Block' => ['/admin/tests/app/sonatapageblock/shared/list'];
-        yield 'List Block types' => ['/admin/tests/app/sonatapageblock/shared/create'];
+        yield 'List Shared Block' => ['/admin/tests/app/sonatapageblock/shared/list'];
+        yield 'List Shared Block types' => ['/admin/tests/app/sonatapageblock/shared/create'];
 
-        yield 'Create Block' => ['/admin/tests/app/sonatapageblock/shared/create', [
+        yield 'Create Shared Block' => ['/admin/tests/app/sonatapageblock/shared/create', [
             'type' => 'sonata.page.block.shared_block',
         ]];
 
-        yield 'Edit Block' => ['/admin/tests/app/sonatapageblock/shared/1/edit'];
-        yield 'Remove Block' => ['/admin/tests/app/sonatapageblock/shared/1/delete'];
+        yield 'Edit Shared Block' => ['/admin/tests/app/sonatapageblock/shared/1/edit'];
+        yield 'Remove Shared Block' => ['/admin/tests/app/sonatapageblock/shared/1/delete'];
     }
 
     /**


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->

This together with: https://github.com/sonata-project/SonataBlockBundle/pull/1100 makes the children blocks work on the edit block (the composer page still needs some work).