### PR TITLE
Simplify AppKernel configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ phpstan.neon
 /.phpunit.result.cache
 /docs/_build/
 npm-debug.log
+tests/App/var

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,6 +9,8 @@ parameters:
     paths:
         - src
         - tests
+    excludePaths:
+        - tests/App/var
     treatPhpDocTypesAsCertain: false
     checkGenericClassInNonGenericObjectType: true
     checkInternalClassCaseSensitivity: true

--- a/psalm.xml
+++ b/psalm.xml
@@ -3,8 +3,9 @@
     <projectFiles>
         <directory name="src"/>
         <directory name="tests"/>
-        <ignoreFiles>
+        <ignoreFiles allowMissingFiles="true">
             <directory name="vendor"/>
+            <directory name="tests/App/var"/>
         </ignoreFiles>
     </projectFiles>
     <plugins>

--- a/tests/App/AppKernel.php
+++ b/tests/App/AppKernel.php
@@ -63,16 +63,6 @@ final class AppKernel extends Kernel
         return $bundles;
     }
 
-    public function getCacheDir(): string
-    {
-        return $this->getBaseDir().'cache';
-    }
-
-    public function getLogDir(): string
-    {
-        return $this->getBaseDir().'log';
-    }
-
     public function getProjectDir(): string
     {
         return __DIR__;
@@ -93,8 +83,6 @@ final class AppKernel extends Kernel
      */
     protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader): void
     {
-        $container->setParameter('app.base_dir', $this->getBaseDir());
-
         $loader->load($this->getProjectDir().'/config/config.yaml');
 
         if (class_exists(AuthenticatorManager::class)) {
@@ -106,10 +94,5 @@ final class AppKernel extends Kernel
         if (class_exists(HttpCacheHandler::class)) {
             $loader->load($this->getProjectDir().'/config/config_sonata_block_v4.yaml');
         }
-    }
-
-    private function getBaseDir(): string
-    {
-        return sys_get_temp_dir().'/sonata-page-bundle/var/';
     }
 }

--- a/tests/App/config/doctrine.yaml
+++ b/tests/App/config/doctrine.yaml
@@ -1,6 +1,6 @@
 doctrine:
     dbal:
-        url: 'sqlite:///%app.base_dir%database.db'
+        url: 'sqlite:///%kernel.project_dir%/var/database.db'
     orm:
         auto_generate_proxy_classes: true
         naming_strategy: doctrine.orm.naming_strategy.underscore_number_aware


### PR DESCRIPTION
This is a try to see if we can simplify a bit our AppKernel file. It is strange to store caches on a temporal folder outisde the project structure, and makes things a bit obscure.

With this change, the cache could always be on the same place for all projects, and the user can easily see it or manipulate it.