### PR TITLE
Add symfony recipes in installation doc

### DIFF
--- a/docs/reference/installation.rst
+++ b/docs/reference/installation.rst
@@ -5,8 +5,22 @@
 Installation
 ============
 
-Prerequisites
+Automatically
 -------------
+
+Using Symfony recipes, you can easily set up Sonata Page.
+
+Add the ``SonataPageBundle`` via Composer::
+
+    composer require sonata-project/page-bundle
+
+The command will ask you to execute some Symfony recipes. Just type ``y`` for all of them.
+
+Manually
+-----------------
+
+Prerequisites
+~~~~~~~~~~~~~
 
 There are some Sonata dependencies that need to be installed and configured beforehand.
 
@@ -29,7 +43,7 @@ their own installation chapter.
     another dependency, you won't need to install it again.
 
 Enable the Bundle
------------------
+~~~~~~~~~~~~~~~~~
 
 Add ``SonataPageBundle`` via composer::
 
@@ -50,10 +64,10 @@ are not already enabled::
     ];
 
 Configuration
-=============
+~~~~~~~~~~~~~
 
 CMF Routing Configuration
--------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ``sonata.page.router`` service must be added to the index of ``cmf_routing.router`` chain router.
 
@@ -84,7 +98,7 @@ Or register ``sonata.page.router`` automatically:
             priority: 150
 
 SonataPageBundle Configuration
-------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: yaml
 
@@ -122,7 +136,7 @@ SonataPageBundle Configuration
             fatal: [500] # so you can use the same page for different http errors or specify specific page for each error
 
 SonataAdminBundle Configuration
--------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: yaml
 
@@ -136,7 +150,7 @@ SonataAdminBundle Configuration
                 - bundles/sonatapage/app.css
 
 SonataBlockBundle Configuration
--------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: yaml
 
@@ -146,7 +160,7 @@ SonataBlockBundle Configuration
         default_contexts: [sonata_page_bundle]
 
 Security Configuration
-----------------------
+^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: yaml
 
@@ -176,7 +190,7 @@ this logout handler:
                     handlers: ['sonata.page.cms_manager_selector']
 
 Routing Configuration
----------------------
+^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: yaml
 
@@ -187,7 +201,7 @@ Routing Configuration
         prefix: /
 
 Doctrine ORM Configuration
---------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 And these in the config mapping definition (or enable auto_mapping)::
 
@@ -271,9 +285,21 @@ and ``src/Entity/SonataPageSnapshot``::
         protected $id;
     }
 
-The only thing left is to update your schema::
+Post install
+============
 
-    bin/console doctrine:schema:update --force
+Generate a migration for the newly created entities::
+
+    bin/console doctrine:migrations:diff
+
+Apply the migrations::
+
+    bin/console doctrine:migrations:migrate --no-interaction
+
+Generate your first site::
+
+     bin/console sonata:page:create-site --enabled --name=localhost --locale=- --host=localhost --relativePath=- --enabledFrom=now --enabledTo=- --default
+
 
 Next Steps
 ----------


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Clean up installation doc

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because it does not have any break change and can be introduce on version 4.x.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataPageBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Changed
- Add symfony recipes in installation doc.
```

I was playing with sonata pagebundle in a new symfony project and I was strugulling to make this work 😄 ,
after a while I realised the issue was, because new symfony projects are using php attributes as default, for this reason I am changing the recipes: https://github.com/symfony/recipes-contrib/pull/1809

and running `composer require sonata-project/page-bundle -W` it works as expected.

here there is some screenshots

![Screenshot from 2025-05-27 20-18-32](https://github.com/user-attachments/assets/6f369a0b-6af2-462e-9c14-931945ecc928)

![Screenshot from 2025-05-27 20-24-40](https://github.com/user-attachments/assets/ac7f01be-9a25-4f2b-a429-c1fde5eafcd0)

 
