### PR TITLE
Not render block that does not exist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "doctrine/doctrine-bundle": "^2.5",
         "doctrine/persistence": "^2.1 || ^3.0",
         "sonata-project/admin-bundle": "^4.15",
-        "sonata-project/block-bundle": "^4.16.2",
+        "sonata-project/block-bundle": "^4.17",
         "sonata-project/doctrine-extensions": "^1.18 || ^2.1",
         "sonata-project/doctrine-orm-admin-bundle": "^4.0",
         "sonata-project/form-extensions": "^1.4",

--- a/src/Resources/config/twig.php
+++ b/src/Resources/config/twig.php
@@ -29,6 +29,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 new ReferenceConfigurator('router'),
                 new ReferenceConfigurator('sonata.block.templating.helper'),
                 new ReferenceConfigurator('request_stack'),
+                new ReferenceConfigurator('logger'),
                 '%sonata.page.hide_disabled_blocks%',
             ])
 

--- a/src/Twig/Extension/PageExtension.php
+++ b/src/Twig/Extension/PageExtension.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\PageBundle\Twig\Extension;
 
+use Sonata\BlockBundle\Exception\BlockNotFoundException;
 use Sonata\BlockBundle\Templating\Helper\BlockHelper;
 use Sonata\PageBundle\CmsManager\CmsManagerSelectorInterface;
 use Sonata\PageBundle\Exception\PageNotFoundException;
@@ -183,15 +184,21 @@ final class PageExtension extends AbstractExtension
      */
     public function renderBlock(PageBlockInterface $block, array $options = []): string
     {
-        if (
-            false === $block->getEnabled()
-            && !$this->cmsManagerSelector->isEditor()
-            && $this->hideDisabledBlocks
-        ) {
+        try {
+            if (
+                false === $block->getEnabled()
+                && !$this->cmsManagerSelector->isEditor()
+                && $this->hideDisabledBlocks
+            ) {
+                return '';
+            }
+
+            return $this->blockHelper->render($block, $options);
+        } catch (BlockNotFoundException $exception) {
+            //TODO add log here
+            // TODO it requires block chnages
             return '';
         }
-
-        return $this->blockHelper->render($block, $options);
     }
 
     /**

--- a/src/Twig/Extension/PageExtension.php
+++ b/src/Twig/Extension/PageExtension.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\PageBundle\Twig\Extension;
 
+use Psr\Log\LoggerInterface;
 use Sonata\BlockBundle\Exception\BlockNotFoundException;
 use Sonata\BlockBundle\Templating\Helper\BlockHelper;
 use Sonata\PageBundle\CmsManager\CmsManagerSelectorInterface;
@@ -47,6 +48,8 @@ final class PageExtension extends AbstractExtension
 
     private RequestStack $requestStack;
 
+    private LoggerInterface $logger;
+
     private bool $hideDisabledBlocks;
 
     public function __construct(
@@ -55,6 +58,7 @@ final class PageExtension extends AbstractExtension
         RouterInterface $router,
         BlockHelper $blockHelper,
         RequestStack $requestStack,
+        LoggerInterface $logger,
         bool $hideDisabledBlocks = false
     ) {
         $this->cmsManagerSelector = $cmsManagerSelector;
@@ -62,6 +66,7 @@ final class PageExtension extends AbstractExtension
         $this->router = $router;
         $this->blockHelper = $blockHelper;
         $this->requestStack = $requestStack;
+        $this->logger = $logger;
         $this->hideDisabledBlocks = $hideDisabledBlocks;
     }
 
@@ -187,7 +192,7 @@ final class PageExtension extends AbstractExtension
         try {
             if (
                 false === $block->getEnabled()
-                && !$this->cmsManagerSelector->isEditor()
+                && false === $this->cmsManagerSelector->isEditor()
                 && $this->hideDisabledBlocks
             ) {
                 return '';
@@ -195,8 +200,8 @@ final class PageExtension extends AbstractExtension
 
             return $this->blockHelper->render($block, $options);
         } catch (BlockNotFoundException $exception) {
-            //TODO add log here
-            // TODO it requires block chnages
+            $this->logger->error($exception->getMessage(), ['previous_exception' => $exception]);
+
             return '';
         }
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Not render block that does not exist

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because it requires a fix in sonata block bundle 4.x and it's supported only for page bundle 4.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Issue #1609.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataPageBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Skipping blocks that doesn't exist from the page.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
