### PR TITLE
Remove deprecated spaceless filter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "cocur/slugify": "^4.0",
         "doctrine/doctrine-bundle": "^2.7",
         "doctrine/persistence": "^3.0.2",
-        "sonata-project/admin-bundle": "^4.34",
+        "sonata-project/admin-bundle": "^4.35.3",
         "sonata-project/block-bundle": "^4.18 || ^5.0",
         "sonata-project/doctrine-extensions": "^1.18 || ^2.1",
         "sonata-project/doctrine-orm-admin-bundle": "^4.0",

--- a/src/Resources/views/PageAdmin/field_hybrid.html.twig
+++ b/src/Resources/views/PageAdmin/field_hybrid.html.twig
@@ -11,11 +11,9 @@ file that was distributed with this source code.
 {% extends '@SonataAdmin/CRUD/base_list_field.html.twig' %}
 
 {% block field %}
-{% apply spaceless %}
     {% if object.isHybrid %}
         <i class="fa fa-gears"></i>
     {% else %}
         <i class="fa fa-code"></i>
     {% endif %}
-{% endapply %}
 {% endblock %}

--- a/tests/Admin/Extension/CreateSnapshotAdminExtensionTest.php
+++ b/tests/Admin/Extension/CreateSnapshotAdminExtensionTest.php
@@ -78,7 +78,7 @@ final class CreateSnapshotAdminExtensionTest extends TestCase
     {
         $page = $this->createMock(PageInterface::class);
         $block = $this->createMock(PageBlockInterface::class);
-        $admin = $this->createStub(AdminInterface::class);
+        $admin = static::createStub(AdminInterface::class);
         $createSnapshotByPage = $this->createMock(CreateSnapshotByPageInterface::class);
 
         $block->expects(static::once())->method('getPage')->willReturn($page);
@@ -91,7 +91,7 @@ final class CreateSnapshotAdminExtensionTest extends TestCase
     public function testPostRemoveOnPage(): void
     {
         $page = $this->createMock(PageInterface::class);
-        $admin = $this->createStub(AdminInterface::class);
+        $admin = static::createStub(AdminInterface::class);
         $createSnapshotByPage = $this->createMock(CreateSnapshotByPageInterface::class);
 
         $createSnapshotByPage->expects(static::never())->method('createByPage');

--- a/tests/Admin/PageAdminTest.php
+++ b/tests/Admin/PageAdminTest.php
@@ -33,17 +33,17 @@ final class PageAdminTest extends TestCase
     {
         $request = new Request(['id' => 42]);
         $admin = new PageAdmin(
-            $this->createStub(PageManagerInterface::class),
-            $this->createStub(SiteManagerInterface::class),
+            static::createStub(PageManagerInterface::class),
+            static::createStub(SiteManagerInterface::class),
         );
-        $admin->setModelManager($this->createStub(ModelManagerInterface::class));
+        $admin->setModelManager(static::createStub(ModelManagerInterface::class));
         $admin->setModelClass(Page::class);
         $admin->setBaseControllerName(PageController::class);
         $admin->setCode('admin.page');
         $admin->setMenuFactory(new MenuFactory());
         $admin->setRequest($request);
 
-        $site = $this->createStub(Site::class);
+        $site = static::createStub(Site::class);
         $site->method('getRelativePath')->willReturn('/my-subsite');
 
         $page = new Page();

--- a/tests/App/AppKernel.php
+++ b/tests/App/AppKernel.php
@@ -35,6 +35,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\UX\StimulusBundle\StimulusBundle;
 
 final class AppKernel extends Kernel
 {
@@ -48,6 +49,7 @@ final class AppKernel extends Kernel
             new TwigBundle(),
             new SecurityBundle(),
             new KnpMenuBundle(),
+            new StimulusBundle(),
             new SonataBlockBundle(),
             new SonataDoctrineBundle(),
             new SonataAdminBundle(),

--- a/tests/Block/ContainerBlockServiceTest.php
+++ b/tests/Block/ContainerBlockServiceTest.php
@@ -67,9 +67,9 @@ final class ContainerBlockServiceTest extends BlockServiceTestCase
 
         $formBuilder = $this->createMock(FormBuilderInterface::class);
         $form = new FormMapper(
-            $this->createStub(FormContractorInterface::class),
+            static::createStub(FormContractorInterface::class),
             $formBuilder,
-            $this->createStub(AdminInterface::class)
+            static::createStub(AdminInterface::class)
         );
 
         $formBuilder->expects(static::exactly(2))->method('add');

--- a/tests/Entity/PageManagerTest.php
+++ b/tests/Entity/PageManagerTest.php
@@ -25,7 +25,7 @@ final class PageManagerTest extends TestCase
     {
         $manager = new PageManager(
             Page::class,
-            $this->createStub(ManagerRegistry::class),
+            static::createStub(ManagerRegistry::class),
             new Slugify()
         );
 

--- a/tests/Entity/SnapshotManagerTest.php
+++ b/tests/Entity/SnapshotManagerTest.php
@@ -57,7 +57,7 @@ final class SnapshotManagerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->managerRegistry = $this->createStub(ManagerRegistry::class);
+        $this->managerRegistry = static::createStub(ManagerRegistry::class);
         $this->entityManager = $this->createMock(EntityManagerInterface::class);
 
         $this->managerRegistry->method('getManagerForClass')->willReturn($this->entityManager);

--- a/tests/Functional/Admin/SnapshotAdminTest.php
+++ b/tests/Functional/Admin/SnapshotAdminTest.php
@@ -65,6 +65,8 @@ final class SnapshotAdminTest extends WebTestCase
 
         $client->request('GET', $url, $parameters);
         $client->submitForm($button, $fieldValues);
+
+        dump($client->getResponse());
         $client->followRedirect();
 
         self::assertResponseIsSuccessful();

--- a/tests/Functional/Admin/SnapshotAdminTest.php
+++ b/tests/Functional/Admin/SnapshotAdminTest.php
@@ -65,8 +65,6 @@ final class SnapshotAdminTest extends WebTestCase
 
         $client->request('GET', $url, $parameters);
         $client->submitForm($button, $fieldValues);
-
-        dump($client->getResponse());
         $client->followRedirect();
 
         self::assertResponseIsSuccessful();
@@ -93,8 +91,8 @@ final class SnapshotAdminTest extends WebTestCase
             'uniqid' => 'snapshot',
         ], 'btn_update_and_list', [
             'snapshot[enabled]' => false,
-            'snapshot[publicationDateStart]' => 'May 4, 2022, 8:00:00 AM',
-            'snapshot[publicationDateEnd]' => 'May 4, 2022, 9:00:00 AM',
+            'snapshot[publicationDateStart]' => '',
+            'snapshot[publicationDateEnd]' => '',
         ]];
 
         yield 'Remove Snapshot' => ['/admin/tests/app/sonatapagesnapshot/1/delete', [], 'btn_delete'];


### PR DESCRIPTION
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataPageBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Fixed
- Remove deprecated `spaceless` filter usage
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->