### PR TITLE
POC Use MapQueryString and Remove BCHelper

### DIFF
--- a/src/Controller/BlockAdminController.php
+++ b/src/Controller/BlockAdminController.php
@@ -14,14 +14,14 @@ declare(strict_types=1);
 namespace Sonata\PageBundle\Controller;
 
 use Sonata\AdminBundle\Controller\CRUDController;
-use Sonata\AdminBundle\Exception\BadRequestParamHttpException;
 use Sonata\BlockBundle\Block\BlockServiceManagerInterface;
 use Sonata\BlockBundle\Block\Service\EditableBlockService;
-use Sonata\PageBundle\BCLayer\BCHelper;
 use Sonata\PageBundle\Model\BlockInteractorInterface;
 use Sonata\PageBundle\Model\PageBlockInterface;
+use Sonata\PageBundle\Query\BlockQuery;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Attribute\MapQueryString;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
@@ -111,19 +111,10 @@ final class BlockAdminController extends CRUDController
         return parent::createAction($request);
     }
 
-    public function switchParentAction(Request $request): Response
+    public function switchParentAction(#[MapQueryString(validationFailedStatusCode: 400)] BlockQuery $blockQuery): Response
     {
-        $blockId = BCHelper::getFromRequest($request, 'block_id');
-
-        if (null === $blockId) {
-            throw new BadRequestParamHttpException('block_id', ['int', 'string'], $blockId);
-        }
-
-        $parentId = BCHelper::getFromRequest($request, 'parent_id');
-
-        if (null === $parentId) {
-            throw new BadRequestParamHttpException('parent_id', ['int', 'string'], $parentId);
-        }
+        $blockId = $blockQuery->blockId;
+        $parentId = $blockQuery->parentId;
 
         $block = $this->admin->getObject($blockId);
 

--- a/src/Query/BlockQuery.php
+++ b/src/Query/BlockQuery.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\PageBundle\Query;
+
+use Symfony\Component\Serializer\Attribute\SerializedName;
+use Symfony\Component\Validator\Constraints as Assert;
+
+class BlockQuery
+{
+    public function __construct(
+        #[Assert\Positive]
+        #[Assert\Type('integer')]
+        #[SerializedName('block_id')]
+        public readonly int $blockId,
+        #[Assert\Positive]
+        #[SerializedName('parent_id')]
+        #[Assert\Type('integer')]
+        public readonly int $parentId,
+    ) {
+    }
+}


### PR DESCRIPTION
I want to use this PR just to see if we could use [MapQueryString](https://symfony.com/blog/new-in-symfony-6-3-query-parameters-mapper) and remove [BCHelper](https://github.com/sonata-project/SonataPageBundle/blob/4.x/src/BCLayer/BCHelper.php)

Will it work everywhere? I don't know yet. But I guess we could use this we it is possible.

yeah it will add a lot of BC because I need to replace the `Request` to `SomeQuery`

I added it inside of  `Query/` But on symfony docs recomends `Dto`, But I also saw in some places as `Input`.
Then I would like to know which one you prefer.

I am fine with Dto as well, then it will be into `Dto/BlockQueryDto.php`.

@dmaicher @VincentLanglet 