### PR TITLE
CreateSnapshotAdminExtension bug fix

### DIFF
--- a/src/Admin/Extension/CreateSnapshotAdminExtension.php
+++ b/src/Admin/Extension/CreateSnapshotAdminExtension.php
@@ -40,6 +40,10 @@ final class CreateSnapshotAdminExtension extends AbstractAdminExtension
 
     public function postRemove(AdminInterface $admin, object $object): void
     {
+        if ($object instanceof PageInterface) {
+            return;
+        }
+
         $this->createByPage($object);
     }
 

--- a/src/Route/RoutePageGenerator.php
+++ b/src/Route/RoutePageGenerator.php
@@ -77,7 +77,7 @@ final class RoutePageGenerator
             if (
                 !$this->decoratorStrategy->isRouteNameDecorable($name)
                 || !$this->decoratorStrategy->isRouteUriDecorable($route->getPath())
-                || (null !== $routeHostRegex
+                || (\is_string($routeHostRegex)
                 && 0 === preg_match($routeHostRegex, $site->getHost() ?? ''))
             ) {
                 if (null !== $page) {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, to fix a bug of CreateSnapshotAdminExtension::postRemove() method.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1708.