### PR TITLE
Removed deprecated blocks from base_layout.html.twig

### DIFF
--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -13,6 +13,27 @@ Please read [3.x](https://github.com/sonata-project/SonataPageBundle/tree/3.x) u
 
 See also the [diff code](https://github.com/sonata-project/SonataPageBundle/compare/3.x...4.0.0).
 
+### Template
+
+Remove deprecate blocks from `base_layout.html.twig`
+
+```diff
+- {% block page_stylesheets %}
++ {% block sonata_page_stylesheets %}
+...
+- {% block page_javascripts  %}
++ {% block sonata_page_javascripts  %}
+...
+- {% block page_top_bar  %}
++ {% block sonata_page_top_bar  %}
+...
+- {% block page_container  %}
++ {% block sonata_page_container  %}
+...
+- {% block page_asset_footer  %}
++ {% block sonata_page_asset_footer  %}
+```
+
 ## Slugify Service
 
 This config was removed from sonata page configuration, make sure that, you do not have this anymore into your configs.

--- a/src/Resources/views/base_layout.html.twig
+++ b/src/Resources/views/base_layout.html.twig
@@ -14,21 +14,14 @@ file that was distributed with this source code.
 {% endblock %}
     {% block sonata_page_head %}
         <head {{ sonata_seo_head_attributes() }}>
-
-            <!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
             {{ sonata_seo_title() }}
             {{ sonata_seo_metadatas() }}
 
             {% block sonata_page_stylesheets %}
-                {% block page_stylesheets %} {# Deprecated block #}
-                        <link rel="stylesheet" href="{{ asset('bundles/sonatapage/frontend.css') }}" media="all">
-                {% endblock %}
+                <link rel="stylesheet" href="{{ asset('bundles/sonatapage/frontend.css') }}" media="all">
             {% endblock %}
 
-            {% block sonata_page_javascripts %}
-                {% block page_javascripts %} {# Deprecated block #}
-                {% endblock %}
-            {% endblock %}
+            {% block sonata_page_javascripts %}{% endblock %}
         </head>
     {% endblock %}
 
@@ -37,7 +30,6 @@ file that was distributed with this source code.
     {% endblock %}
 
         {% block sonata_page_top_bar %}
-            {% block page_top_bar %} {# Deprecated block #}
                 {% if sonata_page.isEditor or ( app.user and is_granted('ROLE_PREVIOUS_ADMIN') ) %}
                     <header class="sonata-bc sonata-page-top-bar navbar navbar-inverse navbar-fixed-top" role="banner">
                         <div class="container">
@@ -99,15 +91,11 @@ file that was distributed with this source code.
                         </div>
                     </header>
                 {% endif %}
-            {% endblock %}
         {% endblock %}
 
-        {% block sonata_page_container %}
-            {% block page_container %}{% endblock %} {# Deprecated block #}
-        {% endblock %}
+        {% block sonata_page_container %}{% endblock %}
 
         {% block sonata_page_asset_footer %}
-            {% block page_asset_footer %} {# Deprecated block #}
                 {% if page is defined %}
                     {% if page.javascript is not empty %}
                         <script>
@@ -126,9 +114,6 @@ file that was distributed with this source code.
                 #}
                 {{ sonata_block_include_stylesheets('screen', app.request.basePath) }}
                 {{ sonata_block_include_javascripts('screen', app.request.basePath) }}
-            {% endblock %}
         {% endblock %}
-
-        <!-- monitoring:3e9fda56df2cdd3b039f189693ab7844fbb2d4f6 -->
     </body>
 </html>

--- a/src/Resources/views/base_layout.html.twig
+++ b/src/Resources/views/base_layout.html.twig
@@ -30,90 +30,90 @@ file that was distributed with this source code.
     {% endblock %}
 
         {% block sonata_page_top_bar %}
-                {% if sonata_page.isEditor or ( app.user and is_granted('ROLE_PREVIOUS_ADMIN') ) %}
-                    <header class="sonata-bc sonata-page-top-bar navbar navbar-inverse navbar-fixed-top" role="banner">
-                        <div class="container">
-                            <ul class="nav navbar-nav">
-                                {% if app.user and is_granted('ROLE_SONATA_ADMIN') %}
-                                    <li><a href="{{ path('sonata_admin_dashboard') }}">{{ "header.sonata_admin_dashboard"|trans({}, 'SonataPageBundle') }}</a></li>
-                                {% endif %}
+            {% if sonata_page.isEditor or ( app.user and is_granted('ROLE_PREVIOUS_ADMIN') ) %}
+                <header class="sonata-bc sonata-page-top-bar navbar navbar-inverse navbar-fixed-top" role="banner">
+                    <div class="container">
+                        <ul class="nav navbar-nav">
+                            {% if app.user and is_granted('ROLE_SONATA_ADMIN') %}
+                                <li><a href="{{ path('sonata_admin_dashboard') }}">{{ "header.sonata_admin_dashboard"|trans({}, 'SonataPageBundle') }}</a></li>
+                            {% endif %}
 
-                                {% if sonata_page.isEditor %}
-                                    {% set sites = sonata_page.siteavailables %}
+                            {% if sonata_page.isEditor %}
+                                {% set sites = sonata_page.siteavailables %}
 
-                                    {% if sites|length > 1 and site is defined %}
-                                        <li class="dropdown">
-                                            <a href="#" class="dropdown-toggle" data-toggle="dropdown">{{ site.name }} <span class="caret"></span></a>
-                                            <ul class="dropdown-menu">
-                                                {% for site in sites %}
-                                                    <li><a href="{{ site.url }}">{{ site.name }}</a></li>
-                                                {% endfor %}
-                                            </ul>
-                                        </li>
-                                    {% endif %}
-
+                                {% if sites|length > 1 and site is defined %}
                                     <li class="dropdown">
-                                        <a href="#" class="dropdown-toggle" data-toggle="dropdown">Page <span class="caret"></span></a>
+                                        <a href="#" class="dropdown-toggle" data-toggle="dropdown">{{ site.name }} <span class="caret"></span></a>
                                         <ul class="dropdown-menu">
-                                            {% if page is defined %}
-                                                <li><a href="{{ sonata_page_admin.generateUrl('edit', {(sonata_page_admin.idParameter): page.id}) }}" target="_blank">{{ "header.edit_page"|trans({}, 'SonataPageBundle') }}</a></li>
-                                                <li><a href="{{ sonata_page_admin.generateUrl('sonata.page.admin.page|sonata.page.admin.snapshot.list', {(sonata_page_admin.idParameter): page.id}) }}" target="_blank">{{ "header.create_snapshot"|trans({}, 'SonataPageBundle') }}</a></li>
-                                                <li class="divider"></li>
-                                            {% endif %}
-
-                                            <li><a href="{{ sonata_page_admin.generateUrl('list') }}" target="_blank">{{ "header.view_all_pages"|trans({}, 'SonataPageBundle') }}</a></li>
-
-                                            {% if error_codes is defined and error_codes|length %}
-                                                <li class="divider"></li>
-                                                <li><a href="{{ path('sonata_page_exceptions_list') }}" target="_blank">{{ "header.view_all_exceptions"|trans({}, 'SonataPageBundle') }}</a></li>
-                                            {% endif %}
+                                            {% for site in sites %}
+                                                <li><a href="{{ site.url }}">{{ site.name }}</a></li>
+                                            {% endfor %}
                                         </ul>
                                     </li>
-
-                                    {% if page is defined %}
-                                        <li>
-                                            <a href="{{ sonata_page_admin.generateUrl('compose', {(sonata_page_admin.idParameter): page.id}) }}">
-                                                <i class="fa fa-magic"></i>
-                                                {{ 'header.compose_page'|trans({}, 'SonataPageBundle')}}
-                                            </a>
-                                        </li>
-                                    {% endif %}
-
-                                    {% if page is defined and not page.enabled %}
-                                        <li><span style="padding-left: 20px; background: red;"><strong><em>{{ 'header.page_is_disabled'|trans([], 'SonataPageBundle') }}</em></strong></span></li>
-                                    {% endif %}
                                 {% endif %}
 
-                                {% if app.user and is_granted('ROLE_PREVIOUS_ADMIN') %}
-                                    <li><a href="{{ url('homepage', {'_switch_user': '_exit'}) }}">{{ "header.switch_user_exit"|trans({}, 'SonataPageBundle')}}</a></li>
+                                <li class="dropdown">
+                                    <a href="#" class="dropdown-toggle" data-toggle="dropdown">Page <span class="caret"></span></a>
+                                    <ul class="dropdown-menu">
+                                        {% if page is defined %}
+                                            <li><a href="{{ sonata_page_admin.generateUrl('edit', {(sonata_page_admin.idParameter): page.id}) }}" target="_blank">{{ "header.edit_page"|trans({}, 'SonataPageBundle') }}</a></li>
+                                            <li><a href="{{ sonata_page_admin.generateUrl('sonata.page.admin.page|sonata.page.admin.snapshot.list', {(sonata_page_admin.idParameter): page.id}) }}" target="_blank">{{ "header.create_snapshot"|trans({}, 'SonataPageBundle') }}</a></li>
+                                            <li class="divider"></li>
+                                        {% endif %}
+
+                                        <li><a href="{{ sonata_page_admin.generateUrl('list') }}" target="_blank">{{ "header.view_all_pages"|trans({}, 'SonataPageBundle') }}</a></li>
+
+                                        {% if error_codes is defined and error_codes|length %}
+                                            <li class="divider"></li>
+                                            <li><a href="{{ path('sonata_page_exceptions_list') }}" target="_blank">{{ "header.view_all_exceptions"|trans({}, 'SonataPageBundle') }}</a></li>
+                                        {% endif %}
+                                    </ul>
+                                </li>
+
+                                {% if page is defined %}
+                                    <li>
+                                        <a href="{{ sonata_page_admin.generateUrl('compose', {(sonata_page_admin.idParameter): page.id}) }}">
+                                            <i class="fa fa-magic"></i>
+                                            {{ 'header.compose_page'|trans({}, 'SonataPageBundle')}}
+                                        </a>
+                                    </li>
                                 {% endif %}
-                            </ul>
-                        </div>
-                    </header>
-                {% endif %}
+
+                                {% if page is defined and not page.enabled %}
+                                    <li><span style="padding-left: 20px; background: red;"><strong><em>{{ 'header.page_is_disabled'|trans([], 'SonataPageBundle') }}</em></strong></span></li>
+                                {% endif %}
+                            {% endif %}
+
+                            {% if app.user and is_granted('ROLE_PREVIOUS_ADMIN') %}
+                                <li><a href="{{ url('homepage', {'_switch_user': '_exit'}) }}">{{ "header.switch_user_exit"|trans({}, 'SonataPageBundle')}}</a></li>
+                            {% endif %}
+                        </ul>
+                    </div>
+                </header>
+            {% endif %}
         {% endblock %}
 
         {% block sonata_page_container %}{% endblock %}
 
         {% block sonata_page_asset_footer %}
-                {% if page is defined %}
-                    {% if page.javascript is not empty %}
-                        <script>
-                            {{ page.javascript|raw }}
-                        </script>
-                    {% endif %}
-                    {% if page.stylesheet is not empty %}
-                        <style>
-                            {{ page.stylesheet|raw }}
-                        </style>
-                    {% endif %}
+            {% if page is defined %}
+                {% if page.javascript is not empty %}
+                    <script>
+                        {{ page.javascript|raw }}
+                    </script>
                 {% endif %}
-                {#
-                    These includes can be done only at this point as all blocks are loaded,
-                    Limition : this does not work if a global page is loaded from an ESI tag inside a container block
-                #}
-                {{ sonata_block_include_stylesheets('screen', app.request.basePath) }}
-                {{ sonata_block_include_javascripts('screen', app.request.basePath) }}
+                {% if page.stylesheet is not empty %}
+                    <style>
+                        {{ page.stylesheet|raw }}
+                    </style>
+                {% endif %}
+            {% endif %}
+            {#
+                These includes can be done only at this point as all blocks are loaded,
+                Limition : this does not work if a global page is loaded from an ESI tag inside a container block
+            #}
+            {{ sonata_block_include_stylesheets('screen', app.request.basePath) }}
+            {{ sonata_block_include_javascripts('screen', app.request.basePath) }}
         {% endblock %}
     </body>
 </html>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Removing deprecate blocks from base_layout

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because it was deprecated in 3.x and should be removed in 4.x.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataPageBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Removed deprecate `page_stylesheets` block from `base_layout.html.twig`
- Removed deprecate `page_javascripts` block from `base_layout.html.twig`
- Removed deprecate `page_top_bar` block from `base_layout.html.twig`
- Removed deprecate `page_container` block from `base_layout.html.twig`
- Removed deprecate `page_asset_footer` block from `base_layout.html.twig`
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
