### PR TITLE
Add tests for page types

### DIFF
--- a/src/Model/TransformerInterface.php
+++ b/src/Model/TransformerInterface.php
@@ -41,7 +41,6 @@ use Doctrine\Common\Collections\Collection;
  *     blocks: array<mixed>,
  *   }>,
  * }
- *
  * @phpstan-type PageContent array{
  *   id: int|string|null,
  *   parent_id?: int|string|null,

--- a/src/Resources/views/base_layout.html.twig
+++ b/src/Resources/views/base_layout.html.twig
@@ -50,7 +50,7 @@ file that was distributed with this source code.
         {% block sonata_page_top_bar %}
             {% block page_top_bar %} {# Deprecated block #}
                 {% if sonata_page.isEditor or ( app.user and is_granted('ROLE_PREVIOUS_ADMIN') ) %}
-                    <header class="sonata-bc sonata-page-top-bar navbar navbar-inverse navbar-fixed-top" role="banner"
+                    <header class="sonata-bc sonata-page-top-bar navbar navbar-inverse navbar-fixed-top" role="banner">
                         <div class="container">
                             <ul class="nav navbar-nav">
                                 {% if app.user and is_granted('ROLE_SONATA_ADMIN') %}
@@ -75,16 +75,16 @@ file that was distributed with this source code.
                                         <a href="#" class="dropdown-toggle" data-toggle="dropdown">Page <span class="caret"></span></a>
                                         <ul class="dropdown-menu">
                                             {% if page is defined %}
-                                                <li><a href="{{ sonata_page_admin.generateUrl('edit', {(sonata_page_admin.idParameter): page.id}) }}" target="_new">{{ "header.edit_page"|trans({}, 'SonataPageBundle') }}</a></li>
-                                                <li><a href="{{ sonata_page_admin.generateUrl('sonata.page.admin.page|sonata.page.admin.snapshot.list', {(sonata_page_admin.idParameter): page.id}) }}" target="_new">{{ "header.create_snapshot"|trans({}, 'SonataPageBundle') }}</a></li>
+                                                <li><a href="{{ sonata_page_admin.generateUrl('edit', {(sonata_page_admin.idParameter): page.id}) }}" target="_blank">{{ "header.edit_page"|trans({}, 'SonataPageBundle') }}</a></li>
+                                                <li><a href="{{ sonata_page_admin.generateUrl('sonata.page.admin.page|sonata.page.admin.snapshot.list', {(sonata_page_admin.idParameter): page.id}) }}" target="_blank">{{ "header.create_snapshot"|trans({}, 'SonataPageBundle') }}</a></li>
                                                 <li class="divider"></li>
                                             {% endif %}
 
-                                            <li><a href="{{ sonata_page_admin.generateUrl('list') }}" target="_new">{{ "header.view_all_pages"|trans({}, 'SonataPageBundle') }}</a></li>
+                                            <li><a href="{{ sonata_page_admin.generateUrl('list') }}" target="_blank">{{ "header.view_all_pages"|trans({}, 'SonataPageBundle') }}</a></li>
 
                                             {% if error_codes is defined and error_codes|length %}
                                                 <li class="divider"></li>
-                                                <li><a href="{{ path('sonata_page_exceptions_list') }}" target="_new">{{ "header.view_all_exceptions"|trans({}, 'SonataPageBundle') }}</a></li>
+                                                <li><a href="{{ path('sonata_page_exceptions_list') }}" target="_blank">{{ "header.view_all_exceptions"|trans({}, 'SonataPageBundle') }}</a></li>
                                             {% endif %}
                                         </ul>
                                     </li>
@@ -106,11 +106,9 @@ file that was distributed with this source code.
                                 {% if app.user and is_granted('ROLE_PREVIOUS_ADMIN') %}
                                     <li><a href="{{ url('homepage', {'_switch_user': '_exit'}) }}">{{ "header.switch_user_exit"|trans({}, 'SonataPageBundle')}}</a></li>
                                 {% endif %}
-
                             </ul>
                         </div>
                     </header>
-
                 {% endif %}
             {% endblock %}
         {% endblock %}

--- a/tests/App/config/routes.yaml
+++ b/tests/App/config/routes.yaml
@@ -10,3 +10,9 @@ _sonata_admin:
 sonata_page_exceptions:
     resource: '@SonataPageBundle/Resources/config/routing/exceptions.xml'
     prefix: /
+
+hybrid_route:
+    path: /hybrid
+    controller: Symfony\Bundle\FrameworkBundle\Controller\TemplateController
+    defaults:
+        template: hybrid.html.twig

--- a/tests/App/templates/hybrid.html.twig
+++ b/tests/App/templates/hybrid.html.twig
@@ -1,0 +1,1 @@
+Original content

--- a/tests/Functional/Command/UpdateCoreRoutesCommandTest.php
+++ b/tests/Functional/Command/UpdateCoreRoutesCommandTest.php
@@ -41,7 +41,7 @@ final class UpdateCoreRoutesCommandTest extends KernelTestCase
 
         $this->commandTester->execute([]);
 
-        static::assertSame(12, $this->countPages());
+        static::assertSame(14, $this->countPages());
 
         static::assertStringContainsString('done!', $this->commandTester->getDisplay());
     }
@@ -54,7 +54,7 @@ final class UpdateCoreRoutesCommandTest extends KernelTestCase
 
         $this->commandTester->execute(['--site' => [1]]);
 
-        static::assertSame(7, $this->countPages());
+        static::assertSame(8, $this->countPages());
 
         static::assertStringContainsString('done!', $this->commandTester->getDisplay());
     }
