### PR TITLE
Rework #1817

### DIFF
--- a/src/CmsManager/CmsPageManager.php
+++ b/src/CmsManager/CmsPageManager.php
@@ -26,7 +26,7 @@ use Sonata\PageBundle\Model\SiteInterface;
 final class CmsPageManager extends BaseCmsPageManager
 {
     /**
-     * @var array<string, array<mixed, string|int>>
+     * @var array<int|string, array<string, array<mixed, string|int>>>
      */
     private array $pageReferences = [];
 
@@ -121,19 +121,15 @@ final class CmsPageManager extends BaseCmsPageManager
 
     protected function getPageBy(?SiteInterface $site, string $fieldName, $value): PageInterface
     {
-        $siteRef = $site instanceof SiteInterface ? $site->getId() : 's';
-        $fieldNameRef = ($siteRef ?? 's').'_'.$fieldName;
-
-        if (!isset($this->pageReferences[$fieldNameRef])) {
-            $this->pageReferences[$fieldNameRef] = [];
+        $siteRef = $site?->getId() ?? '';
+        if (!isset($this->pageReferences[$siteRef][$fieldName])) {
+            $this->pageReferences[$siteRef][$fieldName] = [];
         }
 
         if ('id' === $fieldName) {
             $id = $value;
-        } elseif (isset($this->pageReferences[$fieldNameRef][$value])) {
-            $id = $this->pageReferences[$fieldNameRef][$value];
         } else {
-            $id = null;
+            $id = $this->pageReferences[$siteRef][$fieldName][$value] ?? null;
         }
 
         if (null === $id || !isset($this->pages[$id])) {
@@ -157,7 +153,7 @@ final class CmsPageManager extends BaseCmsPageManager
             \assert(null !== $id);
 
             if ('id' !== $fieldName) {
-                $this->pageReferences[$fieldNameRef][$value] = $id;
+                $this->pageReferences[$siteRef][$fieldName][$value] = $id;
             }
 
             $this->pages[$id] = $page;

--- a/src/CmsManager/CmsSnapshotManager.php
+++ b/src/CmsManager/CmsSnapshotManager.php
@@ -27,7 +27,7 @@ use Sonata\PageBundle\Model\TransformerInterface;
 final class CmsSnapshotManager extends BaseCmsPageManager
 {
     /**
-     * @var array<string, array<mixed, string|int>>
+     * @var array<int|string, array<string, array<mixed, string|int>>>
      */
     private array $pageReferences = [];
 
@@ -97,20 +97,16 @@ final class CmsSnapshotManager extends BaseCmsPageManager
 
     protected function getPageBy(?SiteInterface $site, string $fieldName, $value): PageInterface
     {
-        $siteRef = $site instanceof SiteInterface ? $site->getId() : 's';
-        $fieldNameRef = ($siteRef ?? 's').'_'.$fieldName;
-
-        if (!isset($this->pageReferences[$fieldNameRef])) {
-            $this->pageReferences[$fieldNameRef] = [];
+        $siteRef = $site?->getId() ?? '';
+        if (!isset($this->pageReferences[$siteRef][$fieldName])) {
+            $this->pageReferences[$siteRef][$fieldName] = [];
         }
 
         if ('id' === $fieldName) {
             $fieldName = 'pageId';
             $id = $value;
-        } elseif (isset($this->pageReferences[$fieldNameRef][$value])) {
-            $id = $this->pageReferences[$fieldNameRef][$value];
         } else {
-            $id = null;
+            $id = $this->pageReferences[$siteRef][$fieldName][$value] ?? null;
         }
 
         if (null === $id || !isset($this->pages[$id])) {
@@ -133,7 +129,7 @@ final class CmsSnapshotManager extends BaseCmsPageManager
             $id = $page->getId();
             \assert(null !== $id);
 
-            $this->pageReferences[$fieldNameRef][$value] = $id;
+            $this->pageReferences[$siteRef][$fieldName][$value] = $id;
             $this->pages[$id] = $page;
         }
 


### PR DESCRIPTION
Hi @rande I feel like it would be more robust to use multiple level for array cache, rather than a concatenating.

Because `foo_bar` id with value `baz` will conflict with `foo` id and `bar_baz` field.

Do you agree with this PR ?