### PR TITLE
fix(manager): fix implementation bugs with CmsManager classes

### DIFF
--- a/src/CmsManager/CmsManagerSelector.php
+++ b/src/CmsManager/CmsManagerSelector.php
@@ -37,8 +37,8 @@ final class CmsManagerSelector implements CmsManagerSelectorInterface
      * @param AdminInterface<PageInterface> $pageAdmin
      */
     public function __construct(
-        private CmsPageManager $cmsPageManager,
-        private CmsSnapshotManager $cmsSnapshotManager,
+        private CmsManagerInterface $cmsPageManager,
+        private CmsManagerInterface $cmsSnapshotManager,
         private AdminInterface $pageAdmin,
         private TokenStorageInterface $tokenStorage,
         private RequestStack $requestStack,

--- a/src/CmsManager/CmsPageManager.php
+++ b/src/CmsManager/CmsPageManager.php
@@ -26,22 +26,12 @@ use Sonata\PageBundle\Model\SiteInterface;
 final class CmsPageManager extends BaseCmsPageManager
 {
     /**
-     * @var array{
-     *   url: array<int|string|null>,
-     *   routeName: array<int|string|null>,
-     *   pageAlias: array<int|string|null>,
-     *   name: array<int|string|null>,
-     * }
+     * @var array<string, array<mixed, string|int>>
      */
-    private array $pageReferences = [
-        'url' => [],
-        'routeName' => [],
-        'pageAlias' => [],
-        'name' => [],
-    ];
+    private array $pageReferences = [];
 
     /**
-     * @var array<PageInterface>
+     * @var array<int|string, PageInterface>
      */
     private array $pages = [];
 
@@ -131,10 +121,17 @@ final class CmsPageManager extends BaseCmsPageManager
 
     protected function getPageBy(?SiteInterface $site, string $fieldName, $value): PageInterface
     {
+        $siteRef = $site instanceof SiteInterface ? $site->getId() : 's';
+        $fieldNameRef = ($siteRef ?? 's').'_'.$fieldName;
+
+        if (!isset($this->pageReferences[$fieldNameRef])) {
+            $this->pageReferences[$fieldNameRef] = [];
+        }
+
         if ('id' === $fieldName) {
             $id = $value;
-        } elseif (isset($this->pageReferences[$fieldName][$value])) {
-            $id = $this->pageReferences[$fieldName][$value];
+        } elseif (isset($this->pageReferences[$fieldNameRef][$value])) {
+            $id = $this->pageReferences[$fieldNameRef][$value];
         } else {
             $id = null;
         }
@@ -160,7 +157,7 @@ final class CmsPageManager extends BaseCmsPageManager
             \assert(null !== $id);
 
             if ('id' !== $fieldName) {
-                $this->pageReferences[$fieldName][$value] = $id;
+                $this->pageReferences[$fieldNameRef][$value] = $id;
             }
 
             $this->pages[$id] = $page;

--- a/src/CmsManager/CmsSnapshotManager.php
+++ b/src/CmsManager/CmsSnapshotManager.php
@@ -27,24 +27,12 @@ use Sonata\PageBundle\Model\TransformerInterface;
 final class CmsSnapshotManager extends BaseCmsPageManager
 {
     /**
-     * @var array{
-     *   url: array<int|string|null>,
-     *   routeName: array<int|string|null>,
-     *   pageAlias: array<int|string|null>,
-     *   name: array<int|string|null>,
-     *   pageId: array<int|string|null>,
-     * }
+     * @var array<string, array<mixed, string|int>>
      */
-    private array $pageReferences = [
-        'url' => [],
-        'routeName' => [],
-        'pageAlias' => [],
-        'name' => [],
-        'pageId' => [],
-    ];
+    private array $pageReferences = [];
 
     /**
-     * @var array<PageInterface>
+     * @var array<int|string, PageInterface>
      */
     private array $pages = [];
 
@@ -109,11 +97,18 @@ final class CmsSnapshotManager extends BaseCmsPageManager
 
     protected function getPageBy(?SiteInterface $site, string $fieldName, $value): PageInterface
     {
+        $siteRef = $site instanceof SiteInterface ? $site->getId() : 's';
+        $fieldNameRef = ($siteRef ?? 's').'_'.$fieldName;
+
+        if (!isset($this->pageReferences[$fieldNameRef])) {
+            $this->pageReferences[$fieldNameRef] = [];
+        }
+
         if ('id' === $fieldName) {
             $fieldName = 'pageId';
             $id = $value;
-        } elseif (isset($this->pageReferences[$fieldName][$value])) {
-            $id = $this->pageReferences[$fieldName][$value];
+        } elseif (isset($this->pageReferences[$fieldNameRef][$value])) {
+            $id = $this->pageReferences[$fieldNameRef][$value];
         } else {
             $id = null;
         }
@@ -138,7 +133,7 @@ final class CmsSnapshotManager extends BaseCmsPageManager
             $id = $page->getId();
             \assert(null !== $id);
 
-            $this->pageReferences[$fieldName][$value] = $id;
+            $this->pageReferences[$fieldNameRef][$value] = $id;
             $this->pages[$id] = $page;
         }
 


### PR DESCRIPTION
Co-authored-by: Vincent Langlet <vincentlanglet@hotmail.fr>

## fix implementation bugs with CmsManager classes

This PR fixes 2 issues:
 - the CmsManagerSelector constructor does not use interface for the Cms(Page|Snapshot)Manager, this make impossible to inject another implementation and defeat the purpose on IoC.
- the cache keys for the page in the `getPageBy` does not use the provide $site object. So if the code load 2 similar page (same fieldName and same value). then the former is always returned. 


I am targeting this branch, because we need to fix the bug on the active branch.


## Changelog

```markdown
### Changed
- Update `CmsManagerSelector::__construct()` to do use `CmsManagerInterface` and not the final class. 

### Fixed
- Update `CmsSnapshotManager::getPageBy()` and `CmsPageManager::getPageBy` to properly used the `$site` variable within the cache key.
```