### PR TITLE
Add test for render SonataPage blocks

### DIFF
--- a/tests/Functional/Frontend/PageTest.php
+++ b/tests/Functional/Frontend/PageTest.php
@@ -79,11 +79,38 @@ final class PageTest extends WebTestCase
         $containerBlock->setType('sonata.page.block.container');
         $containerBlock->setSetting('code', 'content');
         $containerBlock->setEnabled(true);
-        $containerBlock->setPage($page);
+
+        $block = new SonataPageBlock();
+        $block->setType('sonata.page.block.shared_block');
+        $block->setSetting('blockId', 3);
+        $block->setParent($containerBlock);
+
+        $block2 = new SonataPageBlock();
+        $block2->setType('sonata.page.block.pagelist');
+        $block2->setParent($containerBlock);
+
+        $block3 = new SonataPageBlock();
+        $block3->setType('sonata.page.block.children_pages');
+        $block3->setSetting('pageId', 1);
+        $block3->setParent($containerBlock);
+
+        $block4 = new SonataPageBlock();
+        $block4->setType('sonata.page.block.breadcrumb');
+        $block4->setParent($containerBlock);
+
+        $page->addBlock($containerBlock);
+        $page->addBlock($block);
+        $page->addBlock($block2);
+        $page->addBlock($block3);
+        $page->addBlock($block4);
 
         $manager->persist($site);
         $manager->persist($page);
         $manager->persist($containerBlock);
+        $manager->persist($block);
+        $manager->persist($block2);
+        $manager->persist($block3);
+        $manager->persist($block4);
 
         $manager->flush();
     }

--- a/tests/Functional/Frontend/SnapshotTest.php
+++ b/tests/Functional/Frontend/SnapshotTest.php
@@ -76,7 +76,8 @@ final class SnapshotTest extends WebTestCase
         $containerBlock->setType('sonata.page.block.container');
         $containerBlock->setSetting('code', 'content');
         $containerBlock->setEnabled(true);
-        $containerBlock->setPage($page);
+
+        $page->addBlock($containerBlock);
 
         $manager->persist($site);
         $manager->persist($page);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
Added test to cover more code on the Block folder.