### PR TITLE
Feature/1713 - Switch slugify for symfony string

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
         "symfony/config": "^6.4 || ^7.1",
         "symfony/console": "^6.4 || ^7.1",
         "symfony/dependency-injection": "^6.4 || ^7.1",
+        "symfony/deprecation-contracts": "^3.0.0",
         "symfony/form": "^6.4 || ^7.1",
         "symfony/framework-bundle": "^6.4 || ^7.1",
         "symfony/http-foundation": "^6.4 || ^7.1",
@@ -50,6 +51,7 @@
         "symfony/security-core": "^6.4 || ^7.1",
         "symfony/security-http": "^6.4 || ^7.1",
         "symfony/serializer": "^6.4 || ^7.1",
+        "symfony/string": "^6.4 || ^7.1",
         "symfony/validator": "^6.4 || ^7.1",
         "twig/string-extra": "^3.0",
         "twig/twig": "^3.0"

--- a/src/DependencyInjection/SonataPageExtension.php
+++ b/src/DependencyInjection/SonataPageExtension.php
@@ -70,7 +70,7 @@ final class SonataPageExtension extends Extension implements PrependExtensionInt
         $loader->load('service.php');
         $loader->load('validators.php');
         $loader->load('command.php');
-        $loader->load('slugify.php');
+        $loader->load('slugify.php'); // NEXT_MAJOR: Remove this line and cocur/slugify dependency.
 
         $this->configureMultisite($container, $config);
         $this->configureTemplates($container, $config);

--- a/src/Entity/PageManager.php
+++ b/src/Entity/PageManager.php
@@ -19,6 +19,7 @@ use Sonata\Doctrine\Entity\BaseEntityManager;
 use Sonata\PageBundle\Model\PageInterface;
 use Sonata\PageBundle\Model\PageManagerInterface;
 use Sonata\PageBundle\Model\SiteInterface;
+use Symfony\Component\String\Slugger\SluggerInterface;
 
 /**
  * @extends BaseEntityManager<PageInterface>
@@ -35,10 +36,21 @@ final class PageManager extends BaseEntityManager implements PageManagerInterfac
     public function __construct(
         string $class,
         ManagerRegistry $registry,
-        private SlugifyInterface $slugify,
+        private SlugifyInterface|SluggerInterface $slugger, // NEXT_MAJOR: Reduce $slugger to SluggerInterface
         private array $defaults = [],
         private array $pageDefaults = [],
     ) {
+        if ($slugger instanceof SlugifyInterface) {
+            trigger_deprecation(
+                'sonata-project/page-bundle',
+                '4.11.0',
+                'Passing an instance of %s to %s is deprecated. Use an instance of %s instead.',
+                SlugifyInterface::class,
+                __METHOD__,
+                SluggerInterface::class
+            );
+        }
+
         parent::__construct($class, $registry);
     }
 
@@ -87,7 +99,7 @@ final class PageManager extends BaseEntityManager implements PageManagerInterfac
                 $slug = $page->getSlug();
 
                 if (null === $slug) {
-                    $slug = $this->slugify->slugify($page->getName() ?? '');
+                    $slug = $this->fixUrlWithSluggerOrSlugify($page->getName() ?? '');
 
                     $page->setSlug($slug);
                 }
@@ -165,5 +177,21 @@ final class PageManager extends BaseEntityManager implements PageManagerInterfac
             ->setParameter('site', $site->getId())
             ->getQuery()
             ->execute();
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this method and move $this->slugger->slug()... to fixUrl method.
+     */
+    private function fixUrlWithSluggerOrSlugify(string $value): string
+    {
+        if ($this->slugger instanceof SlugifyInterface) {
+            return $this->slugger->slugify($value);
+        }
+
+        // NEXT_MAJOR: Move this to fixUrl method.
+        return $this->slugger
+                    ->slug($value)
+                    ->lower()
+                    ->toString();
     }
 }

