### PR TITLE
PR - Proposition for issue #1609

### DIFF
--- a/assets/scss/composer.scss
+++ b/assets/scss/composer.scss
@@ -483,6 +483,11 @@ $color_red: #f56954;
   border-left-color: $color_blue;
 }
 
+.page-composer__container__child__edit.error {
+  background: #fff;
+  border-left-color: $color_red;
+}
+
 .page-composer__container__child--expanded .page-composer__container__child__edit {
   border-left-color: $color_blue;
   box-shadow: 0 0 2px rgb(0 0 0 / 35%) inset;

--- a/assets/scss/composer.scss
+++ b/assets/scss/composer.scss
@@ -483,7 +483,7 @@ $color_red: #f56954;
   border-left-color: $color_blue;
 }
 
-.page-composer__container__child__edit.error {
+.page-composer__container__child__edit.error, .page-composer__container__child__edit.error:hover {
   background: #fff;
   border-left-color: $color_red;
 }

--- a/src/Resources/views/BlockAdmin/compose_preview.html.twig
+++ b/src/Resources/views/BlockAdmin/compose_preview.html.twig
@@ -28,7 +28,7 @@
                 <i class="fa fa-chevron-up"></i>
             </span>
         {% else %}
-            {{ ('block_service_not_found')|trans({}, metadata.domain|default('SonataPageBundle')) ~ ': ' ~ child.name|default(child.type) }}
+            {{ ('block_service_not_found')|trans({}, metadata.domain|default('SonataPageBundle')) ~ ' (' ~ child.name|default(child.type)|trans({}, metadata.domain|default('SonataPageBundle')) ~ ')' }}
         {% endif %}
     </a>
 

--- a/src/Resources/views/BlockAdmin/compose_preview.html.twig
+++ b/src/Resources/views/BlockAdmin/compose_preview.html.twig
@@ -7,25 +7,29 @@
     <a class="page-composer__container__child__edit"
        href="{{ blockAdmin.generateUrl('edit', { 'id': child.id, 'composer': true }) }}"
     >
-        {% set service = attribute(blockServices, child.type) %}
-        {% if service.metadata is defined %}
-            {% set metadata = service.metadata %}
+        {% set service = attribute(blockServices, child.type) ?? null %}
+        {% if service is not null %}
+            {% if service.metadata is defined %}
+                {% set metadata = service.metadata %}
+            {% else %}
+                {% set metadata = service.blockMetadata %}
+            {% endif %}
+            <h4 class="page-composer__container__child__name">
+                {{ child.name|default(metadata.title)|trans({}, metadata.domain|default('SonataPageBundle')) }}
+            </h4>
+            {% if not metadata.image %}
+                <i class="{{ metadata.option('class') }}" ></i>
+            {% else %}
+                <img src="{{ asset(metadata.image) }}" style="max-height: 20px; max-width: 100px;"/>
+            {% endif %}
+            <small>{{ metadata.title|trans({}, metadata.domain|default('SonataPageBundle')) }}</small>
+            <span class="page-composer__container__child__toggle">
+                <i class="fa fa-chevron-down"></i>
+                <i class="fa fa-chevron-up"></i>
+            </span>
         {% else %}
-            {% set metadata = service.blockMetadata %}
+            {{ child.type }}
         {% endif %}
-        <h4 class="page-composer__container__child__name">
-            {{ child.name|default(metadata.title)|trans({}, metadata.domain|default('SonataPageBundle')) }}
-        </h4>
-        {% if not metadata.image %}
-            <i class="{{ metadata.option('class') }}" ></i>
-        {% else %}
-            <img src="{{ asset(metadata.image) }}" style="max-height: 20px; max-width: 100px;"/>
-        {% endif %}
-        <small>{{ metadata.title|trans({}, metadata.domain|default('SonataPageBundle')) }}</small>
-        <span class="page-composer__container__child__toggle">
-            <i class="fa fa-chevron-down"></i>
-            <i class="fa fa-chevron-up"></i>
-        </span>
     </a>
 
     <div class="page-composer__container__child__right">
@@ -33,37 +37,45 @@
             <a class="badge" href="{{ blockAdmin.generateUrl('delete', { 'id': child.id }) }}">{{ 'composer.remove'|trans({}, 'SonataPageBundle') }} <i class="fa fa-times"></i> </a>
         </div>
 
-        <div
-            class="page-composer__container__child__switch-enabled"
-            data-label-enable="{{ ('composer.enable'|trans({}, 'SonataPageBundle') ~ ' <i class="fa fa-toggle-on"></i>')|e }}"
-            data-label-disable="{{ ('composer.disable'|trans({}, 'SonataPageBundle') ~ ' <i class="fa fa-toggle-off"></i>')|e }}"
-        >
-            <a
-                class="badge bg-{{ child.enabled ? 'yellow' : 'green' }}"
-                href="{{ path('sonata_admin_set_object_field_value', {
-                    'objectId': child.id,
-                    'context': 'list',
-                    'field': 'enabled',
-                    '_sonata_admin': 'sonata.page.admin.block'
-                }) }}">
-                    {% if child.enabled %}{{ 'composer.disable'|trans({}, 'SonataPageBundle') }}
-                        <i class="fa fa-toggle-off"></i>
-                    {% else %}
-                        {{ 'composer.enable'|trans({}, 'SonataPageBundle') }}
-                        <i class="fa fa-toggle-on"></i>
-                    {% endif %}
-            </a>
-        </div>
+        {% if service is not null %}
+
+            <div
+                class="page-composer__container__child__switch-enabled"
+                data-label-enable="{{ ('composer.enable'|trans({}, 'SonataPageBundle') ~ ' <i class="fa fa-toggle-on"></i>')|e }}"
+                data-label-disable="{{ ('composer.disable'|trans({}, 'SonataPageBundle') ~ ' <i class="fa fa-toggle-off"></i>')|e }}"
+            >
+                <a
+                    class="badge bg-{{ child.enabled ? 'yellow' : 'green' }}"
+                    href="{{ path('sonata_admin_set_object_field_value', {
+                        'objectId': child.id,
+                        'context': 'list',
+                        'field': 'enabled',
+                        '_sonata_admin': 'sonata.page.admin.block'
+                    }) }}">
+                        {% if child.enabled %}{{ 'composer.disable'|trans({}, 'SonataPageBundle') }}
+                            <i class="fa fa-toggle-off"></i>
+                        {% else %}
+                            {{ 'composer.enable'|trans({}, 'SonataPageBundle') }}
+                            <i class="fa fa-toggle-on"></i>
+                        {% endif %}
+                </a>
+            </div>
+
+        {% endif %}
 
         <div class="page-composer__container__child__enabled">
             <small class="badge bg-{{ child.enabled ? 'green' : 'yellow' }}"><i class="fa fa-{{ child.enabled ? 'check' : 'times' }}"></i></small>
         </div>
     </div>
 
