### PR TITLE
Fix breadcrumb context

### DIFF
--- a/src/Block/BreadcrumbBlockService.php
+++ b/src/Block/BreadcrumbBlockService.php
@@ -42,14 +42,14 @@ final class BreadcrumbBlockService extends BaseBreadcrumbMenuBlockService
 
     public function getMetadata(): MetadataInterface
     {
-        return new Metadata($this->getName(), null, null, 'SonataPageBundle', [
+        return new Metadata('sonata.page.block.breadcrumb', null, null, 'SonataPageBundle', [
             'class' => 'fa fa-bars',
         ]);
     }
 
     public function handleContext(string $context): bool
     {
-        return $this->getName() === $context;
+        return 'page' === $context;
     }
 
     protected function getMenu(BlockContextInterface $blockContext): ItemInterface
@@ -79,11 +79,6 @@ final class BreadcrumbBlockService extends BaseBreadcrumbMenuBlockService
         }
 
         return $menu;
-    }
-
-    private function getName(): string
-    {
-        return 'sonata.page.block.breadcrumb';
     }
 
     private function getCurrentPage(): ?PageInterface

--- a/src/Resources/views/layout.html.twig
+++ b/src/Resources/views/layout.html.twig
@@ -19,7 +19,7 @@ file that was distributed with this source code.
 
             {% block sonata_page_breadcrumb %}
                 <div class="row page-breadcrumb">
-                    {{ sonata_block_render_event('breadcrumb', { 'context': 'sonata.page.block.breadcrumb', 'current_uri': app.request.requestUri }) }}
+                    {{ sonata_block_render_event('breadcrumb', { 'context': 'page', 'current_uri': app.request.requestUri }) }}
                 </div>
             {% endblock %}
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this fixes unwanted BC break on breadcrumb context.

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
