### PR TITLE
Feature/1713 - Switch slugify to symfony string

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,7 @@
         "symfony/security-core": "^5.4 || ^6.2",
         "symfony/security-http": "^5.4 || ^6.2",
         "symfony/serializer": "^5.4.24 || ^6.2.11",
+        "symfony/string": "^5.4 || ^6.2",
         "symfony/validator": "^5.4 || ^6.2",
         "twig/string-extra": "^3.0",
         "twig/twig": "^3.0"

--- a/src/DependencyInjection/SonataPageExtension.php
+++ b/src/DependencyInjection/SonataPageExtension.php
@@ -70,7 +70,7 @@ final class SonataPageExtension extends Extension implements PrependExtensionInt
         $loader->load('service.php');
         $loader->load('validators.php');
         $loader->load('command.php');
-        $loader->load('slugify.php');
+        $loader->load('slugify.php'); // NEXT_MAJOR: Remove this line.
 
         $this->configureMultisite($container, $config);
         $this->configureTemplates($container, $config);

--- a/src/Resources/config/orm.php
+++ b/src/Resources/config/orm.php
@@ -27,6 +27,7 @@ use Sonata\PageBundle\Model\SnapshotPageProxy;
 use Sonata\PageBundle\Model\SnapshotPageProxyFactory;
 use Sonata\PageBundle\Serializer\BlockTypeExtractor;
 use Sonata\PageBundle\Serializer\InterfaceTypeExtractor;
+use Symfony\Component\String\Slugger\SluggerInterface;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $containerConfigurator->services()
@@ -42,7 +43,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->args([
                 param('sonata.page.page.class'),
                 service('doctrine'),
-                service('sonata.page.slugify.cocur'),
+                service(SluggerInterface::class),
                 abstract_arg('defaults'),
                 abstract_arg('page defaults'),
             ])


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Replace  slugify to symfony string

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1713.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataPageBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Added
- Handle slugs using `Symfony string`

### Deprecated
- Deprecated `slugify` in favor of symfony string
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
