### PR TITLE
Remove group legacy from tests

### DIFF
--- a/tests/Form/Type/PageSelectorTypeTest.php
+++ b/tests/Form/Type/PageSelectorTypeTest.php
@@ -92,9 +92,6 @@ final class PageSelectorTypeTest extends TestCase
         return $manager;
     }
 
-    /**
-     * @group legacy
-     */
     public function testNoSite(): void
     {
         $pageSelector = new PageSelectorType($this->getPageManager());
@@ -108,9 +105,6 @@ final class PageSelectorTypeTest extends TestCase
         static::assertSame([], $options['choices']);
     }
 
-    /**
-     * @group legacy
-     */
     public function testAllRequestMethodChoices(): void
     {
         $pageSelector = new PageSelectorType($this->getPageManager());

--- a/tests/Route/CmsPageRouterTest.php
+++ b/tests/Route/CmsPageRouterTest.php
@@ -201,9 +201,6 @@ final class CmsPageRouterTest extends TestCase
         static::assertSame('//localhost/test/path?key=value', $url);
     }
 
-    /**
-     * @group legacy
-     */
     public function testGenerateWithPageCustomUrl(): void
     {
         $page = $this->createMock(PageInterface::class);
@@ -235,9 +232,6 @@ final class CmsPageRouterTest extends TestCase
         static::assertSame('//localhost/test/path?key=value', $url);
     }
 
-    /**
-     * @group legacy
-     */
     public function testGenerateWithHybridPage(): void
     {
         $page = $this->createMock(PageInterface::class);
@@ -267,9 +261,6 @@ final class CmsPageRouterTest extends TestCase
         static::assertSame('//localhost/test/path?key=value', $url);
     }
 
-    /**
-     * @group legacy
-     */
     public function testGenerateWithPageAlias(): void
     {
         $page = $this->createMock(PageInterface::class);

--- a/tests/Validator/UniqueUrlValidatorTest.php
+++ b/tests/Validator/UniqueUrlValidatorTest.php
@@ -54,9 +54,6 @@ final class UniqueUrlValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
-    /**
-     * @group legacy
-     */
     public function testValidateWithNoPageFound(): void
     {
         $site = $this->createMock(SiteInterface::class);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is needed for 4.x.