@@ -70,7 +70,7 @@ final class UpdateCoreRoutesCommandTest extends KernelTestCase
             '--clean' => true,
         ]);
 
-        static::assertSame(6, $this->countPages());
+        static::assertSame(7, $this->countPages());
 
         static::assertStringContainsString('done!', $this->commandTester->getDisplay());
     }

--- a/tests/Functional/Frontend/PageTypesTest.php
+++ b/tests/Functional/Frontend/PageTypesTest.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\PageBundle\Tests\Frontend;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Sonata\PageBundle\Model\PageInterface;
+use Sonata\PageBundle\Tests\App\Entity\SonataPageBlock;
+use Sonata\PageBundle\Tests\App\Entity\SonataPagePage;
+use Sonata\PageBundle\Tests\App\Entity\SonataPageSite;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\BrowserKit\AbstractBrowser;
+use Symfony\Component\BrowserKit\Cookie;
+use Symfony\Component\HttpFoundation\Session\SessionFactoryInterface;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+final class PageTypesTest extends WebTestCase
+{
+    /**
+     * @dataProvider providePages
+     *
+     * @param array<string> $shouldContain
+     * @param array<string> $shouldNotContain
+     */
+    public function testPageRender(PageInterface $page, array $shouldContain, array $shouldNotContain): void
+    {
+        $client = self::createClient();
+
+        $this->prepareData($page);
+        $this->becomeEditor($client);
+
+        $url = $page->getUrl();
+        \assert(null !== $url);
+
+        $client->request('GET', $url);
+
+        self::assertResponseIsSuccessful();
+
+        $content = $client->getResponse()->getContent();
+        \assert(false !== $content);
+
+        foreach ($shouldContain as $string) {
+            static::assertStringContainsString($string, $content);
+        }
+
+        foreach ($shouldNotContain as $string) {
+            static::assertStringNotContainsString($string, $content);
+        }
+    }
+
+    /**
+     * @return iterable<array<PageInterface|array<string>>>
+     *
+     * @phpstan-return iterable<array{0: PageInterface, 1: array<string>, 2: array<string>}>
+     */
+    public static function providePages(): iterable
+    {
+        yield 'CMS Page' => [(static function () {
+            $page = new SonataPagePage();
+            $page->setName('name');
+            $page->setTemplateCode('default');
+            $page->setEnabled(true);
+            $page->setUrl('/hybrid');
+
+            return $page;
+        })(), ['Page content'], ['Original content']];
+
+        yield 'Hybrid Page without decoration' => [(static function () {
+            $page = new SonataPagePage();
+            $page->setName('name');
+            $page->setTemplateCode('default');
+            $page->setEnabled(true);
+            $page->setUrl('/hybrid');
+            $page->setRouteName('hybrid_route');
+            $page->setDecorate(false);
+
+            return $page;
+        })(), ['Original content'], ['Page content']];
+
+        yield 'Hybrid Page' => [(static function () {
+            $page = new SonataPagePage();
+            $page->setName('name');
+            $page->setTemplateCode('default');
+            $page->setEnabled(true);
+            $page->setUrl('/hybrid');
+            $page->setRouteName('hybrid_route');
+
+            return $page;
+        })(), ['Original content', 'Page content'], []];
+    }
+
+    /**
+     * @psalm-suppress UndefinedPropertyFetch
+     */
+    private function prepareData(PageInterface $page): void
+    {
+        // TODO: Simplify this when dropping support for Symfony 4.
+        // @phpstan-ignore-next-line
+        $container = method_exists($this, 'getContainer') ? self::getContainer() : self::$container;
+        $manager = $container->get('doctrine.orm.entity_manager');
+        \assert($manager instanceof EntityManagerInterface);
+
+        $site = new SonataPageSite();
+        $site->setName('name');
+        $site->setHost('localhost');
+        $site->setEnabled(true);
+
+        $containerBlock = new SonataPageBlock();
+        $containerBlock->setType('sonata.page.block.container');
+        $containerBlock->setSetting('code', 'content_top');
+        $containerBlock->setEnabled(true);
+
+        $block = new SonataPageBlock();
+        $block->setType('sonata.block.service.text');
+        $block->setSetting('content', 'Page content');
+        $block->setParent($containerBlock);
+
+        $page->setSite($site);
+        $page->addBlock($containerBlock);
+        $page->addBlock($block);
+
+        $manager->persist($site);
+        $manager->persist($page);
+        $manager->persist($containerBlock);
+        $manager->persist($block);
+
+        $manager->flush();
+    }
+
+    /**
+     * Normally this would happen via an interactive login.
+     * Part of this logic is also copied from AbstractBrowser::loginUser().
+     *
+     * @psalm-suppress UndefinedPropertyFetch
+     */
+    private function becomeEditor(AbstractBrowser $client): void
+    {
+        // TODO: Simplify this when dropping support for Symfony 4.
+        // @phpstan-ignore-next-line
+        $container = method_exists($this, 'getContainer') ? self::getContainer() : self::$container;
+
+        // TODO: Simplify this when dropping support for Symfony 4.
+        if ($container->has('session.factory')) {
+            $sessionFactory = $container->get('session.factory');
+            \assert($sessionFactory instanceof SessionFactoryInterface);
+
+            $session = $sessionFactory->createSession();
+        } else {
+            $session = $container->get('session');
+            \assert($session instanceof SessionInterface);
+        }
+
+        $session->set('sonata/page/isEditor', true);
+        $session->save();
+
+        $domains = array_unique(array_map(
+            static fn (Cookie $cookie) => $cookie->getName() === $session->getName() ? $cookie->getDomain() : '',
+            $client->getCookieJar()->all()
+        ));
+        $domains = [] !== $domains ? $domains : [''];
+
+        foreach ($domains as $domain) {
+            $cookie = new Cookie($session->getName(), $session->getId(), null, null, $domain);
+            $client->getCookieJar()->set($cookie);
+        }
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
Added more test to ensure hybrid pages work. (This can be later used to document how hybrid pages work)

Still missing (next PRs): 
* Disabled pages (For editors they appear to be published)
* Dynamic pages
* Snapshot types