### PR TITLE
Support list_action_button_content in buttons

### DIFF
--- a/src/Resources/views/SiteAdmin/list_action_create_snapshots.html.twig
+++ b/src/Resources/views/SiteAdmin/list_action_create_snapshots.html.twig
@@ -10,11 +10,21 @@ file that was distributed with this source code.
 #}
 
 {% if admin.hasRoute('snapshots') %}
+    {% set button_content = sonata_config.getOption('list_action_button_content') %}
     <a
         href="{{ admin.generateObjectUrl('snapshots', object) }}"
         class="btn btn-sm btn-default"
         title="{{ 'link_create_snapshots'|trans({}, 'SonataPageBundle') }}"
     >
-        {{ 'link_create_snapshots'|trans({}, 'SonataPageBundle') }}
+        {% if button_content == 'icon' or button_content == 'all' %}
+            <i class="fas fa-upload" aria-hidden="true"></i>
+        {% endif %}
+        {% if button_content == 'text' or button_content == 'all' %}
+            {{ 'link_create_snapshots'|trans({}, 'SonataPageBundle') }}
+        {% else %}
+            <span class="sr-only">
+                {{ 'link_create_snapshots'|trans({}, 'SonataPageBundle') }}
+            </span>
+        {% endif %}
     </a>
 {% endif %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is a minor fix. The setting `list_action_button_content` exists since SonataAdmin 3.x. as well as `sonata_config`global Twig variable.

Feel free to change the icon (not present before this PR) for the "create publications" button. I've chosen the fa-upload icon.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1659
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataPageBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Usage of list_action_button_content options and create publications icon
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
