### PR TITLE
Remove twig form themes config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "sonata-project/block-bundle": "^4.18 || ^5.0",
         "sonata-project/doctrine-extensions": "^1.18 || ^2.1",
         "sonata-project/doctrine-orm-admin-bundle": "^4.0",
-        "sonata-project/form-extensions": "^1.4 || ^2.0",
+        "sonata-project/form-extensions": "^1.20 || ^2.0",
         "sonata-project/seo-bundle": "^3.4",
         "sonata-project/twig-extensions": "^1.3 || ^2.0",
         "symfony-cmf/routing-bundle": "^2.1 || ^3.0",

--- a/src/DependencyInjection/SonataPageExtension.php
+++ b/src/DependencyInjection/SonataPageExtension.php
@@ -27,22 +27,16 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * NEXT_MAJOR: stop implementing PrependExtensionInterface
  */
 final class SonataPageExtension extends Extension implements PrependExtensionInterface
 {
+    /**
+     * NEXT_MAJOR: Remove this method.
+     */
     public function prepend(ContainerBuilder $container): void
     {
-        $bundles = $container->getParameter('kernel.bundles');
-        \assert(\is_array($bundles));
-
-        // add custom form widgets
-        if ($container->hasExtension('twig')) {
-            if (isset($bundles['SonataFormBundle'])) {
-                $container->prependExtensionConfig('twig', [
-                    'form_themes' => ['@SonataForm/Form/datepicker.html.twig'],
-                ]);
-            }
-        }
     }
 
     public function load(array $configs, ContainerBuilder $container): void

--- a/tests/DependencyInjection/SonataPageExtensionTest.php
+++ b/tests/DependencyInjection/SonataPageExtensionTest.php
@@ -15,7 +15,6 @@ namespace Sonata\PageBundle\Tests\DependencyInjection;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 use Sonata\PageBundle\DependencyInjection\SonataPageExtension;
-use Symfony\Bundle\TwigBundle\DependencyInjection\TwigExtension;
 
 /**
  * @author Rémi Marseille <marseille@ekino.com>

--- a/tests/DependencyInjection/SonataPageExtensionTest.php
+++ b/tests/DependencyInjection/SonataPageExtensionTest.php
@@ -55,26 +55,6 @@ final class SonataPageExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasParameter('sonata.page.router_auto_register.priority', 84);
     }
 
-    public function testDatePickerFormThemeFromSonataForm(): void
-    {
-        $this->container->setParameter('kernel.bundles', [
-            'SonataFormBundle' => true,
-            'SonataDoctrineBundle' => true,
-        ]);
-        $this->container->setParameter('kernel.bundles_metadata', []);
-        $this->container->setParameter('kernel.project_dir', __DIR__);
-        $this->container->setParameter('kernel.root_dir', __DIR__);
-        $this->container->setParameter('kernel.debug', false);
-        $this->container->registerExtension(new TwigExtension());
-
-        $this->container->compile();
-
-        $resources = $this->container->getParameter('twig.form.resources');
-
-        static::assertIsArray($resources);
-        static::assertContains('@SonataForm/Form/datepicker.html.twig', $resources);
-    }
-
     protected function getContainerExtensions(): array
     {
         return [new SonataPageExtension()];


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because its BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1699.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataPageBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Removed
- Removed twig form themes from SonataPageExtension
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
