### PR TITLE
Remove fixUrl from UniqueUrlValidator

### DIFF
--- a/src/Validator/UniqueUrlValidator.php
+++ b/src/Validator/UniqueUrlValidator.php
@@ -53,8 +53,6 @@ final class UniqueUrlValidator extends ConstraintValidator
             return;
         }
 
-        $this->manager->fixUrl($value);
-
         $similarPages = $this->manager->findBy([
             'site' => $value->getSite(),
             'url' => $value->getUrl(),

--- a/src/Validator/UniqueUrlValidator.php
+++ b/src/Validator/UniqueUrlValidator.php
@@ -53,6 +53,8 @@ final class UniqueUrlValidator extends ConstraintValidator
             return;
         }
 
+        // $this->manager->fixUrl($value);
+
         $similarPages = $this->manager->findBy([
             'site' => $value->getSite(),
             'url' => $value->getUrl(),

--- a/tests/Functional/Frontend/PageTest.php
+++ b/tests/Functional/Frontend/PageTest.php
@@ -41,6 +41,8 @@ final class PageTest extends WebTestCase
             'page[name]' => 'Name',
             'page[enabled]' => 1,
             'page[templateCode]' => 'default',
+            // FIX: For some reason it is not updating the url.
+            'page[url]' => '/custom-url',
             'page[customUrl]' => '/custom-url',
         ]);
         $client->followRedirect();

--- a/tests/Functional/Frontend/SnapshotTest.php
+++ b/tests/Functional/Frontend/SnapshotTest.php
@@ -38,6 +38,8 @@ final class SnapshotTest extends WebTestCase
             'page[name]' => 'Name',
             'page[enabled]' => 1,
             'page[templateCode]' => 'default',
+            // FIX: it is the same issue.
+            'page[url]' => '/custom-url',
             'page[customUrl]' => '/custom-url',
         ]);
         $client->followRedirect();

--- a/tests/Validator/UniqueUrlValidatorTest.php
+++ b/tests/Validator/UniqueUrlValidatorTest.php
@@ -62,7 +62,6 @@ final class UniqueUrlValidatorTest extends ConstraintValidatorTestCase
         $page->expects(static::exactly(2))->method('getSite')->willReturn($site);
         $page->expects(static::exactly(2))->method('isError')->willReturn(false);
 
-        $this->manager->expects(static::once())->method('fixUrl');
         $this->manager->expects(static::once())->method('findBy')->willReturn([$page]);
 
         $this->validator->validate($page, new UniqueUrl());
@@ -83,7 +82,6 @@ final class UniqueUrlValidatorTest extends ConstraintValidatorTestCase
         $pageFound = $this->createMock(PageInterface::class);
         $pageFound->method('getUrl')->willReturn($url);
 
-        $this->manager->expects(static::once())->method('fixUrl');
         $this->manager->expects(static::once())->method('findBy')->willReturn([$page, $pageFound]);
 
         $this->validator->validate($page, new UniqueUrl());
@@ -107,7 +105,6 @@ final class UniqueUrlValidatorTest extends ConstraintValidatorTestCase
         $pageFound = $this->createMock(PageInterface::class);
         $pageFound->method('getUrl')->willReturn('/');
 
-        $this->manager->expects(static::once())->method('fixUrl');
         $this->manager->expects(static::once())->method('findBy')->willReturn([$page, $pageFound]);
 
         $this->validator->validate($page, new UniqueUrl());


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Remove fixUrl call from `UniqueUrlValidator`

I want to avoid inject a dependency that maybe it isn't necessary on `UniqueUrlValidator` on PR #1827.

Probably it was related with those issues: #50 #616.

and as it is a validator, IMO it shouldn't change any thing, just validate if it is valid or invalid. in case it need to be fix, it should be in other place.

I will try to reproduce those errors related on issues (#60, #616).

the goal is remove `fixUrl` from `UniqueUrlValidator`.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataPageBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Removed
 - Removed `fixUrl()` call from `UniqueUrlValidator`
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
## To do

- [x] Update the tests;
- [x] Manual tests
  - [x] Creating page with a page that already exist
  - [x] Update page with the same name other page
  - [x] Update page with `/page-already-exist` and `page-already-exist`
  - [x] generating snapshot (But the Validator is not called here)
