### PR TITLE
Fix page admin filter by type throwing

### DIFF
--- a/src/Admin/PageAdmin.php
+++ b/src/Admin/PageAdmin.php
@@ -18,6 +18,7 @@ use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
+use Sonata\AdminBundle\Filter\Model\FilterData;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Route\RouteCollectionInterface;
 use Sonata\AdminBundle\Security\Acl\Permission\AdminPermissionMap;
@@ -194,13 +195,17 @@ final class PageAdmin extends AbstractAdmin
             ->add('parent')
             ->add('edited')
             ->add('hybrid', CallbackFilter::class, [
-                'callback' => static function (ProxyQueryInterface $queryBuilder, string $alias, string $field, array $data): void {
+                'callback' => static function (ProxyQueryInterface $queryBuilder, string $alias, string $field, FilterData $data): bool {
                     $builder = $queryBuilder->getQueryBuilder();
 
-                    if (\in_array($data['value'], ['hybrid', 'cms'], true)) {
-                        $builder->andWhere(sprintf('%s.routeName %s :routeName', $alias, 'cms' === $data['value'] ? '=' : '!='));
+                    if (\in_array($data->getValue(), ['hybrid', 'cms'], true)) {
+                        $builder->andWhere(sprintf('%s.routeName %s :routeName', $alias, 'cms' === $data->getValue() ? '=' : '!='));
                         $builder->setParameter('routeName', PageInterface::PAGE_ROUTE_CMS_NAME);
+
+                        return true;
                     }
+
+                    return false;
                 },
                 'field_options' => [
                     'required' => false,


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is a bugfix. Thanks to @VincentLanglet pointing us to the resolution.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1652.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataPageBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Page admin filter by page type.

```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
