### PR TITLE
Remove show route for blocks

### DIFF
--- a/src/Admin/BaseBlockAdmin.php
+++ b/src/Admin/BaseBlockAdmin.php
@@ -17,6 +17,7 @@ use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Route\RouteCollectionInterface;
 use Sonata\BlockBundle\Block\BlockServiceManagerInterface;
 use Sonata\PageBundle\Model\PageBlockInterface;
 use Sonata\PageBundle\Model\PageInterface;
@@ -66,6 +67,11 @@ abstract class BaseBlockAdmin extends AbstractAdmin
         }
 
         parent::preBatchAction($actionName, $query, $idx, $allElements);
+    }
+
+    protected function configureRoutes(RouteCollectionInterface $collection): void
+    {
+        $collection->remove('show');
     }
 
     protected function preRemove(object $object): void

--- a/src/Admin/BaseBlockAdmin.php
+++ b/src/Admin/BaseBlockAdmin.php
@@ -113,7 +113,7 @@ abstract class BaseBlockAdmin extends AbstractAdmin
     protected function configureListFields(ListMapper $list): void
     {
         $list
-            ->addIdentifier('type')
+            ->addIdentifier('type', null, ['route' => ['name' => 'edit']])
             ->add('name')
             ->add('enabled', null, ['editable' => true])
             ->add('updatedAt')

--- a/src/Admin/SharedBlockAdmin.php
+++ b/src/Admin/SharedBlockAdmin.php
@@ -59,7 +59,7 @@ final class SharedBlockAdmin extends BaseBlockAdmin
     protected function configureListFields(ListMapper $list): void
     {
         $list
-            ->addIdentifier('name')
+            ->addIdentifier('name', null, ['route' => ['name' => 'edit']])
             ->add('type')
             ->add('enabled', null, ['editable' => true])
             ->add('updatedAt');


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is in preparation for 4.0

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataPageBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Remove show route for block since blocks are meant to be edited through compose page.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
