### PR TITLE
Fix CmsManagerSelector.isEditor always returns false

### DIFF
--- a/src/CmsManager/CmsManagerSelector.php
+++ b/src/CmsManager/CmsManagerSelector.php
@@ -78,7 +78,7 @@ final class CmsManagerSelector implements CmsManagerSelectorInterface
     {
         @trigger_error(sprintf(
             'The method "%s()" is deprecated since sonata-project/page-bundle 4.7.0 and will be removed in 5.0.'
-                . '  Use "%s()" instead.',
+            .'  Use "%s()" instead.',
             __METHOD__,
             'onLoginSuccess'
         ), \E_USER_DEPRECATED);

--- a/src/CmsManager/CmsManagerSelector.php
+++ b/src/CmsManager/CmsManagerSelector.php
@@ -20,6 +20,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
 use Symfony\Component\Security\Http\Event\LoginSuccessEvent;
 use Symfony\Component\Security\Http\Event\LogoutEvent;
 
@@ -65,9 +66,29 @@ final class CmsManagerSelector implements CmsManagerSelectorInterface
 
     public function onLoginSuccess(LoginSuccessEvent $event): void
     {
+        $this->handleLoginSuccess($event->getRequest());
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this class.
+     *
+     * @deprecated since sonata-project/page-bundle 4.7.0
+     */
+    public function onSecurityInteractiveLogin(InteractiveLoginEvent $event): void
+    {
+        @trigger_error(sprintf(
+            'The method "%s()" is deprecated since sonata-project/page-bundle 4.7.0 and will be removed in 5.0.'
+                . '  Use "%s()" instead.',
+            __METHOD__,
+            'onLoginSuccess'
+        ), \E_USER_DEPRECATED);
+        $this->handleLoginSuccess($event->getRequest());
+    }
+
+    private function handleLoginSuccess(Request $request): void
+    {
         if (null !== $this->tokenStorage->getToken()
             && $this->pageAdmin->isGranted('EDIT')) {
-            $request = $event->getRequest();
 
             if ($request->hasSession()) {
                 $request->getSession()->set('sonata/page/isEditor', true);

--- a/src/CmsManager/CmsManagerSelector.php
+++ b/src/CmsManager/CmsManagerSelector.php
@@ -85,16 +85,6 @@ final class CmsManagerSelector implements CmsManagerSelectorInterface
         $this->handleLoginSuccess($event->getRequest());
     }
 
-    private function handleLoginSuccess(Request $request): void
-    {
-        if (null !== $this->tokenStorage->getToken()
-            && $this->pageAdmin->isGranted('EDIT')) {
-            if ($request->hasSession()) {
-                $request->getSession()->set('sonata/page/isEditor', true);
-            }
-        }
-    }
-
     /**
      * NEXT_MAJOR: Remove this method.
      */
@@ -122,6 +112,16 @@ final class CmsManagerSelector implements CmsManagerSelectorInterface
 
             if (null !== $response) {
                 $response->headers->clearCookie('sonata_page_is_editor');
+            }
+        }
+    }
+
+    private function handleLoginSuccess(Request $request): void
+    {
+        if (null !== $this->tokenStorage->getToken()
+            && $this->pageAdmin->isGranted('EDIT')) {
+            if ($request->hasSession()) {
+                $request->getSession()->set('sonata/page/isEditor', true);
             }
         }
     }

--- a/src/CmsManager/CmsManagerSelector.php
+++ b/src/CmsManager/CmsManagerSelector.php
@@ -89,7 +89,6 @@ final class CmsManagerSelector implements CmsManagerSelectorInterface
     {
         if (null !== $this->tokenStorage->getToken()
             && $this->pageAdmin->isGranted('EDIT')) {
-
             if ($request->hasSession()) {
                 $request->getSession()->set('sonata/page/isEditor', true);
             }

--- a/src/CmsManager/CmsManagerSelector.php
+++ b/src/CmsManager/CmsManagerSelector.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
-use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
+use Symfony\Component\Security\Http\Event\LoginSuccessEvent;
 use Symfony\Component\Security\Http\Event\LogoutEvent;
 
 /**
@@ -63,7 +63,7 @@ final class CmsManagerSelector implements CmsManagerSelectorInterface
             && false !== $request->getSession()->get('sonata/page/isEditor', false);
     }
 
-    public function onSecurityInteractiveLogin(InteractiveLoginEvent $event): void
+    public function onLoginSuccess(LoginSuccessEvent $event): void
     {
         if (null !== $this->tokenStorage->getToken()
             && $this->pageAdmin->isGranted('EDIT')) {

--- a/src/Resources/config/page.php
+++ b/src/Resources/config/page.php
@@ -31,6 +31,7 @@ use Sonata\PageBundle\Site\HostPathSiteSelector;
 use Sonata\PageBundle\Site\HostSiteSelector;
 use Sonata\PageBundle\Site\SiteSelectorInterface;
 use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Security\Http\Event\LoginSuccessEvent;
 use Symfony\Component\Security\Http\Event\LogoutEvent;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
@@ -133,8 +134,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->set('sonata.page.cms_manager_selector', CmsManagerSelector::class)
             ->public()
             ->tag('kernel.event_listener', [
-                'event' => 'security.interactive_login',
-                'method' => 'onSecurityInteractiveLogin',
+                'event' => LoginSuccessEvent::class,
+                'method' => 'onLoginSuccess',
             ])
             ->tag('kernel.event_listener', [
                 'event' => LogoutEvent::class,

--- a/src/Resources/config/page.php
+++ b/src/Resources/config/page.php
@@ -138,6 +138,10 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 'method' => 'onLoginSuccess',
             ])
             ->tag('kernel.event_listener', [
+                'event' => 'security.interactive_login',
+                'method' => 'onSecurityInteractiveLogin',
+            ])
+            ->tag('kernel.event_listener', [
                 'event' => LogoutEvent::class,
                 'method' => 'onLogout',
             ])


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Migrate security.interactive_login event to LoginSuccessEvent

<!-- Describe your Pull Request content here -->

Symfony security doesn't use security.interactive_login since v5.1:
[https://symfony.com/blog/new-in-symfony-5-1-updated-security-system](https://symfony.com/blog/new-in-symfony-5-1-updated-security-system)

So the 'sonata/page/isEditor' session item is never defined and PAGE_ADMIN can't see the last modification on their  page without publishing when sonata_page.direct_publication is set to false


<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is the default branch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1675 .

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataPageBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Fixed
-  `CmsManagerSelector::isEditor` always returns false

### Deprecated
- `CmsManagerSelector::onSecurityInteractiveLogin`
```