-    <div class="page-composer__container__child__content">
-    </div>
+    {% if service is not null %}
 
-    <div class="page-composer__container__child__loader">
-        <span>{{ 'loading'|trans({}, 'SonataPageBundle') }}</span>
-    </div>
+        <div class="page-composer__container__child__content">
+        </div>
+
+        <div class="page-composer__container__child__loader">
+            <span>{{ 'loading'|trans({}, 'SonataPageBundle') }}</span>
+        </div>
+
+    {% endif %}
 </li>

--- a/src/Resources/views/BlockAdmin/compose_preview.html.twig
+++ b/src/Resources/views/BlockAdmin/compose_preview.html.twig
@@ -4,10 +4,10 @@
     data-block-enabled="{{ child.enabled|default('0') }}"
     data-block-type="{{ child.type }}"
 >
-    <a class="page-composer__container__child__edit"
+    {% set service = attribute(blockServices, child.type) ?? null %}
+    <a class="page-composer__container__child__edit{{ service is null ? ' error' : '' }}"
        href="{{ blockAdmin.generateUrl('edit', { 'id': child.id, 'composer': true }) }}"
     >
-        {% set service = attribute(blockServices, child.type) ?? null %}
         {% if service is not null %}
             {% if service.metadata is defined %}
                 {% set metadata = service.metadata %}
@@ -28,7 +28,7 @@
                 <i class="fa fa-chevron-up"></i>
             </span>
         {% else %}
-            {{ child.type }}
+            {{ ('block_service_not_found')|trans({}, metadata.domain|default('SonataPageBundle')) ~ ': ' ~ child.name|default(child.type) }}
         {% endif %}
     </a>
 
@@ -61,11 +61,11 @@
                 </a>
             </div>
 
-        {% endif %}
+            <div class="page-composer__container__child__enabled">
+                <small class="badge bg-{{ child.enabled ? 'green' : 'yellow' }}"><i class="fa fa-{{ child.enabled ? 'check' : 'times' }}"></i></small>
+            </div>
 
-        <div class="page-composer__container__child__enabled">
-            <small class="badge bg-{{ child.enabled ? 'green' : 'yellow' }}"><i class="fa fa-{{ child.enabled ? 'check' : 'times' }}"></i></small>
-        </div>
+        {% endif %}
     </div>
 
     {% if service is not null %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Keep the blocks into the page rendering even if some blocks does not exists

<!-- Describe your Pull Request content here -->
To fix BO issue I've add a `?? null` into twig file `sonata-project/page-bundle/src/Resources/views/BlockAdmin/compose_preview.html.twig`
```
{% set service = attribute(blockServices, child.type) ?? null %}
```
In case of service is null :
- removed render and display bloc type instead
- keep only the remove button

I am targeting branch 4.x to help finish 4.0 version

Related to issue #1609.

## Similar error In front-end

~~To fix same issue in front it's related to SonataBlockBundle :~~

~~into \Sonata\BlockBundle\Block\BlockRenderer::render into the `catch (\Throwable $exception) {` section here an idee to fix it :~~

```php
#if ($exception instanceof RuntimeError && !empty($_SERVER['APP_DEBUG'])) {
#    return new Response();
#}
```

Fixed [here](https://github.com/sonata-project/SonataBlockBundle/pull/1115)  
