### PR TITLE
Fix breadcrumb block service

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,12 @@
         }
     ],
     "homepage": "https://docs.sonata-project.org/projects/SonataPageBundle",
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/jordisala1991/SonataSeoBundle"
+        }
+    ],
     "require": {
         "php": "^7.4 || ^8.0",
         "cocur/slugify": "^4.0",
@@ -30,7 +36,7 @@
         "sonata-project/doctrine-extensions": "^1.8 || ^2.0",
         "sonata-project/doctrine-orm-admin-bundle": "^4.0",
         "sonata-project/form-extensions": "^1.4",
-        "sonata-project/seo-bundle": "^3.0",
+        "sonata-project/seo-bundle": "dev-hotfix/fix-base-breadcrumb-block-service as 3.0",
         "sonata-project/twig-extensions": "^1.3 || ^2.0",
         "symfony-cmf/routing-bundle": "^2.1 || ^3.0",
         "symfony/config": "^4.4 || ^5.4 || ^6.0",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "sonata-project/doctrine-extensions": "^1.8 || ^2.0",
         "sonata-project/doctrine-orm-admin-bundle": "^4.0",
         "sonata-project/form-extensions": "^1.4",
-        "sonata-project/seo-bundle": "3.x-dev as 3.0",
+        "sonata-project/seo-bundle": "^3.3.0",
         "sonata-project/twig-extensions": "^1.3 || ^2.0",
         "symfony-cmf/routing-bundle": "^2.1 || ^3.0",
         "symfony/config": "^4.4 || ^5.4 || ^6.0",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "sonata-project/doctrine-extensions": "^1.8 || ^2.0",
         "sonata-project/doctrine-orm-admin-bundle": "^4.0",
         "sonata-project/form-extensions": "^1.4",
-        "sonata-project/seo-bundle": "^3.3.0",
+        "sonata-project/seo-bundle": "^3.3",
         "sonata-project/twig-extensions": "^1.3 || ^2.0",
         "symfony-cmf/routing-bundle": "^2.1 || ^3.0",
         "symfony/config": "^4.4 || ^5.4 || ^6.0",

--- a/composer.json
+++ b/composer.json
@@ -20,12 +20,6 @@
         }
     ],
     "homepage": "https://docs.sonata-project.org/projects/SonataPageBundle",
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/jordisala1991/SonataSeoBundle"
-        }
-    ],
     "require": {
         "php": "^7.4 || ^8.0",
         "cocur/slugify": "^4.0",
@@ -36,7 +30,7 @@
         "sonata-project/doctrine-extensions": "^1.8 || ^2.0",
         "sonata-project/doctrine-orm-admin-bundle": "^4.0",
         "sonata-project/form-extensions": "^1.4",
-        "sonata-project/seo-bundle": "dev-hotfix/fix-base-breadcrumb-block-service as 3.0",
+        "sonata-project/seo-bundle": "3.x-dev as 3.0",
         "sonata-project/twig-extensions": "^1.3 || ^2.0",
         "symfony-cmf/routing-bundle": "^2.1 || ^3.0",
         "symfony/config": "^4.4 || ^5.4 || ^6.0",

--- a/src/Block/BreadcrumbBlockService.php
+++ b/src/Block/BreadcrumbBlockService.php
@@ -16,6 +16,8 @@ namespace Sonata\PageBundle\Block;
 use Knp\Menu\FactoryInterface;
 use Knp\Menu\ItemInterface;
 use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Block\Service\BlockServiceInterface;
+use Sonata\BlockBundle\Block\Service\EditableBlockService;
 use Sonata\BlockBundle\Meta\Metadata;
 use Sonata\BlockBundle\Meta\MetadataInterface;
 use Sonata\PageBundle\CmsManager\CmsManagerSelectorInterface;
@@ -30,12 +32,16 @@ final class BreadcrumbBlockService extends BaseBreadcrumbMenuBlockService
 {
     private CmsManagerSelectorInterface $cmsSelector;
 
+    /**
+     * @param BlockServiceInterface&EditableBlockService $menuBlock
+     */
     public function __construct(
         Environment $twig,
+        object $menuBlock,
         FactoryInterface $factory,
         CmsManagerSelectorInterface $cmsSelector
     ) {
-        parent::__construct($twig, $factory);
+        parent::__construct($twig, $menuBlock, $factory);
 
         $this->cmsSelector = $cmsSelector;
     }

--- a/src/Resources/config/block.php
+++ b/src/Resources/config/block.php
@@ -44,6 +44,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->tag('sonata.breadcrumb')
             ->args([
                 new ReferenceConfigurator('twig'),
+                new ReferenceConfigurator('sonata.block.service.menu'),
                 new ReferenceConfigurator('knp_menu.factory'),
                 new ReferenceConfigurator('sonata.page.cms_manager_selector'),
             ])

--- a/tests/Functional/Admin/SharedBlockAdminTest.php
+++ b/tests/Functional/Admin/SharedBlockAdminTest.php
@@ -141,11 +141,22 @@ final class SharedBlockAdminTest extends WebTestCase
             'shared_block[settings][template]' => '@SonataPage/Block/block_container.html.twig',
         ]];
 
-        // yield 'Create Shared Block - Breadcrumb' => ['/admin/tests/app/sonatapageblock/shared/create', [
-        //     'uniqid' => 'shared_block',
-        //     'type' => 'sonata.page.block.breadcrumb',
-        // ], 'btn_create_and_list', [
-        // ]];
+        yield 'Create Shared Block - Breadcrumb' => ['/admin/tests/app/sonatapageblock/shared/create', [
+            'uniqid' => 'shared_block',
+            'type' => 'sonata.page.block.breadcrumb',
+        ], 'btn_create_and_list', [
+            'shared_block[name]' => 'Name',
+            'shared_block[enabled]' => 1,
+            'shared_block[settings][title]' => 'Title',
+            'shared_block[settings][menu_name]' => 'sonata_admin_sidebar',
+            'shared_block[settings][safe_labels]' => 1,
+            'shared_block[settings][current_class]' => 'current',
+            'shared_block[settings][first_class]' => 'first',
+            'shared_block[settings][last_class]' => 'last',
+            'shared_block[settings][menu_class]' => 'menu',
+            'shared_block[settings][children_class]' => 'children',
+            'shared_block[settings][menu_template]' => 'default',
+        ]];
 
         yield 'Create Shared Block - Shared Block' => ['/admin/tests/app/sonatapageblock/shared/create', [
             'uniqid' => 'shared_block',


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
Fixing the last test for Blocks.