--- a/src/Resources/config/orm.php
+++ b/src/Resources/config/orm.php
@@ -27,6 +27,7 @@ use Sonata\PageBundle\Model\SnapshotPageProxy;
 use Sonata\PageBundle\Model\SnapshotPageProxyFactory;
 use Sonata\PageBundle\Serializer\BlockTypeExtractor;
 use Sonata\PageBundle\Serializer\InterfaceTypeExtractor;
+use Symfony\Component\String\Slugger\SluggerInterface;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $containerConfigurator->services()
@@ -42,7 +43,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->args([
                 param('sonata.page.page.class'),
                 service('doctrine'),
-                service('sonata.page.slugify.cocur'),
+                service(SluggerInterface::class),
                 abstract_arg('defaults'),
                 abstract_arg('page defaults'),
             ])

--- a/src/Resources/config/slugify.php
+++ b/src/Resources/config/slugify.php
@@ -15,9 +15,15 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Cocur\Slugify\Slugify;
 
+// NEXT_MAJOR: Remove this file.
 return static function (ContainerConfigurator $containerConfigurator): void {
     $containerConfigurator->services()
 
         ->set('sonata.page.slugify.cocur', Slugify::class)
+            ->deprecate(
+                'sonata-project/page-bundle',
+                '4.11.0',
+                'Service "%service_id%" is deprecated.',
+            )
             ->public();
 };

--- a/tests/Entity/PageManagerTest.php
+++ b/tests/Entity/PageManagerTest.php
@@ -14,19 +14,37 @@ declare(strict_types=1);
 namespace Sonata\PageBundle\Tests\Entity;
 
 use Cocur\Slugify\Slugify;
+use Cocur\Slugify\SlugifyInterface;
 use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Sonata\PageBundle\Entity\PageManager;
 use Sonata\PageBundle\Tests\Model\Page;
+use Symfony\Component\String\Slugger\AsciiSlugger;
+use Symfony\Component\String\Slugger\SluggerInterface;
 
+#[IgnoreDeprecations] // NEXT_MAJOR: Remove this line.
 final class PageManagerTest extends TestCase
 {
-    public function testFixUrl(): void
+    /**
+     * NEXT_MAJOR: Remove this data provider and keep only "AsciiSlugger" in tests that is using it.
+     *
+     * @return iterable<array<SlugifyInterface|SluggerInterface>>
+     **/
+    public static function providerSlugs(): iterable
+    {
+        yield [new Slugify()];
+        yield [new AsciiSlugger()];
+    }
+
+    #[DataProvider('providerSlugs')]
+    public function testFixUrl(SlugifyInterface|SluggerInterface $slug): void
     {
         $manager = new PageManager(
             Page::class,
             static::createStub(ManagerRegistry::class),
-            new Slugify()
+            $slug,
         );
 
         $page1 = new Page();
@@ -65,12 +83,13 @@ final class PageManagerTest extends TestCase
         static::assertSame('/', $page1->getUrl());
     }
 
-    public function testWithSlashAtTheEnd(): void
+    #[DataProvider('providerSlugs')]
+    public function testWithSlashAtTheEnd(SlugifyInterface|SluggerInterface $slug): void
     {
         $manager = new PageManager(
             Page::class,
             $this->createMock(ManagerRegistry::class),
-            new Slugify()
+            $slug,
         );
 
         $homepage = new Page();
@@ -92,12 +111,13 @@ final class PageManagerTest extends TestCase
         static::assertSame('/bundles/foobar', $child->getUrl());
     }
 
-    public function testCreateWithGlobalDefaults(): void
+    #[DataProvider('providerSlugs')]
+    public function testCreateWithGlobalDefaults(SlugifyInterface|SluggerInterface $slug): void
     {
         $manager = new PageManager(
             Page::class,
             $this->createMock(ManagerRegistry::class),
-            new Slugify(),
+            $slug,
             [],
             ['my_route' => ['decorate' => false, 'name' => 'Salut!']]
         );


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Replace  slugify to symfony string

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1713.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataPageBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Added
- Handle slugs using `SluggerInterface::class` from `symfony/string`

### Deprecated
- Deprecated passing `SlugifyInterface::class` to `PageManager::__construct`.
- Deprecated `sonata.page.slugify.cocur` service.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
